### PR TITLE
Dynamic registry routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /reference
 target/
 PR_DESCRIPTION.md
+docs/pr-description.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 PR_DESCRIPTION.md
 docs/pr-description.md
+docs/feature-expansion-plan.md

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This crate provides:
 - Message encode/decode to/from bytes and I/O helpers for streams
 - JSON body helpers using `serde`/`serde_json`
 - BEVE binary body helpers via the [`beve`](https://crates.io/crates/beve) crate
+- Dynamic registry routing with JSON Pointer semantics
 - Error codes and formats aligned with the spec
 
 Installation
@@ -71,6 +72,8 @@ Examples
 - `examples/json_roundtrip.rs` – construct/serialize/parse a JSON message.
 - `examples/server.rs` – run a JSON-pointer server (TCP).
 - `examples/client.rs` – call the server routes.
+- `examples/registry_server.rs` – serve a dynamic registry under a path prefix.
+- `examples/registry_roundtrip.rs` – local registry READ/WRITE/CALL roundtrip.
 - `examples/async_server.rs` – tokio-based async server.
 - `examples/async_client.rs` – tokio-based async client.
 
@@ -208,6 +211,37 @@ Router handles `Arc<L>` for any lock implementing `repe::Lockable<T>`, so you ca
 `parking-lot` feature to use `parking_lot::Mutex`/`RwLock` without extra wrapper types.
 ```
 
+Registry (Dynamic Routing)
+
+- Mount a `Registry` on any path prefix with `Router::with_registry("/api/v1", registry)`.
+- Registry request semantics:
+  - Empty body => READ value.
+  - Non-empty body + function target => CALL function.
+  - Non-empty body + non-function target => WRITE value.
+- See [docs/registry.md](docs/registry.md) for full behavior, format decoding details, and client examples.
+
+```rust
+use repe::{ErrorCode, Registry, Router, Server};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+let registry = Arc::new(Registry::new());
+registry.register_value("/counter", json!(0))?;
+registry.register_function("/add", |params| {
+    let Some(Value::Object(map)) = params else {
+        return Err((ErrorCode::InvalidBody, "expected object body".into()));
+    };
+    let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+    let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+    Ok(json!({"result": a + b}))
+})?;
+
+let router = Router::new().with_registry("/api/v1", Arc::clone(&registry));
+let server = Server::new(router);
+let listener = server.listen("127.0.0.1:8082")?;
+server.serve(listener)?;
+```
+
 Client
 
 - Connect and call JSON-pointer routes with JSON bodies:
@@ -245,6 +279,13 @@ Typed helpers work for BEVE payloads too:
 let beve_sum: AddResp = client.call_typed_beve("/add", &AddReq { a: 4, b: 5 })?;
 assert_eq!(beve_sum.sum, 9);
 ```
+
+Registry-oriented client helpers:
+
+- Empty-body READs: `registry_read("/api/v1/counter")` or `call_message(...)`
+- Typed READs: `registry_read_typed::<_, MyType>(...)`
+- JSON WRITE/CALL helpers: `registry_write_json(...)` and `registry_call_json(...)`
+- Custom wire formats: `call_with_formats(...)` and `notify_with_formats(...)`
 
 Multiplexed calls, timeouts, and batching
 
@@ -325,6 +366,8 @@ Running the examples
 ```
 cargo run --example server
 cargo run --example client
+cargo run --example registry_server
+cargo run --example registry_roundtrip
 cargo run --example async_server
 cargo run --example async_client
 ```

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,114 @@
+# Registry Support
+
+`repe-rs` includes a dynamic `Registry` that can be mounted on a `Router` for JSON Pointer style access to values and callable endpoints.
+
+## Semantics
+
+For a request path resolved within a registry:
+
+- Empty body: READ the value at the path.
+- Non-empty body + function target: CALL the function with decoded params.
+- Non-empty body + non-function target: WRITE the value at the path.
+
+This matches the intended Glaze-style registry behavior.
+
+## Quick Start
+
+```rust
+use repe::{ErrorCode, Registry, Router, Server};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+let registry = Arc::new(Registry::new());
+registry.register_value("/counter", json!(0))?;
+registry.register_function("/add", |params| {
+    let Some(Value::Object(map)) = params else {
+        return Err((ErrorCode::InvalidBody, "expected object body".into()));
+    };
+    let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+    let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+    Ok(json!({"result": a + b}))
+})?;
+
+let router = Router::new().with_registry("/api/v1", Arc::clone(&registry));
+let server = Server::new(router);
+let listener = server.listen("127.0.0.1:8082")?;
+server.serve(listener)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Path Prefix
+
+Mounting with a prefix strips that prefix from incoming paths before registry lookup.
+
+Example:
+- Router mount: `with_registry("/api/v1", registry)`
+- Incoming request: `/api/v1/counter`
+- Registry pointer resolved as: `/counter`
+
+## Supported Body Formats
+
+Registry request bodies are decoded as:
+
+- `BodyFormat::Json` -> JSON value
+- `BodyFormat::Beve` -> JSON value decoded from BEVE
+- `BodyFormat::Utf8` -> JSON string value
+- `BodyFormat::RawBinary` -> JSON array of byte integers
+
+Unknown body formats are rejected with `InvalidBody`.
+
+## Examples
+
+- Server example: `cargo run --example registry_server`
+- Local roundtrip example (no TCP): `cargo run --example registry_roundtrip`
+
+## Client APIs
+
+Registry reads require an empty body, and the client API now supports this directly:
+
+- `Client::registry_read(path)` / `AsyncClient::registry_read(path)`
+- `Client::registry_read_typed::<_, R>(path)` / `AsyncClient::registry_read_typed::<_, R>(path)`
+- `Client::call_message(path)` / `AsyncClient::call_message(path)` for full `Message` access
+
+WRITE/CALL operations keep the JSON helper shape:
+
+- `Client::registry_write_json(path, body)` / async equivalent
+- `Client::registry_call_json(path, body)` / async equivalent
+
+### Sync Client Example
+
+```rust
+use repe::Client;
+use serde_json::json;
+
+let client = Client::connect("127.0.0.1:8082")?;
+
+let counter = client.registry_read("/api/v1/counter")?;
+println!("counter={counter}");
+
+let _ = client.registry_write_json("/api/v1/counter", &json!(42))?;
+let sum = client.registry_call_json("/api/v1/add", &json!({"a": 2, "b": 3}))?;
+println!("sum={sum}");
+
+#[derive(serde::Deserialize)]
+struct Snapshot {
+    counter: i64,
+}
+let _snapshot: Snapshot = client.registry_read_typed("/api/v1/state")?;
+
+let raw_message = client.call_message("/api/v1/counter")?;
+println!("raw response body format={}", raw_message.header.body_format);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Generic Formats
+
+For non-standard query/body formats, use:
+
+- `Client::call_with_formats(...)` / `AsyncClient::call_with_formats(...)`
+- `Client::notify_with_formats(...)` / `AsyncClient::notify_with_formats(...)`
+
+These APIs allow:
+- custom `query_format` code
+- optional raw body bytes (including true empty body)
+- custom `body_format` code

--- a/examples/registry_roundtrip.rs
+++ b/examples/registry_roundtrip.rs
@@ -1,0 +1,69 @@
+use repe::{BodyFormat, ErrorCode, Message, QueryFormat, Registry, Router};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+fn request_read(path: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .build()
+}
+
+fn request_json(path: &str, body: &Value) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let registry = Arc::new(Registry::new());
+    registry.register_value("/counter", json!(0))?;
+    registry.register_function("/add", |params| {
+        let Some(Value::Object(map)) = params else {
+            return Err((ErrorCode::InvalidBody, "expected object body".into()));
+        };
+        let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+        let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+        Ok(json!(a + b))
+    })?;
+
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let read_counter = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&request_read("/counter"))?;
+    println!("read /counter => {}", read_counter.body_utf8());
+
+    let write_counter = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&request_json("/counter", &json!(42)))?;
+    println!("write /counter => {}", write_counter.body_utf8());
+
+    let call_add = router
+        .get("/add")
+        .expect("add handler")
+        .handle(&request_json("/add", &json!({"a": 2, "b": 3})))?;
+    println!("call /add => {}", call_add.body_utf8());
+
+    // Registry bodies can be encoded with BEVE as well.
+    let beve_request = Message::builder()
+        .id(1)
+        .query_str("/counter")
+        .query_format(QueryFormat::JsonPointer)
+        .body_beve(&json!(7))?
+        .build();
+    let beve_write = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&beve_request)?;
+    assert_eq!(beve_write.header.body_format, BodyFormat::Json as u16);
+
+    Ok(())
+}

