### PR TITLE
Async calls and batch calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /reference
 target/
+PR_DESCRIPTION.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   - `batch_json`
   - `batch_json_with_timeout`
 - Hardened unknown-response-ID handling:
-  - late responses for recently timed-out requests are dropped
-  - truly unknown response IDs are treated as protocol violations that fail pending requests
+  - unknown response IDs are now logged and dropped by default
+  - late responses for timed-out requests are also dropped without tearing down the connection
 - Preserved structured fatal response-loop errors when failing pending requests instead of flattening everything to `Io(ConnectionAborted)`.
 - Bounded sync `Client::batch_json` worker threads to avoid unbounded OS thread creation on large batches.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Hardened unknown-response-ID handling:
   - unknown response IDs are now logged and dropped by default
   - late responses for timed-out requests are also dropped without tearing down the connection
+- Made `AsyncClient` request tracking cancellation-safe so dropped call futures do not leak entries in the pending-request map.
 - Preserved structured fatal response-loop errors when failing pending requests instead of flattening everything to `Io(ConnectionAborted)`.
 - Bounded sync `Client::batch_json` worker threads to avoid unbounded OS thread creation on large batches.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Changelog
 
 ## [Unreleased]
-- _Nothing yet._
+- Added multiplexed request handling to `Client` and `AsyncClient` so multiple in-flight calls can share a single connection and still match responses by request ID.
+- Added per-request timeout helpers on both clients:
+  - `call_json_with_timeout`
+  - `call_typed_json_with_timeout`
+  - `call_typed_beve_with_timeout`
+- Added JSON batch helpers on both clients:
+  - `batch_json`
+  - `batch_json_with_timeout`
+- Hardened unknown-response-ID handling:
+  - late responses for recently timed-out requests are dropped
+  - truly unknown response IDs are treated as protocol violations that fail pending requests
+- Preserved structured fatal response-loop errors when failing pending requests instead of flattening everything to `Io(ConnectionAborted)`.
+- Bounded sync `Client::batch_json` worker threads to avoid unbounded OS thread creation on large batches.
 
 ## [0.4.0] - 2025-10-24
 - Router middleware hooks (`with_middleware` / `register_middleware`) let servers centralize auth, logging, or validation without manually wrapping each handler.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ struct AddResp {
     sum: i64,
 }
 
-let mut client = Client::connect("127.0.0.1:8081")?;
+let client = Client::connect("127.0.0.1:8081")?;
 let pong = client.call_json("/ping", &json!({}))?;
 assert_eq!(pong["pong"], true);
 
@@ -274,7 +274,8 @@ Error handling
   - Missing routes → `MethodNotFound` with the requested path in the message.
   - Application failures from handlers → return `(ErrorCode, String)` to control both fields.
 - Clients surface mismatched protocol versions as `RepeError::VersionMismatch`.
-- Responses with unknown request IDs are treated as protocol violations unless they match a recently timed-out request ID (late response), in which case they are dropped.
+- Responses with unknown request IDs are logged and dropped by default (including late responses for timed-out requests).
+- For bounded latency, prefer `call_*_with_timeout` APIs so a dropped response ID cannot leave a call waiting indefinitely.
 
 Async usage (minimal end‑to‑end)
 
@@ -301,7 +302,7 @@ struct AddResp {
     sum: i64,
 }
 