--- a/examples/registry_server.rs
+++ b/examples/registry_server.rs
@@ -1,0 +1,30 @@
+use repe::{ErrorCode, Registry, Router, Server};
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let registry = Arc::new(Registry::new());
+
+    registry.register_value("/counter", json!(0))?;
+    registry.register_value("/config", json!({"timeout": 30, "retries": 3}))?;
+    registry.register_function("/add", |params| {
+        let Some(Value::Object(map)) = params else {
+            return Err((ErrorCode::InvalidBody, "expected object body".into()));
+        };
+        let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+        let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+        Ok(json!({"result": a + b}))
+    })?;
+
+    let router = Router::new().with_registry("/api/v1", Arc::clone(&registry));
+    let server = Server::new(router);
+    let listener = server.listen("127.0.0.1:8082")?;
+
+    eprintln!("REPE registry server listening on 127.0.0.1:8082");
+    eprintln!("  read:  /api/v1/counter");
+    eprintln!("  write: /api/v1/counter (JSON body)");
+    eprintln!("  call:  /api/v1/add (JSON body {{\"a\":1,\"b\":2}})");
+
+    server.serve(listener)?;
+    Ok(())
+}

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -174,6 +174,127 @@ impl AsyncClient {
             .await
     }
 
+    /// Send a JSON-pointer request with an empty body and return the full response message.
+    ///
+    /// This is useful for protocols that use empty-body semantics (for example, registry READs).
+    pub async fn call_message<P: AsRef<str>>(&self, path: P) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            None,
+            BodyFormat::RawBinary as u16,
+            None,
+        )
+        .await
+    }
+
+    /// Send a JSON-pointer request with an empty body, failing if no response arrives before
+    /// `timeout_duration`.
+    pub async fn call_message_with_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        timeout_duration: Duration,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            None,
+            BodyFormat::RawBinary as u16,
+            Some(timeout_duration),
+        )
+        .await
+    }
+
+    /// Low-level call API that allows custom query/body format codes and optional raw body bytes.
+    ///
+    /// If `body` is `None`, the request body is empty (`body_length = 0`).
+    pub async fn call_with_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(path, query_format, body, body_format, None)
+            .await
+    }
+
+    /// Timeout variant of [`AsyncClient::call_with_formats`].
+    pub async fn call_with_formats_and_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout_duration: Duration,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            query_format,
+            body,
+            body_format,
+            Some(timeout_duration),
+        )
+        .await
+    }
+
+    /// Registry helper: send an empty-body request and decode the JSON response.
+    pub async fn registry_read<P: AsRef<str>>(&self, path: P) -> Result<Value, RepeError> {
+        let resp = self.call_message(path).await?;
+        resp.json_body::<Value>()
+    }
+
+    /// Registry helper: send an empty-body request and deserialize the JSON response as `R`.
+    pub async fn registry_read_typed<P: AsRef<str>, R: DeserializeOwned>(
+        &self,
+        path: P,
+    ) -> Result<R, RepeError> {
+        let resp = self.call_message(path).await?;
+        resp.json_body::<R>()
+    }
+
+    /// Timeout variant of [`AsyncClient::registry_read`].
+    pub async fn registry_read_with_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        timeout_duration: Duration,
+    ) -> Result<Value, RepeError> {
+        let resp = self
+            .call_message_with_timeout(path, timeout_duration)
+            .await?;
+        resp.json_body::<Value>()
+    }
+
+    /// Timeout variant of [`AsyncClient::registry_read_typed`].
+    pub async fn registry_read_typed_with_timeout<P: AsRef<str>, R: DeserializeOwned>(
+        &self,
+        path: P,
+        timeout_duration: Duration,
+    ) -> Result<R, RepeError> {
+        let resp = self
+            .call_message_with_timeout(path, timeout_duration)
+            .await?;
+        resp.json_body::<R>()
+    }
+
+    /// Registry helper: send a JSON body (WRITE semantics for non-function targets).
+    pub async fn registry_write_json<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<Value, RepeError> {
+        self.call_json(path, body).await
+    }
+
+    /// Registry helper: send a JSON body (CALL semantics for function targets).
+    pub async fn registry_call_json<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<Value, RepeError> {
+        self.call_json(path, body).await
+    }
+
     pub async fn notify_json<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -198,6 +319,20 @@ impl AsyncClient {
         body: &T,
     ) -> Result<(), RepeError> {
         self.notify_with_body(path, |builder| builder.body_beve(body))
+            .await
+    }
+
+    /// Low-level notify API that allows custom query/body format codes and optional raw body bytes.
+    ///
+    /// If `body` is `None`, the notify request is sent with an empty body.
+    pub async fn notify_with_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_message_formats(path, query_format, body, body_format)
             .await
     }
 
@@ -262,7 +397,12 @@ impl AsyncClient {
         timeout_duration: Option<Duration>,
     ) -> Result<Value, RepeError> {
         let resp = self
-            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_json(body))
+            .call_with_body_and_timeout(
+                path,
+                QueryFormat::JsonPointer as u16,
+                timeout_duration,
+                |builder| builder.body_json(body),
+            )
             .await?;
         resp.json_body::<Value>()
     }
@@ -278,7 +418,12 @@ impl AsyncClient {
         timeout_duration: Option<Duration>,
     ) -> Result<R, RepeError> {
         let resp = self
-            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_json(body))
+            .call_with_body_and_timeout(
+                path,
+                QueryFormat::JsonPointer as u16,
+                timeout_duration,
+                |builder| builder.body_json(body),
+            )
             .await?;
         Self::decode_typed_response(&resp)
     }
@@ -294,7 +439,12 @@ impl AsyncClient {
         timeout_duration: Option<Duration>,
     ) -> Result<R, RepeError> {
         let resp = self
-            .call_with_body_and_timeout(path, timeout_duration, |builder| builder.body_beve(body))
+            .call_with_body_and_timeout(
+                path,
+                QueryFormat::JsonPointer as u16,
+                timeout_duration,
+                |builder| builder.body_beve(body),
+            )
             .await?;
         Self::decode_typed_response(&resp)
     }
@@ -302,6 +452,7 @@ impl AsyncClient {
     async fn call_with_body_and_timeout<P, F>(
         &self,
         path: P,
+        query_format: u16,
         timeout_duration: Option<Duration>,
         body_fn: F,
     ) -> Result<Message, RepeError>
@@ -313,7 +464,7 @@ impl AsyncClient {
         let builder = Message::builder()
             .id(id)
             .query_str(path.as_ref())
-            .query_format(QueryFormat::JsonPointer);
+            .query_format_code(query_format);
         let msg = body_fn(builder)?.build();
 
         let (sender, receiver) = oneshot::channel();
@@ -387,14 +538,69 @@ impl AsyncClient {
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
     {
+        self.notify_with_builder(path, QueryFormat::JsonPointer as u16, body_fn)
+            .await
+    }
+
+    async fn notify_with_builder<P, F>(
+        &self,
+        path: P,
+        query_format: u16,
+        body_fn: F,
+    ) -> Result<(), RepeError>
+    where
+        P: AsRef<str>,
+        F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
+    {
         let id = self.next_request_id();
         let builder = Message::builder()
             .id(id)
             .notify(true)
             .query_str(path.as_ref())
-            .query_format(QueryFormat::JsonPointer);
+            .query_format_code(query_format);
         let msg = body_fn(builder)?.build();
         self.write_request(&msg).await
+    }
+
+    async fn call_message_with_formats_and_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout_duration: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        self.call_with_body_and_timeout(path, query_format, timeout_duration, |builder| {
+            let builder = if let Some(bytes) = body {
+                builder
+                    .body_bytes(bytes.to_vec())
+                    .body_format_code(body_format)
+            } else {
+                builder.body_format_code(body_format)
+            };
+            Ok(builder)
+        })
+        .await
+    }
+
+    async fn notify_with_message_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_builder(path, query_format, |builder| {
+            let builder = if let Some(bytes) = body {
+                builder
+                    .body_bytes(bytes.to_vec())
+                    .body_format_code(body_format)
+            } else {
+                builder.body_format_code(body_format)
+            };
+            Ok(builder)
+        })
+        .await
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -149,6 +149,119 @@ impl Client {
         self.call_typed_beve_with_optional_timeout(path, body, Some(timeout))
     }
 
+    /// Send a JSON-pointer request with an empty body and return the full response message.
+    ///
+    /// This is useful for protocols that use empty-body semantics (for example, registry READs).
+    pub fn call_message<P: AsRef<str>>(&self, path: P) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            None,
+            BodyFormat::RawBinary as u16,
+            None,
+        )
+    }
+
+    /// Send a JSON-pointer request with an empty body, failing if no response arrives before
+    /// `timeout`.
+    pub fn call_message_with_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        timeout: Duration,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            None,
+            BodyFormat::RawBinary as u16,
+            Some(timeout),
+        )
+    }
+
+    /// Low-level call API that allows custom query/body format codes and optional raw body bytes.
+    ///
+    /// If `body` is `None`, the request body is empty (`body_length = 0`).
+    pub fn call_with_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(path, query_format, body, body_format, None)
+    }
+
+    /// Timeout variant of [`Client::call_with_formats`].
+    pub fn call_with_formats_and_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout: Duration,
+    ) -> Result<Message, RepeError> {
+        self.call_message_with_formats_and_timeout(
+            path,
+            query_format,
+            body,
+            body_format,
+            Some(timeout),
+        )
+    }
+
+    /// Registry helper: send an empty-body request and decode the JSON response.
+    pub fn registry_read<P: AsRef<str>>(&self, path: P) -> Result<Value, RepeError> {
+        let resp = self.call_message(path)?;
+        resp.json_body::<Value>()
+    }
+
+    /// Registry helper: send an empty-body request and deserialize the JSON response as `R`.
+    pub fn registry_read_typed<P: AsRef<str>, R: DeserializeOwned>(
+        &self,
+        path: P,
+    ) -> Result<R, RepeError> {
+        let resp = self.call_message(path)?;
+        resp.json_body::<R>()
+    }
+
+    /// Timeout variant of [`Client::registry_read`].
+    pub fn registry_read_with_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        timeout: Duration,
+    ) -> Result<Value, RepeError> {
+        let resp = self.call_message_with_timeout(path, timeout)?;
+        resp.json_body::<Value>()
+    }
+
+    /// Timeout variant of [`Client::registry_read_typed`].
+    pub fn registry_read_typed_with_timeout<P: AsRef<str>, R: DeserializeOwned>(
+        &self,
+        path: P,
+        timeout: Duration,
+    ) -> Result<R, RepeError> {
+        let resp = self.call_message_with_timeout(path, timeout)?;
+        resp.json_body::<R>()
+    }
+
+    /// Registry helper: send a JSON body (WRITE semantics for non-function targets).
+    pub fn registry_write_json<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<Value, RepeError> {
+        self.call_json(path, body)
+    }
+
+    /// Registry helper: send a JSON body (CALL semantics for function targets).
+    pub fn registry_call_json<P: AsRef<str>, T: Serialize>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<Value, RepeError> {
+        self.call_json(path, body)
+    }
+
     /// Send a JSON-pointer notify request (no response expected).
     pub fn notify_json<P: AsRef<str>, T: Serialize>(
         &self,
@@ -174,6 +287,19 @@ impl Client {
         body: &T,
     ) -> Result<(), RepeError> {
         self.notify_with_body(path, |builder| builder.body_beve(body))
+    }
+
+    /// Low-level notify API that allows custom query/body format codes and optional raw body bytes.
+    ///
+    /// If `body` is `None`, the notify request is sent with an empty body.
+    pub fn notify_with_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_message_formats(path, query_format, body, body_format)
     }
 
     /// Execute JSON calls in parallel over this single connection and keep request order.
@@ -279,8 +405,12 @@ impl Client {
         body: &T,
         timeout: Option<Duration>,
     ) -> Result<Value, RepeError> {
-        let resp =
-            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_json(body))?;
+        let resp = self.call_with_body_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            timeout,
+            |builder| builder.body_json(body),
+        )?;
         resp.json_body::<Value>()
     }
 
@@ -290,8 +420,12 @@ impl Client {
         body: &T,
         timeout: Option<Duration>,
     ) -> Result<R, RepeError> {
-        let resp =
-            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_json(body))?;
+        let resp = self.call_with_body_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            timeout,
+            |builder| builder.body_json(body),
+        )?;
         Self::decode_typed_response(&resp)
     }
 
@@ -301,14 +435,19 @@ impl Client {
         body: &T,
         timeout: Option<Duration>,
     ) -> Result<R, RepeError> {
-        let resp =
-            self.call_with_body_and_timeout(path, timeout, |builder| builder.body_beve(body))?;
+        let resp = self.call_with_body_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            timeout,
+            |builder| builder.body_beve(body),
+        )?;
         Self::decode_typed_response(&resp)
     }
 
     fn call_with_body_and_timeout<P, F>(
         &self,
         path: P,
+        query_format: u16,
         timeout: Option<Duration>,
         body_fn: F,
     ) -> Result<Message, RepeError>