-let mut client = AsyncClient::connect(addr).await.unwrap();
+let client = AsyncClient::connect(addr).await.unwrap();
 let pong = client.call_json("/ping", &json!({})).await.unwrap();
 assert_eq!(pong["pong"], true);
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ let beve_sum: AddResp = client.call_typed_beve("/add", &AddReq { a: 4, b: 5 })?;
 assert_eq!(beve_sum.sum, 9);
 ```
 
+Multiplexed calls, timeouts, and batching
+
+- `Client` and `AsyncClient` can run multiple in-flight requests on one connection.
+- Clone the client handle and issue calls concurrently; responses are matched by request `id` even if the server replies out of order.
+- Use per-call timeout helpers:
+  - `call_json_with_timeout`
+  - `call_typed_json_with_timeout`
+  - `call_typed_beve_with_timeout`
+- Use batch helpers for JSON calls:
+  - `batch_json(Vec<(String, Value)>)`
+  - `batch_json_with_timeout(Vec<(String, Value)>, Duration)`
+
 Notify semantics
 
 - If a request is marked `notify = true`, the server will process the handler but will not send a response.
@@ -261,7 +273,8 @@ Error handling
   - JSON deserialization/serialization issues → `ParseError`.
   - Missing routes → `MethodNotFound` with the requested path in the message.
   - Application failures from handlers → return `(ErrorCode, String)` to control both fields.
-- Clients also surface mismatched response IDs as `RepeError::ResponseIdMismatch` and mismatched protocol versions as `RepeError::VersionMismatch`.
+- Clients surface mismatched protocol versions as `RepeError::VersionMismatch`.
+- Responses with unknown request IDs are treated as protocol violations unless they match a recently timed-out request ID (late response), in which case they are dropped.
 
 Async usage (minimal end‑to‑end)
 

--- a/examples/async_client.rs
+++ b/examples/async_client.rs
@@ -15,7 +15,7 @@ struct AddResp {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = AsyncClient::connect("127.0.0.1:8082").await?;
+    let client = AsyncClient::connect("127.0.0.1:8082").await?;
 
     let pong = client.call_json("/ping", &json!({})).await?;
     println!("/ping => {}", pong);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = Client::connect("127.0.0.1:8081")?;
+    let client = Client::connect("127.0.0.1:8081")?;
 
     let pong = client.call_json("/ping", &json!({}))?;
     println!("/ping => {}", pong);

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -6,62 +6,149 @@ use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Instant;
 use tokio::io::AsyncWriteExt;
+use tokio::io::{BufReader, BufWriter};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::sync::{Mutex, oneshot};
+use tokio::task::JoinError;
+use tokio::time::{Duration, timeout};
 
+type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
+type PendingRequests = HashMap<u64, PendingSender>;
+type TimedOutRequests = HashMap<u64, Instant>;
+
+const TIMED_OUT_REQUEST_TOMBSTONE_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
 pub struct AsyncClient {
-    stream: TcpStream,
-    next_id: u64,
+    inner: Arc<AsyncClientInner>,
+}
+
+struct AsyncClientInner {
+    writer: Mutex<BufWriter<OwnedWriteHalf>>,
+    pending: Mutex<PendingRequests>,
+    timed_out: Mutex<TimedOutRequests>,
+    next_id: AtomicU64,
+    shutdown: StdMutex<Option<oneshot::Sender<()>>>,
+}
+
+impl Drop for AsyncClientInner {
+    fn drop(&mut self) {
+        if let Ok(mut tx) = self.shutdown.lock() {
+            if let Some(sender) = tx.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+}
+
+enum PendingDispatch {
+    Matched {
+        sender: PendingSender,
+        response: Message,
+    },
+    LateTimedOut {
+        got_id: u64,
+    },
+    Unknown {
+        got_id: u64,
+    },
 }
 
 impl AsyncClient {
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
         let stream = TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;
-        Ok(Self { stream, next_id: 1 })
+        let (read_half, write_half) = stream.into_split();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let inner = Arc::new(AsyncClientInner {
+            writer: Mutex::new(BufWriter::new(write_half)),
+            pending: Mutex::new(HashMap::new()),
+            timed_out: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+            shutdown: StdMutex::new(Some(shutdown_tx)),
+        });
+
+        spawn_response_loop(
+            BufReader::new(read_half),
+            Arc::downgrade(&inner),
+            shutdown_rx,
+        );
+
+        Ok(Self { inner })
     }
 
-    fn next_request_id(&mut self) -> u64 {
-        let id = self.next_id;
-        self.next_id += 1;
-        id
+    fn next_request_id(&self) -> u64 {
+        self.inner.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
     pub async fn call_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<Value, RepeError> {
-        let resp = self
-            .call_with_body(path, |builder| builder.body_json(body))
-            .await?;
-        resp.json_body::<Value>()
+        self.call_json_with_optional_timeout(path, body, None).await
+    }
+
+    /// Send a JSON request and fail if no response arrives before `timeout_duration`.
+    pub async fn call_json_with_timeout<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Duration,
+    ) -> Result<Value, RepeError> {
+        self.call_json_with_optional_timeout(path, body, Some(timeout_duration))
+            .await
     }
 
     pub async fn call_typed_json<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<R, RepeError> {
-        let resp = self
-            .call_with_body(path, |builder| builder.body_json(body))
-            .await?;
-        Self::decode_typed_response(&resp)
+        self.call_typed_json_with_optional_timeout(path, body, None)
+            .await
+    }
+
+    /// Send a typed JSON request and fail if no response arrives before `timeout_duration`.
+    pub async fn call_typed_json_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Duration,
+    ) -> Result<R, RepeError> {
+        self.call_typed_json_with_optional_timeout(path, body, Some(timeout_duration))
+            .await
     }
 
     pub async fn call_typed_beve<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<R, RepeError> {
-        let resp = self
-            .call_with_body(path, |builder| builder.body_beve(body))
-            .await?;
-        Self::decode_typed_response(&resp)
+        self.call_typed_beve_with_optional_timeout(path, body, None)
+            .await
+    }
+
+    /// Send a typed BEVE request and fail if no response arrives before `timeout_duration`.
+    pub async fn call_typed_beve_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Duration,
+    ) -> Result<R, RepeError> {
+        self.call_typed_beve_with_optional_timeout(path, body, Some(timeout_duration))
+            .await
     }
 
     pub async fn notify_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
@@ -70,7 +157,7 @@ impl AsyncClient {
     }
 
     pub async fn notify_typed_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
@@ -79,7 +166,7 @@ impl AsyncClient {
     }
 
     pub async fn notify_typed_beve<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
@@ -87,7 +174,110 @@ impl AsyncClient {
             .await
     }
 
-    async fn call_with_body<P, F>(&mut self, path: P, body_fn: F) -> Result<Message, RepeError>
+    /// Execute JSON calls in parallel over this single connection and keep request order.
+    pub async fn batch_json(
+        &self,
+        requests: Vec<(String, Value)>,
+    ) -> Vec<Result<Value, RepeError>> {
+        self.batch_json_inner(requests, None).await
+    }
+
+    /// Execute JSON calls in parallel with a per-request timeout.
+    pub async fn batch_json_with_timeout(
+        &self,
+        requests: Vec<(String, Value)>,
+        timeout_duration: Duration,
+    ) -> Vec<Result<Value, RepeError>> {
+        self.batch_json_inner(requests, Some(timeout_duration))
+            .await
+    }
+
+    async fn batch_json_inner(
+        &self,
+        requests: Vec<(String, Value)>,
+        timeout_duration: Option<Duration>,
+    ) -> Vec<Result<Value, RepeError>> {
+        let mut workers = Vec::with_capacity(requests.len());
+
+        for (index, (path, body)) in requests.into_iter().enumerate() {
+            let client = self.clone();
+            workers.push((
+                index,
+                tokio::spawn(async move {
+                    client
+                        .call_json_with_optional_timeout(path, &body, timeout_duration)
+                        .await
+                }),
+            ));
+        }
+
+        let mut out: Vec<Option<Result<Value, RepeError>>> = std::iter::repeat_with(|| None)
+            .take(workers.len())
+            .collect();
+
+        for (index, worker) in workers {
+            let result = match worker.await {
+                Ok(value) => value,
+                Err(err) => Err(batch_worker_join_error(err)),
+            };
+            out[index] = Some(result);
+        }
+
+        out.into_iter()
+            .map(|entry| entry.unwrap_or_else(|| Err(batch_worker_missing_result_error())))
+            .collect()
+    }
+
+    async fn call_json_with_optional_timeout<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Option<Duration>,
+    ) -> Result<Value, RepeError> {
+        let resp = self
+            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_json(body))
+            .await?;
+        resp.json_body::<Value>()
+    }
+
+    async fn call_typed_json_with_optional_timeout<
+        P: AsRef<str>,
+        T: Serialize,
+        R: DeserializeOwned,
+    >(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Option<Duration>,
+    ) -> Result<R, RepeError> {
+        let resp = self
+            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_json(body))
+            .await?;
+        Self::decode_typed_response(&resp)
+    }
+
+    async fn call_typed_beve_with_optional_timeout<
+        P: AsRef<str>,
+        T: Serialize,
+        R: DeserializeOwned,
+    >(
+        &self,
+        path: P,
+        body: &T,
+        timeout_duration: Option<Duration>,
+    ) -> Result<R, RepeError> {
+        let resp = self
+            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_beve(body))
+            .await?;
+        Self::decode_typed_response(&resp)
+    }
+
+    async fn call_with_body_and_timeout<P, F>(
+        &self,
+        path: P,
+        timeout_duration: Option<Duration>,
+        body_fn: F,
+    ) -> Result<Message, RepeError>
     where
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
@@ -98,10 +288,60 @@ impl AsyncClient {
             .query_str(path.as_ref())
             .query_format(QueryFormat::JsonPointer);
         let msg = body_fn(builder)?.build();
-        write_message_async(&mut self.stream, &msg).await?;
-        self.stream.flush().await?;
-        let resp = read_message_async(&mut self.stream).await?;
+
+        let (sender, receiver) = oneshot::channel();
+        {
+            let mut pending = self.inner.pending.lock().await;
+            pending.insert(id, sender);
+        }
+
+        if let Err(err) = self.write_request(&msg).await {
+            self.remove_pending(id).await;
+            return Err(err);
+        }
+
+        let received = match timeout_duration {
+            Some(duration) => match timeout(duration, receiver).await {
+                Ok(Ok(value)) => value,
+                Ok(Err(_)) => {
+                    self.remove_pending(id).await;
+                    return Err(response_channel_closed_error(id));
+                }
+                Err(_) => {
+                    self.remove_pending(id).await;
+                    self.mark_timed_out_request(id).await;
+                    return Err(request_timeout_error(id, duration));
+                }
+            },
+            None => match receiver.await {
+                Ok(value) => value,
+                Err(_) => {
+                    self.remove_pending(id).await;
+                    return Err(response_channel_closed_error(id));
+                }
+            },
+        };
+
+        let resp = received?;
         Self::validate_response(id, resp)
+    }
+
+    async fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
+        let mut writer = self.inner.writer.lock().await;
+        write_message_async(&mut *writer, msg).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+
+    async fn remove_pending(&self, id: u64) {
+        let mut pending = self.inner.pending.lock().await;
+        pending.remove(&id);
+    }
+
+    async fn mark_timed_out_request(&self, id: u64) {
+        let mut timed_out = self.inner.timed_out.lock().await;
+        prune_timed_out_requests(&mut timed_out);
+        timed_out.insert(id, Instant::now() + TIMED_OUT_REQUEST_TOMBSTONE_TTL);
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -141,7 +381,7 @@ impl AsyncClient {
         }
     }
 
-    async fn notify_with_body<P, F>(&mut self, path: P, body_fn: F) -> Result<(), RepeError>
+    async fn notify_with_body<P, F>(&self, path: P, body_fn: F) -> Result<(), RepeError>
     where
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
@@ -153,8 +393,170 @@ impl AsyncClient {
             .query_str(path.as_ref())
             .query_format(QueryFormat::JsonPointer);
         let msg = body_fn(builder)?.build();
-        write_message_async(&mut self.stream, &msg).await?;
-        self.stream.flush().await?;
-        Ok(())
+        self.write_request(&msg).await
     }
+}
+
+fn spawn_response_loop(
+    mut reader: BufReader<OwnedReadHalf>,
+    inner: std::sync::Weak<AsyncClientInner>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        loop {
+            let response = tokio::select! {
+                _ = &mut shutdown_rx => {
+                    break;
+                }
+                read = read_message_async(&mut reader) => {
+                    match read {
+                        Ok(message) => message,
+                        Err(err) => {
+                            fail_all_pending(&inner, err).await;
+                            break;
+                        }
+                    }
+                }
+            };
+
+            let dispatch = {
+                let Some(inner_ref) = inner.upgrade() else {
+                    break;
+                };
+                let response_id = response.header.id;
+                let matched_sender = {
+                    let mut pending = inner_ref.pending.lock().await;
+                    pending.remove(&response_id)
+                };
+
+                if let Some(sender) = matched_sender {
+                    PendingDispatch::Matched { sender, response }
+                } else if take_timed_out_tombstone(&inner_ref, response_id).await {
+                    PendingDispatch::LateTimedOut {
+                        got_id: response_id,
+                    }
+                } else {
+                    PendingDispatch::Unknown {
+                        got_id: response_id,
+                    }
+                }
+            };
+
+            match dispatch {
+                PendingDispatch::Matched { sender, response } => {
+                    let _ = sender.send(Ok(response));
+                }
+                PendingDispatch::LateTimedOut { got_id } => {
+                    eprintln!("[repe] dropping late response for timed-out request id {got_id}");
+                }
+                PendingDispatch::Unknown { got_id } => {
+                    eprintln!(
+                        "[repe] protocol violation: received response for unknown request id {got_id}"
+                    );
+                    fail_all_pending(&inner, unknown_response_id_error(got_id)).await;
+                    break;
+                }
+            }
+        }
+    });
+}
+
+async fn fail_all_pending(inner: &std::sync::Weak<AsyncClientInner>, err: RepeError) {
+    let Some(inner_ref) = inner.upgrade() else {
+        return;
+    };
+
+    {
+        let mut writer = inner_ref.writer.lock().await;
+        let _ = writer.shutdown().await;
+    }
+
+    let waiters = {
+        let mut pending = inner_ref.pending.lock().await;
+        pending.drain().collect::<Vec<_>>()
+    };
+
+    for (request_id, sender) in waiters {
+        let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
+    }
+}
+
+fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
+    match err {
+        RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
+        RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
+        RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
+        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
+        RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
+            expected: *expected,
+            got: *got,
+        },
+        RepeError::BufferTooSmall { need, have } => RepeError::BufferTooSmall {
+            need: *need,
+            have: *have,
+        },
+        RepeError::ResponseIdMismatch { expected, got } => RepeError::ResponseIdMismatch {
+            expected: *expected,
+            got: *got,
+        },
+        RepeError::Io(io_err) => RepeError::Io(std::io::Error::new(
+            io_err.kind(),
+            format!("request {request_id}: {io_err}"),
+        )),
+        RepeError::Json(json_err) => RepeError::Json(serde_json::Error::io(std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("request {request_id}: {json_err}"),
+        ))),
+        RepeError::Beve(beve_err) => RepeError::Beve(beve::Error::msg(format!(
+            "request {request_id}: {beve_err}"
+        ))),
+        RepeError::UnknownEnumValue(value) => RepeError::UnknownEnumValue(*value),
+        RepeError::ServerError { code, message } => RepeError::ServerError {
+            code: *code,
+            message: message.clone(),
+        },
+    }
+}
+
+async fn take_timed_out_tombstone(inner: &AsyncClientInner, request_id: u64) -> bool {
+    let mut timed_out = inner.timed_out.lock().await;
+    prune_timed_out_requests(&mut timed_out);
+    timed_out.remove(&request_id).is_some()
+}
+
+fn prune_timed_out_requests(timed_out: &mut TimedOutRequests) {
+    let now = Instant::now();
+    timed_out.retain(|_, expires_at| *expires_at > now);
+}
+
+fn unknown_response_id_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::InvalidData,
+        format!("received response for unknown request id {request_id}"),
+    ))
+}
+
+fn request_timeout_error(request_id: u64, timeout: Duration) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::TimedOut,
+        format!(
+            "request {request_id} timed out after {}ms",
+            timeout.as_millis()
+        ),
+    ))
+}
+
+fn response_channel_closed_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::ConnectionAborted,
+        format!("response channel closed for request {request_id}"),
+    ))
+}
+
+fn batch_worker_join_error(err: JoinError) -> RepeError {
+    RepeError::Io(std::io::Error::other(format!("batch worker failed: {err}")))
+}
+
+fn batch_worker_missing_result_error() -> RepeError {
+    RepeError::Io(std::io::Error::other("batch worker missing result"))
 }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Instant;
 use tokio::io::AsyncWriteExt;
 use tokio::io::{BufReader, BufWriter};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -21,9 +20,6 @@ use tokio::time::{Duration, timeout};
 
 type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
-type TimedOutRequests = HashMap<u64, Instant>;
-
-const TIMED_OUT_REQUEST_TOMBSTONE_TTL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct AsyncClient {
@@ -33,7 +29,6 @@ pub struct AsyncClient {
 struct AsyncClientInner {
     writer: Mutex<BufWriter<OwnedWriteHalf>>,
     pending: Mutex<PendingRequests>,
-    timed_out: Mutex<TimedOutRequests>,
     next_id: AtomicU64,
     shutdown: StdMutex<Option<oneshot::Sender<()>>>,
 }
@@ -53,10 +48,7 @@ enum PendingDispatch {
         sender: PendingSender,
         response: Message,
     },
-    LateTimedOut {
-        got_id: u64,
-    },
-    Unknown {
+    Unrecognized {
         got_id: u64,
     },
 }
@@ -70,7 +62,6 @@ impl AsyncClient {
         let inner = Arc::new(AsyncClientInner {
             writer: Mutex::new(BufWriter::new(write_half)),
             pending: Mutex::new(HashMap::new()),
-            timed_out: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             shutdown: StdMutex::new(Some(shutdown_tx)),
         });
@@ -308,7 +299,6 @@ impl AsyncClient {
                     return Err(response_channel_closed_error(id));
                 }
                 Err(_) => {
-                    self.mark_timed_out_request(id).await;
                     self.remove_pending(id).await;
                     return Err(request_timeout_error(id, duration));
                 }
@@ -336,12 +326,6 @@ impl AsyncClient {
     async fn remove_pending(&self, id: u64) {
         let mut pending = self.inner.pending.lock().await;
         pending.remove(&id);
-    }
-
-    async fn mark_timed_out_request(&self, id: u64) {
-        let mut timed_out = self.inner.timed_out.lock().await;
-        prune_timed_out_requests(&mut timed_out);
-        timed_out.insert(id, Instant::now() + TIMED_OUT_REQUEST_TOMBSTONE_TTL);
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -431,12 +415,8 @@ fn spawn_response_loop(
 
                 if let Some(sender) = matched_sender {
                     PendingDispatch::Matched { sender, response }
-                } else if take_timed_out_tombstone(&inner_ref, response_id).await {
-                    PendingDispatch::LateTimedOut {
-                        got_id: response_id,
-                    }
                 } else {
-                    PendingDispatch::Unknown {
+                    PendingDispatch::Unrecognized {
                         got_id: response_id,
                     }
                 }
@@ -446,15 +426,8 @@ fn spawn_response_loop(
                 PendingDispatch::Matched { sender, response } => {
                     let _ = sender.send(Ok(response));
                 }
-                PendingDispatch::LateTimedOut { got_id } => {
-                    eprintln!("[repe] dropping late response for timed-out request id {got_id}");
-                }
-                PendingDispatch::Unknown { got_id } => {
-                    eprintln!(
-                        "[repe] protocol violation: received response for unknown request id {got_id}"
-                    );
-                    fail_all_pending(&inner, unknown_response_id_error(got_id)).await;
-                    break;
+                PendingDispatch::Unrecognized { got_id } => {
+                    eprintln!("[repe] dropping response for unrecognized request id {got_id}");
                 }
             }
         }
@@ -516,24 +489,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             message: message.clone(),
         },
     }
-}
-
-async fn take_timed_out_tombstone(inner: &AsyncClientInner, request_id: u64) -> bool {
-    let mut timed_out = inner.timed_out.lock().await;
-    prune_timed_out_requests(&mut timed_out);
-    timed_out.remove(&request_id).is_some()
-}
-
-fn prune_timed_out_requests(timed_out: &mut TimedOutRequests) {
-    let now = Instant::now();
-    timed_out.retain(|_, expires_at| *expires_at > now);
-}
-
-fn unknown_response_id_error(request_id: u64) -> RepeError {
-    RepeError::Io(std::io::Error::new(
-        ErrorKind::InvalidData,
-        format!("received response for unknown request id {request_id}"),
-    ))
 }
 
 fn request_timeout_error(request_id: u64, timeout: Duration) -> RepeError {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -319,9 +319,7 @@ impl AsyncClient {
         let (sender, receiver) = oneshot::channel();
         let mut pending_guard = PendingRequestGuard::register(&self.inner, id, sender);
 
-        if let Err(err) = self.write_request(&msg).await {
-            return Err(err);
-        }
+        self.write_request(&msg).await?;
 
         let received = match timeout_duration {
             Some(duration) => match timeout(duration, receiver).await {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -28,7 +28,7 @@ pub struct AsyncClient {
 
 struct AsyncClientInner {
     writer: Mutex<BufWriter<OwnedWriteHalf>>,
-    pending: Mutex<PendingRequests>,
+    pending: StdMutex<PendingRequests>,
     next_id: AtomicU64,
     shutdown: StdMutex<Option<oneshot::Sender<()>>>,
 }
@@ -53,6 +53,42 @@ enum PendingDispatch {
     },
 }
 
+struct PendingRequestGuard {
+    inner: Arc<AsyncClientInner>,
+    request_id: u64,
+    disarmed: bool,
+}
+
+impl PendingRequestGuard {
+    fn register(inner: &Arc<AsyncClientInner>, request_id: u64, sender: PendingSender) -> Self {
+        {
+            let mut pending = lock_pending_map(&inner.pending);
+            pending.insert(request_id, sender);
+        }
+
+        Self {
+            inner: Arc::clone(inner),
+            request_id,
+            disarmed: false,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.disarmed = true;
+    }
+}
+
+impl Drop for PendingRequestGuard {
+    fn drop(&mut self) {
+        if self.disarmed {
+            return;
+        }
+
+        let mut pending = lock_pending_map(&self.inner.pending);
+        pending.remove(&self.request_id);
+    }
+}
+
 impl AsyncClient {
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
         let stream = TcpStream::connect(addr).await?;
@@ -61,7 +97,7 @@ impl AsyncClient {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let inner = Arc::new(AsyncClientInner {
             writer: Mutex::new(BufWriter::new(write_half)),
-            pending: Mutex::new(HashMap::new()),
+            pending: StdMutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             shutdown: StdMutex::new(Some(shutdown_tx)),
         });
@@ -281,38 +317,26 @@ impl AsyncClient {
         let msg = body_fn(builder)?.build();
 
         let (sender, receiver) = oneshot::channel();
-        {
-            let mut pending = self.inner.pending.lock().await;
-            pending.insert(id, sender);
-        }
+        let mut pending_guard = PendingRequestGuard::register(&self.inner, id, sender);
 
         if let Err(err) = self.write_request(&msg).await {
-            self.remove_pending(id).await;
             return Err(err);
         }
 
         let received = match timeout_duration {
             Some(duration) => match timeout(duration, receiver).await {
                 Ok(Ok(value)) => value,
-                Ok(Err(_)) => {
-                    self.remove_pending(id).await;
-                    return Err(response_channel_closed_error(id));
-                }
-                Err(_) => {
-                    self.remove_pending(id).await;
-                    return Err(request_timeout_error(id, duration));
-                }
+                Ok(Err(_)) => return Err(response_channel_closed_error(id)),
+                Err(_) => return Err(request_timeout_error(id, duration)),
             },
             None => match receiver.await {
                 Ok(value) => value,
-                Err(_) => {
-                    self.remove_pending(id).await;
-                    return Err(response_channel_closed_error(id));
-                }
+                Err(_) => return Err(response_channel_closed_error(id)),
             },
         };
 
         let resp = received?;
+        pending_guard.disarm();
         Self::validate_response(id, resp)
     }
 
@@ -321,11 +345,6 @@ impl AsyncClient {
         write_message_async(&mut *writer, msg).await?;
         writer.flush().await?;
         Ok(())
-    }
-
-    async fn remove_pending(&self, id: u64) {
-        let mut pending = self.inner.pending.lock().await;
-        pending.remove(&id);
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -409,7 +428,7 @@ fn spawn_response_loop(
                 };
                 let response_id = response.header.id;
                 let matched_sender = {
-                    let mut pending = inner_ref.pending.lock().await;
+                    let mut pending = lock_pending_map(&inner_ref.pending);
                     pending.remove(&response_id)
                 };
 
@@ -445,7 +464,7 @@ async fn fail_all_pending(inner: &std::sync::Weak<AsyncClientInner>, err: RepeEr
     }
 
     let waiters = {
-        let mut pending = inner_ref.pending.lock().await;
+        let mut pending = lock_pending_map(&inner_ref.pending);
         pending.drain().collect::<Vec<_>>()
     };
 
@@ -514,4 +533,99 @@ fn batch_worker_join_error(err: JoinError) -> RepeError {
 
 fn batch_worker_missing_result_error() -> RepeError {
     RepeError::Io(std::io::Error::other("batch worker missing result"))
+}
+
+fn lock_pending_map(
+    pending: &StdMutex<PendingRequests>,
+) -> std::sync::MutexGuard<'_, PendingRequests> {
+    match pending.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{read_message, write_message};
+    use serde_json::json;
+    use std::io::{BufReader, BufWriter, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn json_response_for(req: &Message) -> Message {
+        Message::builder()
+            .id(req.header.id)
+            .query_bytes(req.query.clone())
+            .query_format(
+                QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
+            )
+            .body_json(&json!({"path": req.query_utf8()}))
+            .expect("json body")
+            .build()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_call_cleans_pending_entry() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (first_seen_tx, first_seen_rx) = mpsc::channel();
+
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut writer = BufWriter::new(stream);
+
+            let _first = read_message(&mut reader).unwrap();
+            first_seen_tx
+                .send(())
+                .expect("signal that first request arrived");
+
+            let second = read_message(&mut reader).unwrap();
+            let response = json_response_for(&second);
+            write_message(&mut writer, &response).unwrap();
+            writer.flush().unwrap();
+        });
+
+        let client = AsyncClient::connect(addr).await.unwrap();
+
+        let cancelled_client = client.clone();
+        let cancelled_call = tokio::spawn(async move {
+            cancelled_client
+                .call_json("/cancelled", &json!({"n": 1}))
+                .await
+        });
+
+        tokio::task::spawn_blocking(move || {
+            first_seen_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("server should observe the first request");
+        })
+        .await
+        .unwrap();
+
+        cancelled_call.abort();
+        let join_err = cancelled_call.await.unwrap_err();
+        assert!(join_err.is_cancelled());
+
+        let pending_count = {
+            let pending = lock_pending_map(&client.inner.pending);
+            pending.len()
+        };
+        assert_eq!(
+            pending_count, 0,
+            "cancelled calls must not leak pending entries"
+        );
+
+        let out = client
+            .call_json_with_timeout("/ok", &json!({"n": 2}), Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert_eq!(out["path"], "/ok");
+
+        tokio::task::spawn_blocking(move || server.join().unwrap())
+            .await
+            .unwrap();
+    }
 }

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -308,8 +308,8 @@ impl AsyncClient {
                     return Err(response_channel_closed_error(id));
                 }
                 Err(_) => {
-                    self.remove_pending(id).await;
                     self.mark_timed_out_request(id).await;
+                    self.remove_pending(id).await;
                     return Err(request_timeout_error(id, duration));
                 }
             },

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -183,7 +183,7 @@ mod tests {
             let _ = handle_connection(stream, router_clone, None, None).await;
         });
 
-        let mut client = AsyncClient::connect(addr).await.unwrap();
+        let client = AsyncClient::connect(addr).await.unwrap();
         let out = client
             .call_json("/mul", &serde_json::json!({"a": 6, "b": 7}))
             .await

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,14 +13,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 type PendingSender = mpsc::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
-type TimedOutRequests = HashMap<u64, Instant>;
 type BatchResults = Vec<Option<Result<Value, RepeError>>>;
 
-const TIMED_OUT_REQUEST_TOMBSTONE_TTL: Duration = Duration::from_secs(30);
 const MAX_BATCH_WORKERS: usize = 64;
 
 #[derive(Clone)]
@@ -31,7 +29,6 @@ pub struct Client {
 struct ClientInner {
     writer: Mutex<BufWriter<TcpStream>>,
     pending: Mutex<PendingRequests>,
-    timed_out: Mutex<TimedOutRequests>,
     next_id: AtomicU64,
 }
 
@@ -58,10 +55,7 @@ enum PendingDispatch {
         sender: PendingSender,
         response: Message,
     },
-    LateTimedOut {
-        got_id: u64,
-    },
-    Unknown {
+    Unrecognized {
         got_id: u64,
     },
 }
@@ -75,7 +69,6 @@ impl Client {
         let inner = Arc::new(ClientInner {
             writer: Mutex::new(BufWriter::new(stream)),
             pending: Mutex::new(HashMap::new()),
-            timed_out: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
         });
         spawn_response_loop(BufReader::new(reader_stream), Arc::downgrade(&inner));
@@ -368,7 +361,6 @@ impl Client {
             Some(duration) => match receiver.recv_timeout(duration) {
                 Ok(value) => value,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
-                    self.mark_timed_out_request(id);
                     self.remove_pending(id);
                     Err(request_timeout_error(id, duration))
                 }
@@ -402,15 +394,6 @@ impl Client {
         if let Ok(mut pending) = self.inner.pending.lock() {
             pending.remove(&id);
         }
-    }
-
-    fn mark_timed_out_request(&self, id: u64) {
-        let mut timed_out = match self.inner.timed_out.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        prune_timed_out_requests(&mut timed_out);
-        timed_out.insert(id, Instant::now() + TIMED_OUT_REQUEST_TOMBSTONE_TTL);
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -495,12 +478,8 @@ fn spawn_response_loop(mut reader: BufReader<TcpStream>, inner: std::sync::Weak<
 
                 if let Some(sender) = pending_map.remove(&response.header.id) {
                     PendingDispatch::Matched { sender, response }
-                } else if take_timed_out_tombstone(&inner_ref, response.header.id) {
-                    PendingDispatch::LateTimedOut {
-                        got_id: response.header.id,
-                    }
                 } else {
-                    PendingDispatch::Unknown {
+                    PendingDispatch::Unrecognized {
                         got_id: response.header.id,
                     }
                 }
@@ -510,15 +489,8 @@ fn spawn_response_loop(mut reader: BufReader<TcpStream>, inner: std::sync::Weak<
                 PendingDispatch::Matched { sender, response } => {
                     let _ = sender.send(Ok(response));
                 }
-                PendingDispatch::LateTimedOut { got_id } => {
-                    eprintln!("[repe] dropping late response for timed-out request id {got_id}");
-                }
-                PendingDispatch::Unknown { got_id } => {
-                    eprintln!(
-                        "[repe] protocol violation: received response for unknown request id {got_id}"
-                    );
-                    fail_all_pending(&inner, unknown_response_id_error(got_id));
-                    break;
+                PendingDispatch::Unrecognized { got_id } => {
+                    eprintln!("[repe] dropping response for unrecognized request id {got_id}");
                 }
             }
         }
@@ -586,27 +558,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             message: message.clone(),
         },
     }
-}
-
-fn take_timed_out_tombstone(inner: &ClientInner, request_id: u64) -> bool {
-    let mut timed_out = match inner.timed_out.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    prune_timed_out_requests(&mut timed_out);
-    timed_out.remove(&request_id).is_some()
-}
-
-fn prune_timed_out_requests(timed_out: &mut TimedOutRequests) {
-    let now = Instant::now();
-    timed_out.retain(|_, expires_at| *expires_at > now);
-}
-
-fn unknown_response_id_error(request_id: u64) -> RepeError {
-    RepeError::Io(std::io::Error::new(
-        ErrorKind::InvalidData,
-        format!("received response for unknown request id {request_id}"),
-    ))
 }
 
 fn poisoned_lock_error(name: &str) -> RepeError {

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,75 +6,167 @@ use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::io::Write;
-use std::io::{BufReader, BufWriter};
-use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufReader, BufWriter, ErrorKind, Write};
+use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
+type PendingSender = mpsc::Sender<Result<Message, RepeError>>;
+type PendingRequests = HashMap<u64, PendingSender>;
+type TimedOutRequests = HashMap<u64, Instant>;
+
+const TIMED_OUT_REQUEST_TOMBSTONE_TTL: Duration = Duration::from_secs(30);
+const MAX_BATCH_WORKERS: usize = 64;
+
+#[derive(Clone)]
 pub struct Client {
-    reader: BufReader<TcpStream>,
-    writer: BufWriter<TcpStream>,
-    next_id: Arc<AtomicU64>,
+    inner: Arc<ClientInner>,
+}
+
+struct ClientInner {
+    writer: Mutex<BufWriter<TcpStream>>,
+    pending: Mutex<PendingRequests>,
+    timed_out: Mutex<TimedOutRequests>,
+    next_id: AtomicU64,
+}
+
+impl Drop for ClientInner {
+    fn drop(&mut self) {
+        if let Ok(writer) = self.writer.lock() {
+            let _ = writer.get_ref().shutdown(Shutdown::Both);
+        }
+
+        if let Ok(mut pending) = self.pending.lock() {
+            for (request_id, sender) in pending.drain() {
+                let io_err = std::io::Error::new(
+                    ErrorKind::ConnectionAborted,
+                    format!("client closed while waiting for request {request_id}"),
+                );
+                let _ = sender.send(Err(RepeError::Io(io_err)));
+            }
+        }
+    }
+}
+
+enum PendingDispatch {
+    Matched {
+        sender: PendingSender,
+        response: Message,
+    },
+    LateTimedOut {
+        got_id: u64,
+    },
+    Unknown {
+        got_id: u64,
+    },
 }
 
 impl Client {
     pub fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
         let stream = TcpStream::connect(addr)?;
         stream.set_nodelay(true).ok();
+
         let reader_stream = stream.try_clone()?;
-        Ok(Self {
-            reader: BufReader::new(reader_stream),
-            writer: BufWriter::new(stream),
-            next_id: Arc::new(AtomicU64::new(1)),
-        })
+        let inner = Arc::new(ClientInner {
+            writer: Mutex::new(BufWriter::new(stream)),
+            pending: Mutex::new(HashMap::new()),
+            timed_out: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        });
+        spawn_response_loop(BufReader::new(reader_stream), Arc::downgrade(&inner));
+
+        Ok(Self { inner })
     }
 
     pub fn set_read_timeout(&self, d: Option<Duration>) -> std::io::Result<()> {
-        self.reader.get_ref().set_read_timeout(d)
+        let writer = self
+            .inner
+            .writer
+            .lock()
+            .map_err(|_| std::io::Error::other("client writer lock poisoned"))?;
+        writer.get_ref().set_read_timeout(d)
     }
+
     pub fn set_write_timeout(&self, d: Option<Duration>) -> std::io::Result<()> {
-        self.writer.get_ref().set_write_timeout(d)
+        let writer = self
+            .inner
+            .writer
+            .lock()
+            .map_err(|_| std::io::Error::other("client writer lock poisoned"))?;
+        writer.get_ref().set_write_timeout(d)
     }
 
     fn next_request_id(&self) -> u64 {
-        self.next_id.fetch_add(1, Ordering::Relaxed)
+        self.inner.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Send a JSON-pointer request with JSON body and receive JSON result.
     pub fn call_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<Value, RepeError> {
-        let resp = self.call_with_body(path, |builder| builder.body_json(body))?;
-        resp.json_body::<Value>()
+        self.call_json_with_optional_timeout(path, body, None)
+    }
+
+    /// Send a JSON-pointer request with JSON body and receive JSON result,
+    /// failing if no response arrives before `timeout`.
+    pub fn call_json_with_timeout<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Duration,
+    ) -> Result<Value, RepeError> {
+        self.call_json_with_optional_timeout(path, body, Some(timeout))
     }
 
     /// Send a JSON-pointer request with JSON body and deserialize the typed result.
     pub fn call_typed_json<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<R, RepeError> {
-        let resp = self.call_with_body(path, |builder| builder.body_json(body))?;
-        Self::decode_typed_response(&resp)
+        self.call_typed_json_with_optional_timeout(path, body, None)
+    }
+
+    /// Send a JSON-pointer request with JSON body and deserialize the typed result,
+    /// failing if no response arrives before `timeout`.
+    pub fn call_typed_json_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Duration,
+    ) -> Result<R, RepeError> {
+        self.call_typed_json_with_optional_timeout(path, body, Some(timeout))
     }
 
     /// Send a JSON-pointer request with BEVE body and deserialize the typed result.
     pub fn call_typed_beve<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<R, RepeError> {
-        let resp = self.call_with_body(path, |builder| builder.body_beve(body))?;
-        Self::decode_typed_response(&resp)
+        self.call_typed_beve_with_optional_timeout(path, body, None)
+    }
+
+    /// Send a JSON-pointer request with BEVE body and deserialize the typed result,
+    /// failing if no response arrives before `timeout`.
+    pub fn call_typed_beve_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Duration,
+    ) -> Result<R, RepeError> {
+        self.call_typed_beve_with_optional_timeout(path, body, Some(timeout))
     }
 
     /// Send a JSON-pointer notify request (no response expected).
     pub fn notify_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
@@ -83,7 +175,7 @@ impl Client {
 
     /// Notify a typed handler with a JSON payload, without waiting for a response.
     pub fn notify_typed_json<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
@@ -92,14 +184,149 @@ impl Client {
 
     /// Notify a typed handler with a BEVE payload, without waiting for a response.
     pub fn notify_typed_beve<P: AsRef<str>, T: Serialize>(
-        &mut self,
+        &self,
         path: P,
         body: &T,
     ) -> Result<(), RepeError> {
         self.notify_with_body(path, |builder| builder.body_beve(body))
     }
 
-    fn call_with_body<P, F>(&mut self, path: P, body_fn: F) -> Result<Message, RepeError>
+    /// Execute JSON calls in parallel over this single connection and keep request order.
+    pub fn batch_json(&self, requests: Vec<(String, Value)>) -> Vec<Result<Value, RepeError>> {
+        self.batch_json_inner(requests, None)
+    }
+
+    /// Execute JSON calls in parallel over this single connection with a per-request timeout.
+    pub fn batch_json_with_timeout(
+        &self,
+        requests: Vec<(String, Value)>,
+        timeout: Duration,
+    ) -> Vec<Result<Value, RepeError>> {
+        self.batch_json_inner(requests, Some(timeout))
+    }
+
+    fn batch_json_inner(
+        &self,
+        requests: Vec<(String, Value)>,
+        timeout: Option<Duration>,
+    ) -> Vec<Result<Value, RepeError>> {
+        let request_count = requests.len();
+        if request_count == 0 {
+            return Vec::new();
+        }
+
+        let worker_count = batch_worker_count(request_count);
+        let queue: VecDeque<(usize, String, Value)> = requests
+            .into_iter()
+            .enumerate()
+            .map(|(index, (path, body))| (index, path, body))
+            .collect();
+        let work_queue = Arc::new(Mutex::new(queue));
+        let results: Arc<Mutex<Vec<Option<Result<Value, RepeError>>>>> = Arc::new(Mutex::new(
+            std::iter::repeat_with(|| None)
+                .take(request_count)
+                .collect(),
+        ));
+
+        let mut workers = Vec::with_capacity(worker_count);
+        for _ in 0..worker_count {
+            let client = self.clone();
+            let work_queue = Arc::clone(&work_queue);
+            let results = Arc::clone(&results);
+            workers.push(thread::spawn(move || {
+                loop {
+                    let next = {
+                        let mut queue = match work_queue.lock() {
+                            Ok(guard) => guard,
+                            Err(poisoned) => poisoned.into_inner(),
+                        };
+                        queue.pop_front()
+                    };
+
+                    let Some((index, path, body)) = next else {
+                        break;
+                    };
+
+                    let result = client.call_json_with_optional_timeout(path, &body, timeout);
+                    let mut out = match results.lock() {
+                        Ok(guard) => guard,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
+                    out[index] = Some(result);
+                }
+            }));
+        }
+
+        let mut panicked = false;
+        for worker in workers {
+            if worker.join().is_err() {
+                panicked = true;
+            }
+        }
+
+        let entries = match Arc::try_unwrap(results) {
+            Ok(mutex) => match mutex.into_inner() {
+                Ok(values) => values,
+                Err(poisoned) => poisoned.into_inner(),
+            },
+            Err(arc) => {
+                let mut guard = match arc.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                std::mem::take(&mut *guard)
+            }
+        };
+
+        entries
+            .into_iter()
+            .map(|entry| match entry {
+                Some(result) => result,
+                None if panicked => Err(batch_worker_panic_error()),
+                None => Err(batch_worker_missing_result_error()),
+            })
+            .collect()
+    }
+
+    fn call_json_with_optional_timeout<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Option<Duration>,
+    ) -> Result<Value, RepeError> {
+        let resp =
+            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_json(body))?;
+        resp.json_body::<Value>()
+    }
+
+    fn call_typed_json_with_optional_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Option<Duration>,
+    ) -> Result<R, RepeError> {
+        let resp =
+            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_json(body))?;
+        Self::decode_typed_response(&resp)
+    }
+
+    fn call_typed_beve_with_optional_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
+        &self,
+        path: P,
+        body: &T,
+        timeout: Option<Duration>,
+    ) -> Result<R, RepeError> {
+        let resp =
+            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_beve(body))?;
+        Self::decode_typed_response(&resp)
+    }
+
+    fn call_with_body_and_timeout<P, F>(
+        &self,
+        path: P,
+        timeout: Option<Duration>,
+        body_fn: F,
+    ) -> Result<Message, RepeError>
     where
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
@@ -110,11 +337,81 @@ impl Client {
             .query_str(path.as_ref())
             .query_format(QueryFormat::JsonPointer);
         let msg = body_fn(builder)?.build();
-        write_message(&mut self.writer, &msg)?;
-        self.writer.flush()?;
 
-        let resp = read_message(&mut self.reader)?;
+        let (sender, receiver) = mpsc::channel();
+        {
+            let mut pending = self
+                .inner
+                .pending
+                .lock()
+                .map_err(|_| poisoned_lock_error("client pending map"))?;
+            pending.insert(id, sender);
+        }
+
+        if let Err(err) = self.write_request(&msg) {
+            self.remove_pending(id);
+            return Err(err);
+        }
+
+        let resp = self.wait_for_response(id, receiver, timeout)?;
         Self::validate_response(id, resp)
+    }
+
+    fn wait_for_response(
+        &self,
+        id: u64,
+        receiver: mpsc::Receiver<Result<Message, RepeError>>,
+        timeout: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        let received = match timeout {
+            Some(duration) => match receiver.recv_timeout(duration) {
+                Ok(value) => value,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    self.remove_pending(id);
+                    self.mark_timed_out_request(id);
+                    return Err(request_timeout_error(id, duration));
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    self.remove_pending(id);
+                    return Err(response_channel_closed_error(id));
+                }
+            },
+            None => match receiver.recv() {
+                Ok(value) => value,
+                Err(_) => {
+                    self.remove_pending(id);
+                    return Err(response_channel_closed_error(id));
+                }
+            },
+        };
+
+        received
+    }
+
+    fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
+        let mut writer = self
+            .inner
+            .writer
+            .lock()
+            .map_err(|_| poisoned_lock_error("client writer"))?;
+        write_message(&mut *writer, msg)?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    fn remove_pending(&self, id: u64) {
+        if let Ok(mut pending) = self.inner.pending.lock() {
+            pending.remove(&id);
+        }
+    }
+
+    fn mark_timed_out_request(&self, id: u64) {
+        let mut timed_out = match self.inner.timed_out.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        prune_timed_out_requests(&mut timed_out);
+        timed_out.insert(id, Instant::now() + TIMED_OUT_REQUEST_TOMBSTONE_TTL);
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -137,7 +434,7 @@ impl Client {
         Ok(resp)
     }
 
-    fn notify_with_body<P, F>(&mut self, path: P, body_fn: F) -> Result<(), RepeError>
+    fn notify_with_body<P, F>(&self, path: P, body_fn: F) -> Result<(), RepeError>
     where
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
@@ -149,9 +446,7 @@ impl Client {
             .query_str(path.as_ref())
             .query_format(QueryFormat::JsonPointer);
         let msg = body_fn(builder)?.build();
-        write_message(&mut self.writer, &msg)?;
-        self.writer.flush()?;
-        Ok(())
+        self.write_request(&msg)
     }
 
     fn decode_typed_response<R: DeserializeOwned>(resp: &Message) -> Result<R, RepeError> {
@@ -169,5 +464,204 @@ impl Client {
             }
             Err(_) => Err(RepeError::UnknownEnumValue(resp.header.body_format as u64)),
         }
+    }
+}
+
+fn spawn_response_loop(mut reader: BufReader<TcpStream>, inner: std::sync::Weak<ClientInner>) {
+    thread::spawn(move || {
+        loop {
+            let response = match read_message(&mut reader) {
+                Ok(message) => message,
+                Err(RepeError::Io(ref io_err))
+                    if io_err.kind() == ErrorKind::TimedOut
+                        || io_err.kind() == ErrorKind::WouldBlock
+                        || io_err.kind() == ErrorKind::Interrupted =>
+                {
+                    continue;
+                }
+                Err(err) => {
+                    fail_all_pending(&inner, err);
+                    break;
+                }
+            };
+
+            let dispatch = {
+                let Some(inner_ref) = inner.upgrade() else {
+                    break;
+                };
+                let mut pending_map = match inner_ref.pending.lock() {
+                    Ok(guard) => guard,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+
+                if let Some(sender) = pending_map.remove(&response.header.id) {
+                    PendingDispatch::Matched { sender, response }
+                } else if take_timed_out_tombstone(&inner_ref, response.header.id) {
+                    PendingDispatch::LateTimedOut {
+                        got_id: response.header.id,
+                    }
+                } else {
+                    PendingDispatch::Unknown {
+                        got_id: response.header.id,
+                    }
+                }
+            };
+
+            match dispatch {
+                PendingDispatch::Matched { sender, response } => {
+                    let _ = sender.send(Ok(response));
+                }
+                PendingDispatch::LateTimedOut { got_id } => {
+                    eprintln!("[repe] dropping late response for timed-out request id {got_id}");
+                }
+                PendingDispatch::Unknown { got_id } => {
+                    eprintln!(
+                        "[repe] protocol violation: received response for unknown request id {got_id}"
+                    );
+                    fail_all_pending(&inner, unknown_response_id_error(got_id));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn fail_all_pending(inner: &std::sync::Weak<ClientInner>, err: RepeError) {
+    let Some(inner_ref) = inner.upgrade() else {
+        return;
+    };
+
+    {
+        let writer = match inner_ref.writer.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let _ = writer.get_ref().shutdown(Shutdown::Both);
+    }
+
+    let waiters = {
+        let mut map = match inner_ref.pending.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        map.drain().collect::<Vec<_>>()
+    };
+
+    for (request_id, sender) in waiters {
+        let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
+    }
+}
+
+fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
+    match err {
+        RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
+        RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
+        RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
+        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
+        RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
+            expected: *expected,
+            got: *got,
+        },
+        RepeError::BufferTooSmall { need, have } => RepeError::BufferTooSmall {
+            need: *need,
+            have: *have,
+        },
+        RepeError::ResponseIdMismatch { expected, got } => RepeError::ResponseIdMismatch {
+            expected: *expected,
+            got: *got,
+        },
+        RepeError::Io(io_err) => RepeError::Io(std::io::Error::new(
+            io_err.kind(),
+            format!("request {request_id}: {io_err}"),
+        )),
+        RepeError::Json(json_err) => RepeError::Json(serde_json::Error::io(std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("request {request_id}: {json_err}"),
+        ))),
+        RepeError::Beve(beve_err) => RepeError::Beve(beve::Error::msg(format!(
+            "request {request_id}: {beve_err}"
+        ))),
+        RepeError::UnknownEnumValue(value) => RepeError::UnknownEnumValue(*value),
+        RepeError::ServerError { code, message } => RepeError::ServerError {
+            code: *code,
+            message: message.clone(),
+        },
+    }
+}
+
+fn take_timed_out_tombstone(inner: &ClientInner, request_id: u64) -> bool {
+    let mut timed_out = match inner.timed_out.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    prune_timed_out_requests(&mut timed_out);
+    timed_out.remove(&request_id).is_some()
+}
+
+fn prune_timed_out_requests(timed_out: &mut TimedOutRequests) {
+    let now = Instant::now();
+    timed_out.retain(|_, expires_at| *expires_at > now);
+}
+
+fn unknown_response_id_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::InvalidData,
+        format!("received response for unknown request id {request_id}"),
+    ))
+}
+
+fn poisoned_lock_error(name: &str) -> RepeError {
+    RepeError::Io(std::io::Error::other(format!("{name} lock poisoned")))
+}
+
+fn request_timeout_error(request_id: u64, timeout: Duration) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::TimedOut,
+        format!(
+            "request {request_id} timed out after {}ms",
+            timeout.as_millis()
+        ),
+    ))
+}
+
+fn response_channel_closed_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::ConnectionAborted,
+        format!("response channel closed for request {request_id}"),
+    ))
+}
+
+fn batch_worker_panic_error() -> RepeError {
+    RepeError::Io(std::io::Error::other("batch worker panicked"))
+}
+
+fn batch_worker_missing_result_error() -> RepeError {
+    RepeError::Io(std::io::Error::other("batch worker missing result"))
+}
+
+fn batch_worker_count(request_count: usize) -> usize {
+    if request_count == 0 {
+        return 0;
+    }
+
+    let parallelism = thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1);
+    let cap = parallelism.saturating_mul(4).max(1).min(MAX_BATCH_WORKERS);
+    request_count.min(cap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_worker_count_is_bounded() {
+        assert_eq!(batch_worker_count(0), 0);
+        assert_eq!(batch_worker_count(1), 1);
+
+        let count = batch_worker_count(usize::MAX);
+        assert!(count >= 1);
+        assert!(count <= MAX_BATCH_WORKERS);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,15 +76,6 @@ impl Client {
         Ok(Self { inner })
     }
 
-    pub fn set_read_timeout(&self, d: Option<Duration>) -> std::io::Result<()> {
-        let writer = self
-            .inner
-            .writer
-            .lock()
-            .map_err(|_| std::io::Error::other("client writer lock poisoned"))?;
-        writer.get_ref().set_read_timeout(d)
-    }
-
     pub fn set_write_timeout(&self, d: Option<Duration>) -> std::io::Result<()> {
         let writer = self
             .inner
@@ -455,9 +446,7 @@ fn spawn_response_loop(mut reader: BufReader<TcpStream>, inner: std::sync::Weak<
             let response = match read_message(&mut reader) {
                 Ok(message) => message,
                 Err(RepeError::Io(ref io_err))
-                    if io_err.kind() == ErrorKind::TimedOut
-                        || io_err.kind() == ErrorKind::WouldBlock
-                        || io_err.kind() == ErrorKind::Interrupted =>
+                    if io_err.kind() == ErrorKind::Interrupted =>
                 {
                     continue;
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -368,8 +368,8 @@ impl Client {
             Some(duration) => match receiver.recv_timeout(duration) {
                 Ok(value) => value,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
-                    self.remove_pending(id);
                     self.mark_timed_out_request(id);
+                    self.remove_pending(id);
                     Err(request_timeout_error(id, duration))
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 type PendingSender = mpsc::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
 type TimedOutRequests = HashMap<u64, Instant>;
+type BatchResults = Vec<Option<Result<Value, RepeError>>>;
 
 const TIMED_OUT_REQUEST_TOMBSTONE_TTL: Duration = Duration::from_secs(30);
 const MAX_BATCH_WORKERS: usize = 64;
@@ -222,7 +223,7 @@ impl Client {
             .map(|(index, (path, body))| (index, path, body))
             .collect();
         let work_queue = Arc::new(Mutex::new(queue));
-        let results: Arc<Mutex<Vec<Option<Result<Value, RepeError>>>>> = Arc::new(Mutex::new(
+        let results: Arc<Mutex<BatchResults>> = Arc::new(Mutex::new(
             std::iter::repeat_with(|| None)
                 .take(request_count)
                 .collect(),
@@ -363,29 +364,27 @@ impl Client {
         receiver: mpsc::Receiver<Result<Message, RepeError>>,
         timeout: Option<Duration>,
     ) -> Result<Message, RepeError> {
-        let received = match timeout {
+        match timeout {
             Some(duration) => match receiver.recv_timeout(duration) {
                 Ok(value) => value,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
                     self.remove_pending(id);
                     self.mark_timed_out_request(id);
-                    return Err(request_timeout_error(id, duration));
+                    Err(request_timeout_error(id, duration))
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
                     self.remove_pending(id);
-                    return Err(response_channel_closed_error(id));
+                    Err(response_channel_closed_error(id))
                 }
             },
             None => match receiver.recv() {
                 Ok(value) => value,
                 Err(_) => {
                     self.remove_pending(id);
-                    return Err(response_channel_closed_error(id));
+                    Err(response_channel_closed_error(id))
                 }
             },
-        };
-
-        received
+        }
     }
 
     fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
@@ -647,7 +646,7 @@ fn batch_worker_count(request_count: usize) -> usize {
     let parallelism = thread::available_parallelism()
         .map(|count| count.get())
         .unwrap_or(1);
-    let cap = parallelism.saturating_mul(4).max(1).min(MAX_BATCH_WORKERS);
+    let cap = parallelism.saturating_mul(4).clamp(1, MAX_BATCH_WORKERS);
     request_count.min(cap)
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -445,9 +445,7 @@ fn spawn_response_loop(mut reader: BufReader<TcpStream>, inner: std::sync::Weak<
         loop {
             let response = match read_message(&mut reader) {
                 Ok(message) => message,
-                Err(RepeError::Io(ref io_err))
-                    if io_err.kind() == ErrorKind::Interrupted =>
-                {
+                Err(RepeError::Io(ref io_err)) if io_err.kind() == ErrorKind::Interrupted => {
                     continue;
                 }
                 Err(err) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1074,7 +1074,7 @@ mod tests {
         });
 
         // Use the public Client API
-        let mut client = crate::client::Client::connect(addr).unwrap();
+        let client = crate::client::Client::connect(addr).unwrap();
         let out = client
             .call_json("/add", &serde_json::json!({"a": 3, "b": 4}))
             .unwrap();
@@ -1254,7 +1254,7 @@ mod tests {
             )
         });
 
-        let mut client = crate::client::Client::connect(addr).unwrap();
+        let client = crate::client::Client::connect(addr).unwrap();
         let err = client
             .call_json("/nope", &serde_json::json!({}))
             .unwrap_err();
@@ -1409,7 +1409,7 @@ mod tests {
             )
         });
 
-        let mut client = crate::client::Client::connect(addr).unwrap();
+        let client = crate::client::Client::connect(addr).unwrap();
         // Provide invalid JSON for NeedsI32 (string instead of number)
         let err = client
             .call_json("/typed", &serde_json::json!({"a": "not-a-number"}))

--- a/tests/async_client_multiplexing.rs
+++ b/tests/async_client_multiplexing.rs
@@ -1,0 +1,293 @@
+use repe::{AsyncClient, Message, QueryFormat, RepeError, read_message, write_message};
+use serde_json::{Value, json};
+use std::io::{BufReader, BufWriter, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+fn json_response_for(req: &Message, body: &Value) -> Message {
+    Message::builder()
+        .id(req.header.id)
+        .query_bytes(req.query.clone())
+        .query_format(
+            QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
+        )
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_multiplexes_out_of_order_responses() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let req_a = read_message(&mut reader).unwrap();
+        let req_b = read_message(&mut reader).unwrap();
+
+        let resp_b = json_response_for(
+            &req_b,
+            &json!({"path": req_b.query_utf8(), "id": req_b.header.id}),
+        );
+        let resp_a = json_response_for(
+            &req_a,
+            &json!({"path": req_a.query_utf8(), "id": req_a.header.id}),
+        );
+
+        write_message(&mut writer, &resp_b).unwrap();
+        writer.flush().unwrap();
+        write_message(&mut writer, &resp_a).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+
+    let c1 = client.clone();
+    let call_a = tokio::spawn(async move {
+        let out = c1.call_json("/first", &json!({"v": 1})).await?;
+        if out["path"] != "/first" {
+            return Err(RepeError::Io(std::io::Error::other(
+                "unexpected response for /first",
+            )));
+        }
+        Ok::<(), RepeError>(())
+    });
+
+    let c2 = client.clone();
+    let call_b = tokio::spawn(async move {
+        let out = c2.call_json("/second", &json!({"v": 2})).await?;
+        if out["path"] != "/second" {
+            return Err(RepeError::Io(std::io::Error::other(
+                "unexpected response for /second",
+            )));
+        }
+        Ok::<(), RepeError>(())
+    });
+
+    call_a.await.unwrap().unwrap();
+    call_b.await.unwrap().unwrap();
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_per_request_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream);
+        let _ = read_message(&mut reader).unwrap();
+        thread::sleep(Duration::from_millis(200));
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+    let err = client
+        .call_json_with_timeout("/slow", &json!({}), Duration::from_millis(50))
+        .await
+        .unwrap_err();
+
+    match err {
+        RepeError::Io(io_err) => assert_eq!(io_err.kind(), std::io::ErrorKind::TimedOut),
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_batch_json_preserves_order() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let mut requests = Vec::new();
+        for _ in 0..3 {
+            requests.push(read_message(&mut reader).unwrap());
+        }
+
+        for req in requests.into_iter().rev() {
+            let response = json_response_for(&req, &json!({"path": req.query_utf8()}));
+            write_message(&mut writer, &response).unwrap();
+            writer.flush().unwrap();
+        }
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+    let results = client
+        .batch_json(vec![
+            ("/a".to_string(), json!({"n": 1})),
+            ("/b".to_string(), json!({"n": 2})),
+            ("/c".to_string(), json!({"n": 3})),
+        ])
+        .await;
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].as_ref().unwrap()["path"], "/a");
+    assert_eq!(results[1].as_ref().unwrap()["path"], "/b");
+    assert_eq!(results[2].as_ref().unwrap()["path"], "/c");
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_ignores_late_response_for_timed_out_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let req_1 = read_message(&mut reader).unwrap();
+        let req_2 = read_message(&mut reader).unwrap();
+        let (timed_out_req, pending_req) = if req_1.query_utf8() == "/timed_out" {
+            (req_1, req_2)
+        } else {
+            (req_2, req_1)
+        };
+
+        thread::sleep(Duration::from_millis(120));
+
+        let late_response =
+            json_response_for(&timed_out_req, &json!({"path": timed_out_req.query_utf8()}));
+        write_message(&mut writer, &late_response).unwrap();
+        writer.flush().unwrap();
+
+        let pending_response =
+            json_response_for(&pending_req, &json!({"path": pending_req.query_utf8()}));
+        write_message(&mut writer, &pending_response).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+
+    let timed_client = client.clone();
+    let timed_call = tokio::spawn(async move {
+        timed_client
+            .call_json_with_timeout("/timed_out", &json!({"n": 1}), Duration::from_millis(50))
+            .await
+    });
+
+    let pending_client = client.clone();
+    let pending_call = tokio::spawn(async move {
+        pending_client
+            .call_json_with_timeout(
+                "/still_pending",
+                &json!({"n": 2}),
+                Duration::from_millis(500),
+            )
+            .await
+    });
+
+    let timed_err = timed_call.await.unwrap().unwrap_err();
+    match timed_err {
+        RepeError::Io(io_err) => assert_eq!(io_err.kind(), std::io::ErrorKind::TimedOut),
+        other => panic!("unexpected timeout error: {other:?}"),
+    }
+
+    let pending_out = pending_call.await.unwrap().unwrap();
+    assert_eq!(pending_out["path"], "/still_pending");
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_unknown_response_id_fails_pending_request_without_hanging() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut req = read_message(&mut reader).unwrap();
+        req.header.id += 1;
+
+        let mut writer = BufWriter::new(stream);
+        write_message(&mut writer, &req).unwrap();
+        writer.flush().unwrap();
+        thread::sleep(Duration::from_millis(200));
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+    let result = tokio::time::timeout(Duration::from_millis(500), async {
+        client.call_json("/x", &json!({"a": 1})).await
+    })
+    .await
+    .expect("call_json should fail quickly instead of hanging");
+
+    let err = result.unwrap_err();
+    match err {
+        RepeError::Io(io_err) => {
+            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+            assert!(
+                io_err.to_string().contains("unknown request id"),
+                "error should mention unknown id, got: {io_err}"
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_client_preserves_structured_fatal_response_loop_error() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let req = read_message(&mut reader).unwrap();
+
+        let mut resp = Message::builder()
+            .id(req.header.id)
+            .query_bytes(req.query.clone())
+            .query_format(QueryFormat::try_from(req.header.query_format).unwrap())
+            .error_code(repe::ErrorCode::Ok)
+            .body_json(&json!({"ok": true}))
+            .unwrap()
+            .build();
+        resp.header.spec = 0;
+
+        let mut writer = BufWriter::new(stream);
+        write_message(&mut writer, &resp).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = AsyncClient::connect(addr).await.unwrap();
+    let err = client
+        .call_json("/fatal", &json!({"a": 1}))
+        .await
+        .unwrap_err();
+    match err {
+        RepeError::InvalidSpec(0) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    tokio::task::spawn_blocking(move || server.join().unwrap())
+        .await
+        .unwrap();
+}

--- a/tests/async_client_multiplexing.rs
+++ b/tests/async_client_multiplexing.rs
@@ -212,7 +212,7 @@ async fn async_client_ignores_late_response_for_timed_out_request() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn async_client_unknown_response_id_fails_pending_request_without_hanging() {
+async fn async_client_unrecognized_response_id_is_discarded() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -220,32 +220,25 @@ async fn async_client_unknown_response_id_fails_pending_request_without_hanging(
         let (stream, _) = listener.accept().unwrap();
         let mut reader = BufReader::new(stream.try_clone().unwrap());
         let mut req = read_message(&mut reader).unwrap();
-        req.header.id += 1;
+        req.header.id += 1; // mangle ID so client won't match it
 
         let mut writer = BufWriter::new(stream);
         write_message(&mut writer, &req).unwrap();
         writer.flush().unwrap();
+        // Server closes after a short delay; client should get a connection error
         thread::sleep(Duration::from_millis(200));
     });
 
     let client = AsyncClient::connect(addr).await.unwrap();
-    let result = tokio::time::timeout(Duration::from_millis(500), async {
+    let result = tokio::time::timeout(Duration::from_millis(2000), async {
         client.call_json("/x", &json!({"a": 1})).await
     })
     .await
-    .expect("call_json should fail quickly instead of hanging");
+    .expect("call_json should fail when server closes connection");
 
-    let err = result.unwrap_err();
-    match err {
-        RepeError::Io(io_err) => {
-            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
-            assert!(
-                io_err.to_string().contains("unknown request id"),
-                "error should mention unknown id, got: {io_err}"
-            );
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
+    // The unrecognized response is discarded; the caller fails when the
+    // server closes the connection (not from a protocol-violation teardown).
+    assert!(result.is_err());
 
     tokio::task::spawn_blocking(move || server.join().unwrap())
         .await

--- a/tests/client_id_mismatch.rs
+++ b/tests/client_id_mismatch.rs
@@ -7,8 +7,8 @@ use std::thread;
 use std::time::Duration;
 
 #[test]
-fn client_unknown_response_id_fails_pending_request_without_hanging() {
-    // Server: echoes response with wrong id (id + 1)
+fn client_unrecognized_response_id_is_discarded() {
+    // Server: echoes response with wrong id (id + 1), then closes
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     let srv = thread::spawn(move || {
@@ -29,6 +29,7 @@ fn client_unknown_response_id_fails_pending_request_without_hanging() {
         let mut writer = BufWriter::new(stream);
         write_message(&mut writer, &resp).unwrap();
         writer.flush().unwrap();
+        // Server closes after a short delay; client should get a connection error
         thread::sleep(Duration::from_millis(200));
     });
 
@@ -39,20 +40,12 @@ fn client_unknown_response_id_fails_pending_request_without_hanging() {
         let _ = done_tx.send(result);
     });
 
+    // The unrecognized response is discarded; the caller fails when the
+    // server closes the connection (not from a protocol-violation teardown).
     let result = done_rx
-        .recv_timeout(Duration::from_millis(500))
-        .expect("call_json should fail quickly instead of hanging");
-    let err = result.unwrap_err();
-    match err {
-        RepeError::Io(io_err) => {
-            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
-            assert!(
-                io_err.to_string().contains("unknown request id"),
-                "error should mention unknown id, got: {io_err}"
-            );
-        }
-        other => panic!("unexpected: {other:?}"),
-    }
+        .recv_timeout(Duration::from_millis(2000))
+        .expect("call_json should fail when server closes connection");
+    assert!(result.is_err());
     worker.join().unwrap();
     srv.join().unwrap();
 }

--- a/tests/client_id_mismatch.rs
+++ b/tests/client_id_mismatch.rs
@@ -2,10 +2,12 @@ use repe::*;
 use serde::{Deserialize, Serialize};
 use std::io::{BufReader, BufWriter, Write};
 use std::net::TcpListener;
+use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 #[test]
-fn client_detects_id_mismatch() {
+fn client_unknown_response_id_fails_pending_request_without_hanging() {
     // Server: echoes response with wrong id (id + 1)
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -27,17 +29,68 @@ fn client_detects_id_mismatch() {
         let mut writer = BufWriter::new(stream);
         write_message(&mut writer, &resp).unwrap();
         writer.flush().unwrap();
+        thread::sleep(Duration::from_millis(200));
     });
 
-    let mut client = client::Client::connect(addr).unwrap();
-    let err = client
-        .call_json("/x", &serde_json::json!({"a":1}))
-        .unwrap_err();
+    let client = client::Client::connect(addr).unwrap();
+    let (done_tx, done_rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        let result = client.call_json("/x", &serde_json::json!({"a": 1}));
+        let _ = done_tx.send(result);
+    });
+
+    let result = done_rx
+        .recv_timeout(Duration::from_millis(500))
+        .expect("call_json should fail quickly instead of hanging");
+    let err = result.unwrap_err();
     match err {
-        RepeError::ResponseIdMismatch { .. } => {}
+        RepeError::Io(io_err) => {
+            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+            assert!(
+                io_err.to_string().contains("unknown request id"),
+                "error should mention unknown id, got: {io_err}"
+            );
+        }
         other => panic!("unexpected: {other:?}"),
     }
-    let _ = srv.join();
+    worker.join().unwrap();
+    srv.join().unwrap();
+}
+
+#[test]
+fn client_preserves_structured_fatal_response_loop_error() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let srv = thread::spawn(move || {
+        let (stream, _addr) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let req = read_message(&mut reader).unwrap();
+
+        let mut resp = Message::builder()
+            .id(req.header.id)
+            .query_bytes(req.query.clone())
+            .query_format(QueryFormat::try_from(req.header.query_format).unwrap())
+            .error_code(ErrorCode::Ok)
+            .body_json(&serde_json::json!({"ok": true}))
+            .unwrap()
+            .build();
+        resp.header.spec = 0;
+
+        let mut writer = BufWriter::new(stream);
+        write_message(&mut writer, &resp).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = client::Client::connect(addr).unwrap();
+    let err = client
+        .call_json("/fatal", &serde_json::json!({"a": 1}))
+        .unwrap_err();
+    match err {
+        RepeError::InvalidSpec(0) => {}
+        other => panic!("unexpected: {other:?}"),
+    }
+
+    srv.join().unwrap();
 }
 
 #[test]
@@ -77,7 +130,7 @@ fn client_notify_sets_flag_and_does_not_wait_for_response() {
         // No response sent back; ensure the client was a pure notify for every request.
     });
 
-    let mut client = client::Client::connect(addr).unwrap();
+    let client = client::Client::connect(addr).unwrap();
     client
         .notify_json("/notify", &serde_json::json!({"ok": true}))
         .unwrap();

--- a/tests/client_multiplexing.rs
+++ b/tests/client_multiplexing.rs
@@ -198,33 +198,3 @@ fn sync_client_ignores_late_response_for_timed_out_request() {
 
     server.join().unwrap();
 }
-
-#[test]
-fn sync_client_read_timeout_does_not_stop_response_loop() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    let server = thread::spawn(move || {
-        let (stream, _) = listener.accept().unwrap();
-        let mut reader = BufReader::new(stream.try_clone().unwrap());
-        let mut writer = BufWriter::new(stream);
-
-        let req = read_message(&mut reader).unwrap();
-        let response = json_response_for(&req, &json!({"path": req.query_utf8()}));
-        write_message(&mut writer, &response).unwrap();
-        writer.flush().unwrap();
-    });
-
-    let client = Client::connect(addr).unwrap();
-    client
-        .set_read_timeout(Some(Duration::from_millis(20)))
-        .unwrap();
-    thread::sleep(Duration::from_millis(120));
-
-    let out = client
-        .call_json_with_timeout("/after_idle", &json!({}), Duration::from_millis(300))
-        .unwrap();
-    assert_eq!(out["path"], "/after_idle");
-
-    server.join().unwrap();
-}

--- a/tests/client_multiplexing.rs
+++ b/tests/client_multiplexing.rs
@@ -1,0 +1,230 @@
+use repe::{Client, Message, QueryFormat, RepeError, read_message, write_message};
+use serde_json::{Value, json};
+use std::io::{BufReader, BufWriter, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+fn json_response_for(req: &Message, body: &Value) -> Message {
+    Message::builder()
+        .id(req.header.id)
+        .query_bytes(req.query.clone())
+        .query_format(
+            QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
+        )
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+#[test]
+fn sync_client_multiplexes_out_of_order_responses() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let req_a = read_message(&mut reader).unwrap();
+        let req_b = read_message(&mut reader).unwrap();
+
+        let resp_b = json_response_for(
+            &req_b,
+            &json!({"path": req_b.query_utf8(), "id": req_b.header.id}),
+        );
+        let resp_a = json_response_for(
+            &req_a,
+            &json!({"path": req_a.query_utf8(), "id": req_a.header.id}),
+        );
+
+        write_message(&mut writer, &resp_b).unwrap();
+        writer.flush().unwrap();
+        write_message(&mut writer, &resp_a).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = Client::connect(addr).unwrap();
+
+    let c1 = client.clone();
+    let call_a = thread::spawn(move || {
+        let out = c1.call_json("/first", &json!({"v": 1}))?;
+        if out["path"] != "/first" {
+            return Err(RepeError::Io(std::io::Error::other(
+                "unexpected response for /first",
+            )));
+        }
+        Ok::<(), RepeError>(())
+    });
+
+    let c2 = client.clone();
+    let call_b = thread::spawn(move || {
+        let out = c2.call_json("/second", &json!({"v": 2}))?;
+        if out["path"] != "/second" {
+            return Err(RepeError::Io(std::io::Error::other(
+                "unexpected response for /second",
+            )));
+        }
+        Ok::<(), RepeError>(())
+    });
+
+    call_a.join().unwrap().unwrap();
+    call_b.join().unwrap().unwrap();
+    server.join().unwrap();
+}
+
+#[test]
+fn sync_client_per_request_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream);
+        let _ = read_message(&mut reader).unwrap();
+        thread::sleep(Duration::from_millis(200));
+    });
+
+    let client = Client::connect(addr).unwrap();
+    let err = client
+        .call_json_with_timeout("/slow", &json!({}), Duration::from_millis(50))
+        .unwrap_err();
+
+    match err {
+        RepeError::Io(io_err) => assert_eq!(io_err.kind(), std::io::ErrorKind::TimedOut),
+        other => panic!("unexpected error: {other:?}"),
+    }
+
+    server.join().unwrap();
+}
+
+#[test]
+fn sync_client_batch_json_preserves_order() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let mut requests = Vec::new();
+        for _ in 0..3 {
+            requests.push(read_message(&mut reader).unwrap());
+        }
+
+        for req in requests.into_iter().rev() {
+            let response = json_response_for(&req, &json!({"path": req.query_utf8()}));
+            write_message(&mut writer, &response).unwrap();
+            writer.flush().unwrap();
+        }
+    });
+
+    let client = Client::connect(addr).unwrap();
+    let results = client.batch_json(vec![
+        ("/a".to_string(), json!({"n": 1})),
+        ("/b".to_string(), json!({"n": 2})),
+        ("/c".to_string(), json!({"n": 3})),
+    ]);
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].as_ref().unwrap()["path"], "/a");
+    assert_eq!(results[1].as_ref().unwrap()["path"], "/b");
+    assert_eq!(results[2].as_ref().unwrap()["path"], "/c");
+
+    server.join().unwrap();
+}
+
+#[test]
+fn sync_client_ignores_late_response_for_timed_out_request() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let req_1 = read_message(&mut reader).unwrap();
+        let req_2 = read_message(&mut reader).unwrap();
+        let (timed_out_req, pending_req) = if req_1.query_utf8() == "/timed_out" {
+            (req_1, req_2)
+        } else {
+            (req_2, req_1)
+        };
+
+        thread::sleep(Duration::from_millis(120));
+
+        let late_response =
+            json_response_for(&timed_out_req, &json!({"path": timed_out_req.query_utf8()}));
+        write_message(&mut writer, &late_response).unwrap();
+        writer.flush().unwrap();
+
+        let pending_response =
+            json_response_for(&pending_req, &json!({"path": pending_req.query_utf8()}));
+        write_message(&mut writer, &pending_response).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = Client::connect(addr).unwrap();
+
+    let timed_client = client.clone();
+    let timed_call = thread::spawn(move || {
+        timed_client.call_json_with_timeout(
+            "/timed_out",
+            &json!({"n": 1}),
+            Duration::from_millis(50),
+        )
+    });
+
+    let pending_client = client.clone();
+    let pending_call = thread::spawn(move || {
+        pending_client.call_json_with_timeout(
+            "/still_pending",
+            &json!({"n": 2}),
+            Duration::from_millis(500),
+        )
+    });
+
+    let timed_err = timed_call.join().unwrap().unwrap_err();
+    match timed_err {
+        RepeError::Io(io_err) => assert_eq!(io_err.kind(), std::io::ErrorKind::TimedOut),
+        other => panic!("unexpected timeout error: {other:?}"),
+    }
+
+    let pending_out = pending_call.join().unwrap().unwrap();
+    assert_eq!(pending_out["path"], "/still_pending");
+
+    server.join().unwrap();
+}
+
+#[test]
+fn sync_client_read_timeout_does_not_stop_response_loop() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = BufWriter::new(stream);
+
+        let req = read_message(&mut reader).unwrap();
+        let response = json_response_for(&req, &json!({"path": req.query_utf8()}));
+        write_message(&mut writer, &response).unwrap();
+        writer.flush().unwrap();
+    });
+
+    let client = Client::connect(addr).unwrap();
+    client
+        .set_read_timeout(Some(Duration::from_millis(20)))
+        .unwrap();
+    thread::sleep(Duration::from_millis(120));
+
+    let out = client
+        .call_json_with_timeout("/after_idle", &json!({}), Duration::from_millis(300))
+        .unwrap();
+    assert_eq!(out["path"], "/after_idle");
+
+    server.join().unwrap();
+}


### PR DESCRIPTION
## Summary
This PR upgrades both sync and async clients to support safe multiplexed in-flight RPC calls on a single connection, adds per-request timeout and batch helpers, and hardens response-loop error handling.

## Changes from `main`
- Added multiplexed request/response handling for `Client` and `AsyncClient`.
- Added per-call timeout APIs:
  - `call_json_with_timeout`
  - `call_typed_json_with_timeout`
  - `call_typed_beve_with_timeout`
- Added batch APIs:
  - `batch_json`
  - `batch_json_with_timeout`
- Unrecognized response IDs (including late responses for timed-out requests) are now logged and silently discarded instead of tearing down the connection. This removes the tombstone/TTL mechanism entirely — no more `timed_out` map, no TTL expiry race, and no risk of a late response killing a healthy connection.
- Removed `Client::set_read_timeout` — it was a footgun that could not actually bound call latency (the response loop swallowed socket timeouts) and caused busy-looping when set to short durations. Use `call_json_with_timeout` for bounded call latency instead.
- Narrowed the response loop's transient-error handling to only retry on `Interrupted` (removed `TimedOut`/`WouldBlock` since the client no longer sets a socket read timeout).
- Preserved structured fatal response-loop error variants when failing pending requests (instead of flattening to `Io(ConnectionAborted)`).
- Bounded sync `Client::batch_json` worker threads to avoid unbounded thread creation on large batches.
- Updated docs/examples/changelog for new APIs and behaviors.

## Testing
- Added new integration coverage:
  - `tests/client_multiplexing.rs`
  - `tests/async_client_multiplexing.rs`
- Expanded `tests/client_id_mismatch.rs` for:
  - unrecognized response ID behavior (logged and discarded, no hang)
  - structured fatal error propagation
- Full test suite and clippy checks pass.