@@ -320,7 +459,7 @@ impl Client {
         let builder = Message::builder()
             .id(id)
             .query_str(path.as_ref())
-            .query_format(QueryFormat::JsonPointer);
+            .query_format_code(query_format);
         let msg = body_fn(builder)?.build();
 
         let (sender, receiver) = mpsc::channel();
@@ -412,14 +551,66 @@ impl Client {
         P: AsRef<str>,
         F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
     {
+        self.notify_with_builder(path, QueryFormat::JsonPointer as u16, body_fn)
+    }
+
+    fn notify_with_builder<P, F>(
+        &self,
+        path: P,
+        query_format: u16,
+        body_fn: F,
+    ) -> Result<(), RepeError>
+    where
+        P: AsRef<str>,
+        F: FnOnce(MessageBuilder) -> Result<MessageBuilder, RepeError>,
+    {
         let id = self.next_request_id();
         let builder = Message::builder()
             .id(id)
             .notify(true)
             .query_str(path.as_ref())
-            .query_format(QueryFormat::JsonPointer);
+            .query_format_code(query_format);
         let msg = body_fn(builder)?.build();
         self.write_request(&msg)
+    }
+
+    fn call_message_with_formats_and_timeout<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        self.call_with_body_and_timeout(path, query_format, timeout, |builder| {
+            let builder = if let Some(bytes) = body {
+                builder
+                    .body_bytes(bytes.to_vec())
+                    .body_format_code(body_format)
+            } else {
+                builder.body_format_code(body_format)
+            };
+            Ok(builder)
+        })
+    }
+
+    fn notify_with_message_formats<P: AsRef<str>>(
+        &self,
+        path: P,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_builder(path, query_format, |builder| {
+            let builder = if let Some(bytes) = body {
+                builder
+                    .body_bytes(bytes.to_vec())
+                    .body_format_code(body_format)
+            } else {
+                builder.body_format_code(body_format)
+            };
+            Ok(builder)
+        })
     }
 
     fn decode_typed_response<R: DeserializeOwned>(resp: &Message) -> Result<R, RepeError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod header;
 pub mod io;
 pub mod json_pointer;
 pub mod message;
+pub mod registry;
 pub mod server;
 pub mod structs;
 
@@ -33,6 +34,7 @@ pub use header::Header;
 pub use io::{read_message, write_message};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::Message;
+pub use registry::{Registry, RegistryCallable, RegistryError};
 pub use server::{
     IntoTypedResponse, JsonTypedHandler, LockError, Lockable, Middleware, Next, Router, Server,
     TypedResponse,

--- a/src/message.rs
+++ b/src/message.rs
@@ -264,6 +264,20 @@ mod tests {
         let err = msg.beve_body::<serde_json::Value>().unwrap_err();
         matches!(err, RepeError::Beve(_));
     }
+
+    #[test]
+    fn builder_format_code_methods_set_explicit_codes() {
+        let msg = Message::builder()
+            .id(9)
+            .query_str("/raw")
+            .query_format_code(0x7777)
+            .body_bytes(vec![1, 2, 3])
+            .body_format_code(0x8888)
+            .build();
+
+        assert_eq!(msg.header.query_format, 0x7777);
+        assert_eq!(msg.header.body_format, 0x8888);
+    }
 }
 
 #[derive(Default)]
@@ -294,8 +308,16 @@ impl MessageBuilder {
         self.query_format = u16::from(f);
         self
     }
+    pub fn query_format_code(mut self, format_code: u16) -> Self {
+        self.query_format = format_code;
+        self
+    }
     pub fn body_format(mut self, f: BodyFormat) -> Self {
         self.body_format = u16::from(f);
+        self
+    }
+    pub fn body_format_code(mut self, format_code: u16) -> Self {
+        self.body_format = format_code;
         self
     }
     pub fn query_bytes(mut self, q: impl Into<Vec<u8>>) -> Self {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,581 @@
+use crate::constants::{BodyFormat, ErrorCode};
+use crate::message::Message;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+type RegistryFunction = Arc<dyn RegistryCallable>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("invalid JSON pointer `{pointer}`")]
+    InvalidPointer { pointer: String },
+    #[error("path not found `{path}`")]
+    PathNotFound { path: String },
+    #[error("array index `{segment}` is invalid at `{path}`")]
+    InvalidArrayIndex { path: String, segment: String },
+    #[error("array index `{segment}` out of bounds at `{path}`")]
+    ArrayIndexOutOfBounds { path: String, segment: String },
+    #[error("root write requires a JSON object body")]
+    RootWriteRequiresObject,
+    #[error("registry body format `{format}` is unsupported")]
+    UnsupportedBodyFormat { format: u16 },
+    #[error("registry body is not valid UTF-8")]
+    InvalidUtf8(#[source] std::str::Utf8Error),
+    #[error("registry JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("registry BEVE parse error: {0}")]
+    Beve(#[from] beve::Error),
+    #[error("{message}")]
+    Execution { code: ErrorCode, message: String },
+}
+
+impl RegistryError {
+    pub fn code(&self) -> ErrorCode {
+        match self {
+            RegistryError::InvalidPointer { .. }
+            | RegistryError::PathNotFound { .. }
+            | RegistryError::InvalidArrayIndex { .. }
+            | RegistryError::ArrayIndexOutOfBounds { .. } => ErrorCode::MethodNotFound,
+            RegistryError::RootWriteRequiresObject => ErrorCode::InvalidBody,
+            RegistryError::UnsupportedBodyFormat { .. }
+            | RegistryError::InvalidUtf8(_)
+            | RegistryError::Json(_)
+            | RegistryError::Beve(_) => ErrorCode::InvalidBody,
+            RegistryError::Execution { code, .. } => *code,
+        }
+    }
+}
+
+pub trait RegistryCallable: Send + Sync {
+    fn call(&self, params: Option<Value>) -> Result<Value, (ErrorCode, String)>;
+}
+
+impl<F> RegistryCallable for F
+where
+    F: Fn(Option<Value>) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
+{
+    fn call(&self, params: Option<Value>) -> Result<Value, (ErrorCode, String)> {
+        (self)(params)
+    }
+}
+
+struct RegistryState {
+    root: Value,
+    functions: HashMap<Vec<String>, RegistryFunction>,
+}
+
+impl Default for RegistryState {
+    fn default() -> Self {
+        Self {
+            root: Value::Object(Map::new()),
+            functions: HashMap::new(),
+        }
+    }
+}
+
+/// Dynamic registry that serves values and callable entries by JSON pointer.
+///
+/// Request semantics:
+/// - Empty body => READ value at pointer.
+/// - Non-empty body + function target => CALL function.
+/// - Non-empty body + non-function target => WRITE value.
+#[derive(Default)]
+pub struct Registry {
+    state: RwLock<RegistryState>,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the root JSON value stored by the registry.
+    pub fn set_root(&self, value: Value) {
+        let mut state = self.write_state();
+        state.root = value;
+    }
+
+    /// Register or replace a value at `path`, creating missing object parents.
+    pub fn register_value(&self, path: &str, value: Value) -> Result<(), RegistryError> {
+        let mut state = self.write_state();
+        let segments = parse_registration_path(path)?;
+        if segments.is_empty() {
+            state.root = value;
+            return Ok(());
+        }
+
+        let parent = ensure_object_parent(&mut state.root, &segments)?;
+        parent.insert(segments.last().unwrap().clone(), value);
+        Ok(())
+    }
+
+    /// Merge object fields into the root.
+    pub fn merge_root(&self, object: Map<String, Value>) -> Result<(), RegistryError> {
+        let mut state = self.write_state();
+        let root = ensure_object_root(&mut state.root)?;
+        for (key, value) in object {
+            root.insert(key, value);
+        }
+        Ok(())
+    }
+
+    /// Merge object fields into an object at `path`.
+    pub fn merge_at(&self, path: &str, object: Map<String, Value>) -> Result<(), RegistryError> {
+        let mut state = self.write_state();
+        let segments = parse_registration_path(path)?;
+        if segments.is_empty() {
+            let root = ensure_object_root(&mut state.root)?;
+            for (key, value) in object {
+                root.insert(key, value);
+            }
+            return Ok(());
+        }
+
+        let target = resolve_mut(&mut state.root, &segments)?;
+        let map = target
+            .as_object_mut()
+            .ok_or_else(|| RegistryError::PathNotFound {
+                path: canonical_pointer(&segments),
+            })?;
+        for (key, value) in object {
+            map.insert(key, value);
+        }
+        Ok(())
+    }
+
+    /// Register a callable at `path`, creating missing object parents for discoverability.
+    pub fn register_function(
+        &self,
+        path: &str,
+        function: impl RegistryCallable + 'static,
+    ) -> Result<(), RegistryError> {
+        self.register_function_arc(path, Arc::new(function))
+    }
+
+    pub fn register_function_arc(
+        &self,
+        path: &str,
+        function: Arc<dyn RegistryCallable>,
+    ) -> Result<(), RegistryError> {
+        let mut state = self.write_state();
+        let segments = parse_registration_path(path)?;
+        if segments.is_empty() {
+            return Err(RegistryError::InvalidPointer {
+                pointer: path.to_string(),
+            });
+        }
+        let _ = ensure_object_parent(&mut state.root, &segments)?;
+        state.functions.insert(segments, function);
+        Ok(())
+    }
+
+    pub fn read_value(&self, pointer: &str) -> Result<Value, RegistryError> {
+        let state = self.read_state();
+        let segments = parse_pointer(pointer)?;
+        resolve_ref(&state.root, &segments).cloned()
+    }
+
+    pub fn dispatch(&self, pointer: &str, body: Option<Value>) -> Result<Value, RegistryError> {
+        let segments = parse_pointer(pointer)?;
+        if body.is_none() {
+            let state = self.read_state();
+            if state.functions.contains_key(&segments) {
+                return Ok(json!({
+                    "type": "function",
+                    "path": canonical_pointer(&segments),
+                }));
+            }
+            return resolve_ref(&state.root, &segments).cloned();
+        }
+
+        let payload = body.unwrap();
+
+        let function = {
+            let state = self.read_state();
+            state.functions.get(&segments).cloned()
+        };
+        if let Some(f) = function {
+            return f
+                .call(Some(payload))
+                .map_err(|(code, message)| RegistryError::Execution { code, message });
+        }
+
+        let mut state = self.write_state();
+        if segments.is_empty() {
+            let Value::Object(object) = payload else {
+                return Err(RegistryError::RootWriteRequiresObject);
+            };
+            let root = ensure_object_root(&mut state.root)?;
+            for (key, value) in object {
+                root.insert(key, value);
+            }
+            return Ok(json!({
+                "status": "ok",
+                "path": "/",
+            }));
+        }
+
+        set_pointer(&mut state.root, &segments, payload)?;
+        Ok(json!({
+            "status": "ok",
+            "path": canonical_pointer(&segments),
+        }))
+    }
+
+    pub fn decode_body(req: &Message) -> Result<Option<Value>, RegistryError> {
+        if req.body.is_empty() {
+            return Ok(None);
+        }
+
+        match BodyFormat::try_from(req.header.body_format) {
+            Ok(BodyFormat::Json) => Ok(Some(serde_json::from_slice::<Value>(&req.body)?)),
+            Ok(BodyFormat::Beve) => Ok(Some(beve::from_slice::<Value>(&req.body)?)),
+            Ok(BodyFormat::Utf8) => {
+                let text = std::str::from_utf8(&req.body).map_err(RegistryError::InvalidUtf8)?;
+                Ok(Some(Value::String(text.to_string())))
+            }
+            Ok(BodyFormat::RawBinary) => Ok(Some(Value::Array(
+                req.body.iter().map(|byte| Value::from(*byte)).collect(),
+            ))),
+            Err(_) => Err(RegistryError::UnsupportedBodyFormat {
+                format: req.header.body_format,
+            }),
+        }
+    }
+
+    fn read_state(&self) -> std::sync::RwLockReadGuard<'_, RegistryState> {
+        match self.state.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn write_state(&self) -> std::sync::RwLockWriteGuard<'_, RegistryState> {
+        match self.state.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+fn parse_registration_path(path: &str) -> Result<Vec<String>, RegistryError> {
+    if path.is_empty() {
+        return Ok(Vec::new());
+    }
+    if path.starts_with('/') {
+        return parse_pointer(path);
+    }
+    parse_pointer(&format!("/{path}"))
+}
+
+fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
+    if pointer.is_empty() || pointer == "/" {
+        return Ok(Vec::new());
+    }
+    if !pointer.starts_with('/') {
+        return Err(RegistryError::InvalidPointer {
+            pointer: pointer.to_string(),
+        });
+    }
+
+    pointer[1..]
+        .split('/')
+        .map(unescape_token)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| RegistryError::InvalidPointer {
+            pointer: pointer.to_string(),
+        })
+}
+
+fn unescape_token(token: &str) -> Result<String, ()> {
+    let mut out = String::with_capacity(token.len());
+    let mut chars = token.chars();
+    while let Some(c) = chars.next() {
+        if c != '~' {
+            out.push(c);
+            continue;
+        }
+        let Some(next) = chars.next() else {
+            return Err(());
+        };
+        match next {
+            '0' => out.push('~'),
+            '1' => out.push('/'),
+            _ => return Err(()),
+        }
+    }
+    Ok(out)
+}
+
+fn escape_token(token: &str) -> String {
+    token.replace('~', "~0").replace('/', "~1")
+}
+
+fn canonical_pointer(segments: &[String]) -> String {
+    if segments.is_empty() {
+        "/".to_string()
+    } else {
+        format!(
+            "/{}",
+            segments
+                .iter()
+                .map(|segment| escape_token(segment))
+                .collect::<Vec<_>>()
+                .join("/")
+        )
+    }
+}
+
+fn ensure_object_root(value: &mut Value) -> Result<&mut Map<String, Value>, RegistryError> {
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    value
+        .as_object_mut()
+        .ok_or_else(|| RegistryError::PathNotFound {
+            path: "/".to_string(),
+        })
+}
+
+fn ensure_object_parent<'a>(
+    root: &'a mut Value,
+    segments: &[String],
+) -> Result<&'a mut Map<String, Value>, RegistryError> {
+    let mut current = ensure_object_root(root)?;
+    if segments.len() <= 1 {
+        return Ok(current);
+    }
+    for segment in &segments[..segments.len() - 1] {
+        let entry = current
+            .entry(segment.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if !entry.is_object() {
+            *entry = Value::Object(Map::new());
+        }
+        current = entry
+            .as_object_mut()
+            .ok_or_else(|| RegistryError::PathNotFound {
+                path: canonical_pointer(segments),
+            })?;
+    }
+    Ok(current)
+}
+
+fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, RegistryError> {
+    let mut current = root;
+    let mut walked: Vec<String> = Vec::new();
+    for segment in segments {
+        walked.push(segment.clone());
+        match current {
+            Value::Object(map) => {
+                current = map
+                    .get(segment)
+                    .ok_or_else(|| RegistryError::PathNotFound {
+                        path: canonical_pointer(&walked),
+                    })?;
+            }
+            Value::Array(array) => {
+                let index =
+                    segment
+                        .parse::<usize>()
+                        .map_err(|_| RegistryError::InvalidArrayIndex {
+                            path: canonical_pointer(&walked),
+                            segment: segment.clone(),
+                        })?;
+                current = array
+                    .get(index)
+                    .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
+                        path: canonical_pointer(&walked),
+                        segment: segment.clone(),
+                    })?;
+            }
+            _ => {
+                return Err(RegistryError::PathNotFound {
+                    path: canonical_pointer(&walked),
+                });
+            }
+        }
+    }
+    Ok(current)
+}
+
+fn resolve_mut<'a>(
+    root: &'a mut Value,
+    segments: &[String],
+) -> Result<&'a mut Value, RegistryError> {
+    let mut current = root;
+    let mut walked: Vec<String> = Vec::new();
+    for segment in segments {
+        walked.push(segment.clone());
+        match current {
+            Value::Object(map) => {
+                current = map
+                    .get_mut(segment)
+                    .ok_or_else(|| RegistryError::PathNotFound {
+                        path: canonical_pointer(&walked),
+                    })?;
+            }
+            Value::Array(array) => {
+                let index =
+                    segment
+                        .parse::<usize>()
+                        .map_err(|_| RegistryError::InvalidArrayIndex {
+                            path: canonical_pointer(&walked),
+                            segment: segment.clone(),
+                        })?;
+                current =
+                    array
+                        .get_mut(index)
+                        .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
+                            path: canonical_pointer(&walked),
+                            segment: segment.clone(),
+                        })?;
+            }
+            _ => {
+                return Err(RegistryError::PathNotFound {
+                    path: canonical_pointer(&walked),
+                });
+            }
+        }
+    }
+    Ok(current)
+}
+
+fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<(), RegistryError> {
+    if segments.is_empty() {
+        *root = value;
+        return Ok(());
+    }
+
+    let mut parent_path = Vec::new();
+    let mut current = root;
+    for segment in &segments[..segments.len() - 1] {
+        parent_path.push(segment.clone());
+        match current {
+            Value::Object(map) => {
+                current = map
+                    .get_mut(segment)
+                    .ok_or_else(|| RegistryError::PathNotFound {
+                        path: canonical_pointer(&parent_path),
+                    })?;
+            }
+            Value::Array(array) => {
+                let index =
+                    segment
+                        .parse::<usize>()
+                        .map_err(|_| RegistryError::InvalidArrayIndex {
+                            path: canonical_pointer(&parent_path),
+                            segment: segment.clone(),
+                        })?;
+                current =
+                    array
+                        .get_mut(index)
+                        .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
+                            path: canonical_pointer(&parent_path),
+                            segment: segment.clone(),
+                        })?;
+            }
+            _ => {
+                return Err(RegistryError::PathNotFound {
+                    path: canonical_pointer(&parent_path),
+                });
+            }
+        }
+    }
+
+    let last = segments.last().unwrap();
+    match current {
+        Value::Object(map) => {
+            map.insert(last.clone(), value);
+            Ok(())
+        }
+        Value::Array(array) => {
+            let index = last
+                .parse::<usize>()
+                .map_err(|_| RegistryError::InvalidArrayIndex {
+                    path: canonical_pointer(segments),
+                    segment: last.clone(),
+                })?;
+            if let Some(slot) = array.get_mut(index) {
+                *slot = value;
+                Ok(())
+            } else {
+                Err(RegistryError::ArrayIndexOutOfBounds {
+                    path: canonical_pointer(segments),
+                    segment: last.clone(),
+                })
+            }
+        }
+        _ => Err(RegistryError::PathNotFound {
+            path: canonical_pointer(segments),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pointer_unescapes_tokens() {
+        let segments = parse_pointer("/a~1b/m~0n").unwrap();
+        assert_eq!(segments, vec!["a/b".to_string(), "m~n".to_string()]);
+    }
+
+    #[test]
+    fn parse_pointer_rejects_invalid_tilde_escape() {
+        let err = parse_pointer("/a~2b").unwrap_err();
+        assert!(matches!(err, RegistryError::InvalidPointer { .. }));
+    }
+
+    #[test]
+    fn registry_dispatch_read_write_call() {
+        let registry = Registry::new();
+        registry
+            .register_value("/counter", Value::from(0))
+            .expect("register counter");
+        registry
+            .register_function("/add", |params| {
+                let Some(Value::Object(map)) = params else {
+                    return Err((ErrorCode::InvalidBody, "expected object".into()));
+                };
+                let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+                let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+                Ok(Value::from(a + b))
+            })
+            .expect("register function");
+
+        let read_counter = registry.dispatch("/counter", None).expect("read");
+        assert_eq!(read_counter, Value::from(0));
+
+        let write_result = registry
+            .dispatch("/counter", Some(Value::from(42)))
+            .expect("write");
+        assert_eq!(write_result["status"], "ok");
+
+        let read_counter = registry.dispatch("/counter", None).expect("read");
+        assert_eq!(read_counter, Value::from(42));
+
+        let function_info = registry.dispatch("/add", None).expect("function info");
+        assert_eq!(function_info["type"], "function");
+        assert_eq!(function_info["path"], "/add");
+
+        let call_result = registry
+            .dispatch("/add", Some(json!({"a": 2, "b": 3})))
+            .expect("call");
+        assert_eq!(call_result, Value::from(5));
+    }
+
+    #[test]
+    fn decode_body_maps_utf8_to_string_value() {
+        let req = Message::builder()
+            .id(1)
+            .query_str("/name")
+            .query_format(crate::constants::QueryFormat::JsonPointer)
+            .body_utf8("alice")
+            .build();
+        let decoded = Registry::decode_body(&req).expect("decode");
+        assert_eq!(decoded, Some(Value::String("alice".into())));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,6 +2,7 @@ use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
 use crate::io::{read_message, write_message};
 use crate::message::{Message, create_error_response_like, create_response};
+use crate::registry::Registry;
 use crate::structs::RepeStruct;
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
@@ -209,6 +210,10 @@ trait StructRouterEntry: Send + Sync {
     fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>>;
 }
 
+trait RegistryRouterEntry: Send + Sync {
+    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>>;
+}
+
 #[derive(Debug)]
 pub enum LockError {
     Poisoned(String),
@@ -321,6 +326,7 @@ impl<T: ?Sized + Send + Sync> Lockable<T> for parking_lot::RwLock<T> {
 pub struct Router {
     inner: Arc<HashMap<String, Arc<dyn HandlerErased>>>,
     structs: Arc<Vec<Arc<dyn StructRouterEntry>>>,
+    registries: Arc<Vec<Arc<dyn RegistryRouterEntry>>>,
     middlewares: Arc<Vec<Arc<dyn Middleware>>>,
 }
 
@@ -329,6 +335,7 @@ impl Router {
         Self {
             inner: Arc::new(HashMap::new()),
             structs: Arc::new(Vec::new()),
+            registries: Arc::new(Vec::new()),
             middlewares: Arc::new(Vec::new()),
         }
     }
@@ -459,9 +466,39 @@ impl Router {
         shared
     }
 
+    /// Register a dynamic [`Registry`] under `path_prefix`.
+    ///
+    /// The prefix can be empty to serve the registry at the root path. Requests under the
+    /// prefix are mapped to registry JSON pointers by stripping the prefix.
+    pub fn with_registry(mut self, path_prefix: &str, registry: Arc<Registry>) -> Self {
+        self.register_registry(path_prefix, registry);
+        self
+    }
+
+    /// Register a dynamic [`Registry`] in-place and return the shared handle.
+    pub fn register_registry(
+        &mut self,
+        path_prefix: &str,
+        registry: Arc<Registry>,
+    ) -> Arc<Registry> {
+        let mut entries = (*self.registries).clone();
+        entries.push(Arc::new(RegisteredRegistry::new(
+            path_prefix,
+            Arc::clone(&registry),
+        )));
+        self.registries = Arc::new(entries);
+        registry
+    }
+
     pub fn get(&self, path: &str) -> Option<Arc<dyn HandlerErased>> {
         let handler = if let Some(handler) = self.inner.get(path) {
             Some(handler.clone())
+        } else if let Some(handler) = self
+            .registries
+            .iter()
+            .find_map(|entry| entry.handler_for(path))
+        {
+            Some(handler)
         } else {
             self.structs
                 .iter()
@@ -496,6 +533,80 @@ where
     root: String,
     shared: Arc<L>,
     phantom: std::marker::PhantomData<T>,
+}
+
+struct RegisteredRegistry {
+    prefix: String,
+    registry: Arc<Registry>,
+}
+
+impl RegisteredRegistry {
+    fn new(prefix: &str, registry: Arc<Registry>) -> Self {
+        let mut normalized = if prefix.is_empty() || prefix == "/" {
+            String::new()
+        } else if prefix.starts_with('/') {
+            prefix.to_string()
+        } else {
+            format!("/{}", prefix)
+        };
+        if normalized.len() > 1 {
+            normalized = normalized.trim_end_matches('/').to_string();
+        }
+        Self {
+            prefix: normalized,
+            registry,
+        }
+    }
+
+    fn pointer_for<'a>(&self, path: &'a str) -> Option<&'a str> {
+        if self.prefix.is_empty() {
+            return if path.is_empty() {
+                Some("/")
+            } else {
+                Some(path)
+            };
+        }
+
+        if path == self.prefix {
+            return Some("/");
+        }
+
+        let rest = path.strip_prefix(&self.prefix)?;
+        if rest.starts_with('/') {
+            Some(rest)
+        } else {
+            None
+        }
+    }
+}
+
+impl RegistryRouterEntry for RegisteredRegistry {
+    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>> {
+        let pointer = self.pointer_for(path)?.to_string();
+        Some(Arc::new(RegistryRequestHandler {
+            registry: Arc::clone(&self.registry),
+            pointer,
+        }))
+    }
+}
+
+struct RegistryRequestHandler {
+    registry: Arc<Registry>,
+    pointer: String,
+}
+
+impl HandlerErased for RegistryRequestHandler {
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let body = match Registry::decode_body(req) {
+            Ok(value) => value,
+            Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
+        };
+
+        match self.registry.dispatch(&self.pointer, body) {
+            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
+        }
+    }
 }
 
 impl<T, L> RegisteredStruct<T, L>

--- a/tests/async_client_format_apis.rs
+++ b/tests/async_client_format_apis.rs
@@ -1,0 +1,196 @@
+use repe::{AsyncClient, BodyFormat, Message, QueryFormat, read_message, write_message};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::io::{BufReader, BufWriter, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct ReadPayload {
+    kind: String,
+    n: i64,
+}
+
+fn json_response_for(req: &Message, body: &Value) -> Message {
+    Message::builder()
+        .id(req.header.id)
+        .query_bytes(req.query.clone())
+        .query_format(
+            QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
+        )
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_call_message_and_registry_read_send_empty_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let first = read_message(&mut reader).expect("first request");
+        assert_eq!(first.query_utf8(), "/first");
+        assert_eq!(first.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(first.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(first.header.body_length, 0);
+        assert!(first.body.is_empty());
+
+        let first_response = json_response_for(&first, &json!({"kind": "message"}));
+        write_message(&mut writer, &first_response).expect("write first response");
+        writer.flush().expect("flush first response");
+
+        let second = read_message(&mut reader).expect("second request");
+        assert_eq!(second.query_utf8(), "/second");
+        assert_eq!(second.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(second.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(second.header.body_length, 0);
+        assert!(second.body.is_empty());
+
+        let second_response = json_response_for(&second, &json!({"kind": "read", "n": 5}));
+        write_message(&mut writer, &second_response).expect("write second response");
+        writer.flush().expect("flush second response");
+
+        let third = read_message(&mut reader).expect("third request");
+        assert_eq!(third.query_utf8(), "/third");
+        assert_eq!(third.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(third.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(third.header.body_length, 0);
+        assert!(third.body.is_empty());
+
+        let third_response = json_response_for(&third, &json!({"kind": "typed", "n": 7}));
+        write_message(&mut writer, &third_response).expect("write third response");
+        writer.flush().expect("flush third response");
+    });
+
+    let client = AsyncClient::connect(addr).await.expect("connect client");
+
+    let message = client.call_message("/first").await.expect("call_message");
+    let decoded = message.json_body::<Value>().expect("decode JSON");
+    assert_eq!(decoded["kind"], "message");
+
+    let read_value = client
+        .registry_read("/second")
+        .await
+        .expect("registry_read");
+    assert_eq!(read_value["kind"], "read");
+    assert_eq!(read_value["n"], 5);
+
+    let typed: ReadPayload = client
+        .registry_read_typed_with_timeout("/third", Duration::from_secs(1))
+        .await
+        .expect("registry_read_typed_with_timeout");
+    assert_eq!(typed.kind, "typed");
+    assert_eq!(typed.n, 7);
+
+    tokio::task::spawn_blocking(move || server.join().expect("join server"))
+        .await
+        .expect("await server join");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_call_with_formats_sets_custom_wire_codes() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let request = read_message(&mut reader).expect("request");
+        assert_eq!(request.query_utf8(), "/custom");
+        assert_eq!(request.header.query_format, 0x2222);
+        assert_eq!(request.header.body_format, 0x3333);
+        assert_eq!(request.body, vec![1, 2, 3]);
+
+        let response = Message::builder()
+            .id(request.header.id)
+            .query_bytes(request.query.clone())
+            .query_format_code(request.header.query_format)
+            .body_bytes(vec![9, 8])
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        write_message(&mut writer, &response).expect("write response");
+        writer.flush().expect("flush response");
+    });
+
+    let client = AsyncClient::connect(addr).await.expect("connect client");
+    let response = client
+        .call_with_formats("/custom", 0x2222, Some(&[1, 2, 3]), 0x3333)
+        .await
+        .expect("call_with_formats");
+
+    assert_eq!(response.header.body_format, BodyFormat::RawBinary as u16);
+    assert_eq!(response.body, vec![9, 8]);
+
+    tokio::task::spawn_blocking(move || server.join().expect("join server"))
+        .await
+        .expect("await server join");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_registry_read_typed_deserializes_target_type() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let request = read_message(&mut reader).expect("request");
+        assert_eq!(request.query_utf8(), "/typed");
+        assert_eq!(request.header.body_length, 0);
+
+        let response = json_response_for(&request, &json!({"kind": "typed", "n": 11}));
+        write_message(&mut writer, &response).expect("write response");
+        writer.flush().expect("flush response");
+    });
+
+    let client = AsyncClient::connect(addr).await.expect("connect client");
+    let typed: ReadPayload = client
+        .registry_read_typed("/typed")
+        .await
+        .expect("registry_read_typed");
+    assert_eq!(typed.kind, "typed");
+    assert_eq!(typed.n, 11);
+
+    tokio::task::spawn_blocking(move || server.join().expect("join server"))
+        .await
+        .expect("await server join");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn async_notify_with_formats_sets_notify_and_empty_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream);
+
+        let request = read_message(&mut reader).expect("notify request");
+        assert_eq!(request.query_utf8(), "/notify");
+        assert_eq!(request.header.notify, 1);
+        assert_eq!(request.header.query_format, 0x4444);
+        assert_eq!(request.header.body_format, 0x5555);
+        assert_eq!(request.header.body_length, 0);
+        assert!(request.body.is_empty());
+    });
+
+    let client = AsyncClient::connect(addr).await.expect("connect client");
+    client
+        .notify_with_formats("/notify", 0x4444, None, 0x5555)
+        .await
+        .expect("notify_with_formats");
+
+    tokio::task::spawn_blocking(move || server.join().expect("join server"))
+        .await
+        .expect("await server join");
+}

--- a/tests/client_format_apis.rs
+++ b/tests/client_format_apis.rs
@@ -1,0 +1,181 @@
+use repe::{BodyFormat, Client, Message, QueryFormat, read_message, write_message};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::io::{BufReader, BufWriter, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct ReadPayload {
+    kind: String,
+    n: i64,
+}
+
+fn json_response_for(req: &Message, body: &Value) -> Message {
+    Message::builder()
+        .id(req.header.id)
+        .query_bytes(req.query.clone())
+        .query_format(
+            QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
+        )
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+#[test]
+fn sync_call_message_and_registry_read_send_empty_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let first = read_message(&mut reader).expect("first request");
+        assert_eq!(first.query_utf8(), "/first");
+        assert_eq!(first.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(first.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(first.header.body_length, 0);
+        assert!(first.body.is_empty());
+
+        let first_response = json_response_for(&first, &json!({"kind": "message"}));
+        write_message(&mut writer, &first_response).expect("write first response");
+        writer.flush().expect("flush first response");
+
+        let second = read_message(&mut reader).expect("second request");
+        assert_eq!(second.query_utf8(), "/second");
+        assert_eq!(second.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(second.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(second.header.body_length, 0);
+        assert!(second.body.is_empty());
+
+        let second_response = json_response_for(&second, &json!({"kind": "read", "n": 5}));
+        write_message(&mut writer, &second_response).expect("write second response");
+        writer.flush().expect("flush second response");
+
+        let third = read_message(&mut reader).expect("third request");
+        assert_eq!(third.query_utf8(), "/third");
+        assert_eq!(third.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(third.header.body_format, BodyFormat::RawBinary as u16);
+        assert_eq!(third.header.body_length, 0);
+        assert!(third.body.is_empty());
+
+        let third_response = json_response_for(&third, &json!({"kind": "typed", "n": 7}));
+        write_message(&mut writer, &third_response).expect("write third response");
+        writer.flush().expect("flush third response");
+    });
+
+    let client = Client::connect(addr).expect("connect client");
+
+    let message = client.call_message("/first").expect("call_message");
+    let decoded = message.json_body::<Value>().expect("decode JSON");
+    assert_eq!(decoded["kind"], "message");
+
+    let read_value = client.registry_read("/second").expect("registry_read");
+    assert_eq!(read_value["kind"], "read");
+    assert_eq!(read_value["n"], 5);
+
+    let typed: ReadPayload = client
+        .registry_read_typed_with_timeout("/third", Duration::from_secs(1))
+        .expect("registry_read_typed_with_timeout");
+    assert_eq!(typed.kind, "typed");
+    assert_eq!(typed.n, 7);
+
+    server.join().expect("join server");
+}
+
+#[test]
+fn sync_call_with_formats_sets_custom_wire_codes() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let request = read_message(&mut reader).expect("request");
+        assert_eq!(request.query_utf8(), "/custom");
+        assert_eq!(request.header.query_format, 0x2222);
+        assert_eq!(request.header.body_format, 0x3333);
+        assert_eq!(request.body, vec![1, 2, 3]);
+
+        let response = Message::builder()
+            .id(request.header.id)
+            .query_bytes(request.query.clone())
+            .query_format_code(request.header.query_format)
+            .body_bytes(vec![9, 8])
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        write_message(&mut writer, &response).expect("write response");
+        writer.flush().expect("flush response");
+    });
+
+    let client = Client::connect(addr).expect("connect client");
+    let response = client
+        .call_with_formats("/custom", 0x2222, Some(&[1, 2, 3]), 0x3333)
+        .expect("call_with_formats");
+
+    assert_eq!(response.header.body_format, BodyFormat::RawBinary as u16);
+    assert_eq!(response.body, vec![9, 8]);
+
+    server.join().expect("join server");
+}
+
+#[test]
+fn sync_registry_read_typed_deserializes_target_type() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = BufWriter::new(stream);
+
+        let request = read_message(&mut reader).expect("request");
+        assert_eq!(request.query_utf8(), "/typed");
+        assert_eq!(request.header.body_length, 0);
+
+        let response = json_response_for(&request, &json!({"kind": "typed", "n": 11}));
+        write_message(&mut writer, &response).expect("write response");
+        writer.flush().expect("flush response");
+    });
+
+    let client = Client::connect(addr).expect("connect client");
+    let typed: ReadPayload = client
+        .registry_read_typed("/typed")
+        .expect("registry_read_typed");
+    assert_eq!(typed.kind, "typed");
+    assert_eq!(typed.n, 11);
+
+    server.join().expect("join server");
+}
+
+#[test]
+fn sync_notify_with_formats_sets_notify_and_empty_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    let server = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream);
+
+        let request = read_message(&mut reader).expect("notify request");
+        assert_eq!(request.query_utf8(), "/notify");
+        assert_eq!(request.header.notify, 1);
+        assert_eq!(request.header.query_format, 0x4444);
+        assert_eq!(request.header.body_format, 0x5555);
+        assert_eq!(request.header.body_length, 0);
+        assert!(request.body.is_empty());
+    });
+
+    let client = Client::connect(addr).expect("connect client");
+    client
+        .notify_with_formats("/notify", 0x4444, None, 0x5555)
+        .expect("notify_with_formats");
+
+    server.join().expect("join server");
+}

--- a/tests/registry_tests.rs
+++ b/tests/registry_tests.rs
@@ -1,0 +1,485 @@
+use repe::{BodyFormat, ErrorCode, Message, QueryFormat, Registry, Router};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::thread;
+
+fn request_empty(path: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .build()
+}
+
+fn request_json(path: &str, body: &Value) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_json(body)
+        .expect("json body")
+        .build()
+}
+
+fn request_utf8(path: &str, body: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_utf8(body)
+        .build()
+}
+
+fn request_beve(path: &str, body: &Value) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_beve(body)
+        .expect("beve body")
+        .build()
+}
+
+fn request_raw(path: &str, body: &[u8]) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_bytes(body.to_vec())
+        .body_format(BodyFormat::RawBinary)
+        .build()
+}
+
+#[test]
+fn registry_router_read_write_call_semantics() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/counter", Value::from(0))
+        .expect("register value");
+    registry
+        .register_function("/add", |params| {
+            let Some(Value::Object(map)) = params else {
+                return Err((ErrorCode::InvalidBody, "expected object body".into()));
+            };
+            let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+            let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+            Ok(Value::from(a + b))
+        })
+        .expect("register function");
+
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let read = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&request_empty("/counter"))
+        .expect("read response");
+    assert_eq!(read.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(read.json_body::<Value>().expect("json body"), json!(0));
+
+    let write = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&request_json("/counter", &json!(42)))
+        .expect("write response");
+    assert_eq!(write.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(
+        write.json_body::<Value>().expect("json body"),
+        json!({"status":"ok","path":"/counter"})
+    );
+
+    let read_after = router
+        .get("/counter")
+        .expect("counter handler")
+        .handle(&request_empty("/counter"))
+        .expect("read response");
+    assert_eq!(
+        read_after.json_body::<Value>().expect("json body"),
+        json!(42)
+    );
+
+    let function_info = router
+        .get("/add")
+        .expect("add handler")
+        .handle(&request_empty("/add"))
+        .expect("function info response");
+    assert_eq!(
+        function_info.json_body::<Value>().expect("json body"),
+        json!({"type":"function","path":"/add"})
+    );
+
+    let call = router
+        .get("/add")
+        .expect("add handler")
+        .handle(&request_json("/add", &json!({"a": 2, "b": 3})))
+        .expect("call response");
+    assert_eq!(call.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(call.json_body::<Value>().expect("json body"), json!(5));
+}
+
+#[test]
+fn registry_path_prefix_routes_only_matching_paths() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/status", json!("ok"))
+        .expect("register value");
+
+    let router = Router::new().with_registry("/api/v1", Arc::clone(&registry));
+    assert!(router.get("/status").is_none());
+
+    let response = router
+        .get("/api/v1/status")
+        .expect("prefixed handler")
+        .handle(&request_empty("/api/v1/status"))
+        .expect("response");
+    assert_eq!(response.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(
+        response.json_body::<Value>().expect("json body"),
+        json!("ok")
+    );
+}
+
+#[test]
+fn registry_utf8_body_writes_plain_string_value() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/name", json!("initial"))
+        .expect("register value");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let write = router
+        .get("/name")
+        .expect("name handler")
+        .handle(&request_utf8("/name", "alice"))
+        .expect("write response");
+    assert_eq!(write.header.ec, ErrorCode::Ok as u32);
+
+    let read = router
+        .get("/name")
+        .expect("name handler")
+        .handle(&request_empty("/name"))
+        .expect("read response");
+    assert_eq!(
+        read.json_body::<Value>().expect("json body"),
+        json!("alice")
+    );
+}
+
+#[test]
+fn registry_root_write_requires_object_body() {
+    let registry = Arc::new(Registry::new());
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let response = router
+        .get("/")
+        .expect("root handler")
+        .handle(&request_json("/", &json!(7)))
+        .expect("response");
+    assert_eq!(response.header.ec, ErrorCode::InvalidBody as u32);
+    assert!(
+        response
+            .error_message_utf8()
+            .expect("error message")
+            .contains("root write requires")
+    );
+}
+
+#[test]
+fn registry_beve_body_writes_object_value() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/payload", Value::Null)
+        .expect("register placeholder");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let response = router
+        .get("/payload")
+        .expect("handler")
+        .handle(&request_beve("/payload", &json!({"n": 7, "ok": true})))
+        .expect("write response");
+    assert_eq!(response.header.ec, ErrorCode::Ok as u32);
+
+    let read = router
+        .get("/payload")
+        .expect("handler")
+        .handle(&request_empty("/payload"))
+        .expect("read response");
+    assert_eq!(
+        read.json_body::<Value>().expect("json body"),
+        json!({"n": 7, "ok": true})
+    );
+}
+
+#[test]
+fn registry_raw_body_writes_json_array_of_bytes() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/blob", Value::Null)
+        .expect("register placeholder");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let response = router
+        .get("/blob")
+        .expect("handler")
+        .handle(&request_raw("/blob", &[1, 2, 255]))
+        .expect("write response");
+    assert_eq!(response.header.ec, ErrorCode::Ok as u32);
+
+    let read = router
+        .get("/blob")
+        .expect("handler")
+        .handle(&request_empty("/blob"))
+        .expect("read response");
+    assert_eq!(
+        read.json_body::<Value>().expect("json body"),
+        json!([1, 2, 255])
+    );
+}
+
+#[test]
+fn registry_unknown_body_format_is_invalid_body() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/blob", Value::Null)
+        .expect("register placeholder");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let mut request = Message::builder()
+        .id(1)
+        .query_str("/blob")
+        .query_format(QueryFormat::JsonPointer)
+        .body_bytes(vec![1, 2, 3])
+        .build();
+    request.header.body_format = 7777;
+
+    let response = router
+        .get("/blob")
+        .expect("handler")
+        .handle(&request)
+        .expect("response");
+    assert_eq!(response.header.ec, ErrorCode::InvalidBody as u32);
+}
+
+#[test]
+fn registry_invalid_utf8_body_is_invalid_body() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/name", json!("init"))
+        .expect("register placeholder");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let request = Message::builder()
+        .id(1)
+        .query_str("/name")
+        .query_format(QueryFormat::JsonPointer)
+        .body_bytes(vec![0xFF, 0xFE])
+        .body_format(BodyFormat::Utf8)
+        .build();
+
+    let response = router
+        .get("/name")
+        .expect("handler")
+        .handle(&request)
+        .expect("response");
+    assert_eq!(response.header.ec, ErrorCode::InvalidBody as u32);
+}
+
+#[test]
+fn registry_array_index_read_write_and_error_cases() {
+    let registry = Arc::new(Registry::new());
+    registry.set_root(json!({"items":[10,20,30]}));
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let read = router
+        .get("/items/1")
+        .expect("handler")
+        .handle(&request_empty("/items/1"))
+        .expect("response");
+    assert_eq!(read.json_body::<Value>().expect("json body"), json!(20));
+
+    let write = router
+        .get("/items/1")
+        .expect("handler")
+        .handle(&request_json("/items/1", &json!(99)))
+        .expect("response");
+    assert_eq!(write.header.ec, ErrorCode::Ok as u32);
+
+    let read_after = router
+        .get("/items/1")
+        .expect("handler")
+        .handle(&request_empty("/items/1"))
+        .expect("response");
+    assert_eq!(
+        read_after.json_body::<Value>().expect("json body"),
+        json!(99)
+    );
+
+    let invalid_index = router
+        .get("/items/nope")
+        .expect("handler")
+        .handle(&request_empty("/items/nope"))
+        .expect("response");
+    assert_eq!(invalid_index.header.ec, ErrorCode::MethodNotFound as u32);
+
+    let out_of_bounds = router
+        .get("/items/99")
+        .expect("handler")
+        .handle(&request_empty("/items/99"))
+        .expect("response");
+    assert_eq!(out_of_bounds.header.ec, ErrorCode::MethodNotFound as u32);
+}
+
+#[test]
+fn registry_escaped_pointer_paths_roundtrip() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/a~1b", json!(123))
+        .expect("register escaped path");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let read = router
+        .get("/a~1b")
+        .expect("handler")
+        .handle(&request_empty("/a~1b"))
+        .expect("response");
+    assert_eq!(read.json_body::<Value>().expect("json body"), json!(123));
+
+    let write = router
+        .get("/a~1b")
+        .expect("handler")
+        .handle(&request_json("/a~1b", &json!(456)))
+        .expect("response");
+    assert_eq!(write.header.ec, ErrorCode::Ok as u32);
+
+    let read_after = router
+        .get("/a~1b")
+        .expect("handler")
+        .handle(&request_empty("/a~1b"))
+        .expect("response");
+    assert_eq!(
+        read_after.json_body::<Value>().expect("json body"),
+        json!(456)
+    );
+}
+
+#[test]
+fn registry_function_error_code_propagates() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_function("/boom", |_params| {
+            Err((ErrorCode::ApplicationErrorBase, "denied".into()))
+        })
+        .expect("register function");
+    let router = Router::new().with_registry("", Arc::clone(&registry));
+
+    let response = router
+        .get("/boom")
+        .expect("handler")
+        .handle(&request_json("/boom", &json!({"x": 1})))
+        .expect("response");
+    assert_eq!(response.header.ec, ErrorCode::ApplicationErrorBase as u32);
+    assert_eq!(response.error_message_utf8().as_deref(), Some("denied"));
+}
+
+#[test]
+fn registry_merge_helpers_update_nested_objects() {
+    let registry = Registry::new();
+    registry
+        .merge_root(serde_json::Map::from_iter([
+            ("status".to_string(), json!("ok")),
+            ("version".to_string(), json!("1.0")),
+        ]))
+        .expect("merge root");
+    registry
+        .register_value("/api", json!({}))
+        .expect("register api object");
+    registry
+        .merge_at(
+            "/api",
+            serde_json::Map::from_iter([
+                ("users".to_string(), json!(3)),
+                ("posts".to_string(), json!(5)),
+            ]),
+        )
+        .expect("merge at path");
+
+    assert_eq!(registry.read_value("/status").expect("status"), json!("ok"));
+    assert_eq!(
+        registry.read_value("/version").expect("version"),
+        json!("1.0")
+    );
+    assert_eq!(registry.read_value("/api/users").expect("users"), json!(3));
+    assert_eq!(registry.read_value("/api/posts").expect("posts"), json!(5));
+}
+
+#[test]
+fn registry_prefix_exact_and_trailing_slash_hit_root() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/status", json!("ok"))
+        .expect("register status");
+    let router = Router::new().with_registry("/api/v1/", Arc::clone(&registry));
+
+    let exact = router
+        .get("/api/v1")
+        .expect("exact prefix handler")
+        .handle(&request_empty("/api/v1"))
+        .expect("response");
+    assert_eq!(exact.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(
+        exact.json_body::<Value>().expect("json body"),
+        json!({"status":"ok"})
+    );
+
+    let slash = router
+        .get("/api/v1/")
+        .expect("slash prefix handler")
+        .handle(&request_empty("/api/v1/"))
+        .expect("response");
+    assert_eq!(slash.header.ec, ErrorCode::Ok as u32);
+    assert_eq!(
+        slash.json_body::<Value>().expect("json body"),
+        json!({"status":"ok"})
+    );
+}
+
+#[test]
+fn registry_invalid_pointer_error_code_maps_to_method_not_found() {
+    let registry = Registry::new();
+    let err = registry
+        .dispatch("not/a/pointer", None)
+        .expect_err("invalid pointer should fail");
+    assert_eq!(err.code(), ErrorCode::MethodNotFound);
+}
+
+#[test]
+fn registry_concurrent_dispatch_stress() {
+    let registry = Arc::new(Registry::new());
+    registry
+        .register_value("/counter", json!(0))
+        .expect("register counter");
+
+    let workers = (0..8)
+        .map(|worker| {
+            let registry = Arc::clone(&registry);
+            thread::spawn(move || {
+                for i in 0..200 {
+                    let value = (worker * 1_000 + i) as i64;
+                    registry
+                        .dispatch("/counter", Some(json!(value)))
+                        .expect("write should succeed");
+                    let _ = registry
+                        .dispatch("/counter", None)
+                        .expect("read should succeed");
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for worker in workers {
+        worker.join().expect("worker should not panic");
+    }
+
+    let final_value = registry.dispatch("/counter", None).expect("final read");
+    assert!(final_value.as_i64().is_some());
+}


### PR DESCRIPTION
# PR Description

## Summary
This PR adds Registry parity foundations to `repe-rs`, including dynamic registry routing, client APIs for true empty-body reads, and expanded protocol-level test coverage.

## Changes from `main`
- Added dynamic registry support:
  - New `Registry` implementation with READ/WRITE/CALL semantics and JSON Pointer path handling.
  - Router integration to mount registries under configurable path prefixes.
- Expanded client APIs (sync + async):
  - Empty-body request support via `call_message(...)`.
  - Registry helpers: `registry_read`, `registry_write_json`, `registry_call_json`.
  - Typed registry reads: `registry_read_typed(...)` (+ timeout variants).
  - Generic wire-format APIs: `call_with_formats(...)` and `notify_with_formats(...)`.
- Added low-level message builder support for explicit format codes:
  - `query_format_code(u16)`
  - `body_format_code(u16)`
- Added registry docs and examples:
  - `docs/registry.md`
  - `examples/registry_server.rs`
  - `examples/registry_roundtrip.rs`
  - README updates for new registry/client APIs.
- Added test coverage:
  - Registry behavior tests (`tests/registry_tests.rs`)
  - Sync/async client format API tests (`tests/client_format_apis.rs`, `tests/async_client_format_apis.rs`)
  - Builder format-code test additions.

## Verification
- `cargo test -q`
- `cargo check --examples`