### PR TITLE
Websocket support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -39,7 +39,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +155,46 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -213,6 +271,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +321,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -518,6 +602,9 @@ name = "repe"
 version = "1.0.0"
 dependencies = [
  "beve",
+ "futures-channel",
+ "futures-util",
+ "js-sys",
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "repe-derive",
@@ -525,7 +612,11 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "uniudp",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -552,6 +643,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -612,6 +709,17 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -726,6 +834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +860,24 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "utf-8",
 ]
 
 [[package]]
@@ -771,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +933,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,44 @@ include = [
 default = []
 parking-lot = ["dep:parking_lot"]
 fleet-udp = ["dep:uniudp"]
+websocket = ["dep:futures-util", "dep:tokio-tungstenite"]
+websocket-wasm = [
+    "dep:futures-channel",
+    "dep:futures-util",
+    "dep:js-sys",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+]
 
 [dependencies]
 beve = "0.1"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time", "io-util", "sync"] }
 repe-derive = { path = "repe-derive", version = "0.1.0" }
 parking_lot = { version = "0.12", optional = true }
 uniudp = { version = "1.0.0", optional = true }
+futures-channel = { version = "0.3", optional = true }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time", "io-util", "sync"] }
+tokio-tungstenite = { version = "0.24", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+web-sys = { version = "0.3", optional = true, features = [
+    "BinaryType",
+    "CloseEvent",
+    "ErrorEvent",
+    "Event",
+    "MessageEvent",
+    "Window",
+    "WebSocket",
+] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -1,8 +1,8 @@
 use crate::async_io::{read_message_async, write_message_async};
-use crate::constants::{ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
-use crate::message::{Message, create_error_response_like};
+use crate::message::Message;
 use crate::server::Router;
+use crate::server_request::route_request;
 use tokio::io::AsyncWriteExt;
 use tokio::io::{BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
@@ -69,84 +69,7 @@ async fn handle_connection(
             read_message_async(&mut reader).await?
         };
 
-        let notify = req.header.notify == 1;
-        if req.header.version != REPE_VERSION {
-            if !notify {
-                let resp = create_error_response_like(
-                    &req,
-                    ErrorCode::VersionMismatch,
-                    format!("Unsupported REPE version {}", req.header.version),
-                );
-                if let Some(dur) = write_timeout {
-                    timeout(dur, write_message_async(&mut writer, &resp))
-                        .await
-                        .ok();
-                    timeout(dur, writer.flush()).await.ok();
-                } else {
-                    write_message_async(&mut writer, &resp).await?;
-                    writer.flush().await?;
-                }
-            }
-            continue;
-        }
-        let qf = QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary);
-        let path = match qf {
-            QueryFormat::JsonPointer => match req.query_str() {
-                Ok(s) => s,
-                Err(_) => {
-                    if !notify {
-                        let resp = create_error_response_like(
-                            &req,
-                            ErrorCode::InvalidQuery,
-                            "Query must be valid UTF-8",
-                        );
-                        if let Some(dur) = write_timeout {
-                            timeout(dur, write_message_async(&mut writer, &resp))
-                                .await
-                                .ok();
-                            timeout(dur, writer.flush()).await.ok();
-                        } else {
-                            write_message_async(&mut writer, &resp).await?;
-                            writer.flush().await?;
-                        }
-                    }
-                    continue;
-                }
-            },
-            QueryFormat::RawBinary => {
-                if !notify {
-                    let resp = create_error_response_like(
-                        &req,
-                        ErrorCode::InvalidQuery,
-                        "Raw binary queries are not supported by this server",
-                    );
-                    if let Some(dur) = write_timeout {
-                        timeout(dur, write_message_async(&mut writer, &resp))
-                            .await
-                            .ok();
-                        timeout(dur, writer.flush()).await.ok();
-                    } else {
-                        write_message_async(&mut writer, &resp).await?;
-                        writer.flush().await?;
-                    }
-                }
-                continue;
-            }
-        };
-
-        let resp = match router.get(path) {
-            Some(handler) => match handler.handle(&req) {
-                Ok(m) => m,
-                Err(e) => create_error_response_like(&req, e.to_error_code(), e.to_string()),
-            },
-            None => create_error_response_like(
-                &req,
-                ErrorCode::MethodNotFound,
-                format!("Method not found: {path}"),
-            ),
-        };
-
-        if !notify {
+        if let Some(resp) = route_request(&router, &req) {
             if let Some(dur) = write_timeout {
                 timeout(dur, write_message_async(&mut writer, &resp))
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,20 +23,20 @@ pub mod io;
 pub mod json_pointer;
 pub mod message;
 pub mod registry;
+pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 mod server_request;
-pub mod server;
 pub mod structs;
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub mod udp_client;
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub mod uniudp_fleet;
+#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
+pub mod wasm_client;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub mod websocket_client;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub mod websocket_server;
-#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
-pub mod wasm_client;
 
 #[doc(hidden)]
 pub mod derive {
@@ -67,20 +67,20 @@ pub use io::{read_message, write_message};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::Message;
 pub use registry::{Registry, RegistryCallable, RegistryError};
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::Server;
 pub use server::{
     IntoTypedResponse, JsonTypedHandler, LockError, Lockable, Middleware, Next, Router,
     TypedResponse,
 };
-#[cfg(not(target_arch = "wasm32"))]
-pub use server::Server;
 pub use structs::{RepeStruct, StructError};
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub use udp_client::UniUdpClient;
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
+#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
+pub use wasm_client::WasmClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_client::WebSocketClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_server::{WebSocketServer, proxy_connection};
-#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
-pub use wasm_client::WasmClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,25 +3,40 @@
 //! Supports JSON, UTF-8, raw binary, and BEVE body formats.
 //! Spec reference: <https://github.com/beve-org/beve>
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod async_client;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod async_fleet;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod async_io;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod async_server;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod client;
 pub mod constants;
 pub mod error;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod fleet;
 pub mod header;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod io;
 pub mod json_pointer;
 pub mod message;
 pub mod registry;
+#[cfg(not(target_arch = "wasm32"))]
+mod server_request;
 pub mod server;
 pub mod structs;
-#[cfg(feature = "fleet-udp")]
+#[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub mod udp_client;
-#[cfg(feature = "fleet-udp")]
+#[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub mod uniudp_fleet;
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub mod websocket_client;
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub mod websocket_server;
+#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
+pub mod wasm_client;
 
 #[doc(hidden)]
 pub mod derive {
@@ -31,27 +46,41 @@ pub mod derive {
 /// Derive macro to generate [`structs::RepeStruct`](crate::structs::RepeStruct) implementations.
 pub use repe_derive::RepeStruct;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use async_client::AsyncClient;
+#[cfg(not(target_arch = "wasm32"))]
 pub use async_fleet::AsyncFleet;
+#[cfg(not(target_arch = "wasm32"))]
 pub use async_server::AsyncServer;
+#[cfg(not(target_arch = "wasm32"))]
 pub use client::Client;
 pub use constants::{BodyFormat, ErrorCode, HEADER_SIZE, QueryFormat, REPE_SPEC, REPE_VERSION};
 pub use error::RepeError;
+#[cfg(not(target_arch = "wasm32"))]
 pub use fleet::{
     ConnectSummary, DisconnectSummary, Fleet, FleetError, FleetOptions, HealthStatus, Node,
     NodeConfig, ReconnectSummary, RemoteResult, RetryPolicy,
 };
 pub use header::Header;
+#[cfg(not(target_arch = "wasm32"))]
 pub use io::{read_message, write_message};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::Message;
 pub use registry::{Registry, RegistryCallable, RegistryError};
 pub use server::{
-    IntoTypedResponse, JsonTypedHandler, LockError, Lockable, Middleware, Next, Router, Server,
+    IntoTypedResponse, JsonTypedHandler, LockError, Lockable, Middleware, Next, Router,
     TypedResponse,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::Server;
 pub use structs::{RepeStruct, StructError};
-#[cfg(feature = "fleet-udp")]
+#[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub use udp_client::UniUdpClient;
-#[cfg(feature = "fleet-udp")]
+#[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub use websocket_client::WebSocketClient;
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub use websocket_server::{WebSocketServer, proxy_connection};
+#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
+pub use wasm_client::WasmClient;

--- a/src/message.rs
+++ b/src/message.rs
@@ -60,6 +60,18 @@ impl Message {
         Self::new(header, query, body)
     }
 
+    pub fn from_slice_exact(buf: &[u8]) -> Result<Self, RepeError> {
+        let message = Self::from_slice(buf)?;
+        let expected = HEADER_SIZE + message.query.len() + message.body.len();
+        if buf.len() != expected {
+            return Err(RepeError::LengthMismatch {
+                expected: expected as u64,
+                got: buf.len() as u64,
+            });
+        }
+        Ok(message)
+    }
+
     pub fn is_error(&self) -> bool {
         self.header.ec != ErrorCode::Ok as u32
     }
@@ -173,6 +185,26 @@ mod tests {
             RepeError::BufferTooSmall { need, have } => {
                 assert_eq!(need, full_len);
                 assert_eq!(have, full_len - 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_from_slice_exact_rejects_trailing_bytes() {
+        let msg = Message::builder()
+            .id(11)
+            .query_str("/a")
+            .query_format(QueryFormat::JsonPointer)
+            .body_utf8("payload")
+            .build();
+        let mut bytes = msg.to_vec();
+        bytes.extend_from_slice(&[0xAA, 0xBB]);
+
+        match Message::from_slice_exact(&bytes).unwrap_err() {
+            RepeError::LengthMismatch { expected, got } => {
+                assert_eq!(expected, msg.to_vec().len() as u64);
+                assert_eq!(got, bytes.len() as u64);
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::io::Write;
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{BufReader, BufWriter};
-use std::sync::Mutex;
 use std::sync::Arc;
+use std::sync::Mutex;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::Ordering;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,24 +1,32 @@
-use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
+use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
 use crate::message::{Message, create_error_response_like, create_response};
 use crate::registry::Registry;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::server_request::route_request;
 use crate::structs::RepeStruct;
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::collections::HashMap;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::Write;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::{BufReader, BufWriter};
-use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::Mutex;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::Ordering;
+#[cfg(not(target_arch = "wasm32"))]
+use std::{
+    net::{TcpListener, TcpStream, ToSocketAddrs},
+    sync::atomic::AtomicBool,
+    thread,
+    time::Duration,
 };
-use std::thread;
-use std::time::Duration;
 
 pub trait HandlerErased: Send + Sync {
     fn handle(&self, req: &Message) -> Result<Message, RepeError>;
@@ -276,6 +284,7 @@ impl<T: ?Sized + Send + Sync> Lockable<T> for std::sync::RwLock<T> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T: ?Sized + Send> Lockable<T> for tokio::sync::Mutex<T> {
     type Guard<'a>
         = tokio::sync::MutexGuard<'a, T>
@@ -287,6 +296,7 @@ impl<T: ?Sized + Send> Lockable<T> for tokio::sync::Mutex<T> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T: ?Sized + Send + Sync> Lockable<T> for tokio::sync::RwLock<T> {
     type Guard<'a>
         = tokio::sync::RwLockWriteGuard<'a, T>
@@ -791,6 +801,7 @@ impl<H: JsonTypedHandler> HandlerErased for JsonTypedAdapter<H> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub struct Server {
     router: Router,
     read_timeout: Option<Duration>,
@@ -799,6 +810,7 @@ pub struct Server {
     tcp_nodelay: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Server {
     pub fn new(router: Router) -> Self {
         Self {
@@ -862,6 +874,7 @@ impl Server {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn handle_connection(
     stream: TcpStream,
     router: Router,
@@ -881,62 +894,7 @@ fn handle_connection(
             Err(RepeError::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(e) => return Err(e),
         };
-        let notify = req.header.notify == 1;
-        if req.header.version != REPE_VERSION {
-            if !notify {
-                let resp = create_error_response_like(
-                    &req,
-                    ErrorCode::VersionMismatch,
-                    format!("Unsupported REPE version {}", req.header.version),
-                );
-                write_message(&mut writer, &resp)?;
-                writer.flush()?;
-            }
-            continue;
-        }
-        let qf = QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary);
-        let path = match qf {
-            QueryFormat::JsonPointer => match req.query_str() {
-                Ok(s) => s,
-                Err(_) => {
-                    if !notify {
-                        let resp = create_error_response_like(
-                            &req,
-                            ErrorCode::InvalidQuery,
-                            "Query must be valid UTF-8",
-                        );
-                        write_message(&mut writer, &resp)?;
-                        writer.flush()?;
-                    }
-                    continue;
-                }
-            },
-            QueryFormat::RawBinary => {
-                if !notify {
-                    let resp = create_error_response_like(
-                        &req,
-                        ErrorCode::InvalidQuery,
-                        "Raw binary queries are not supported by this server",
-                    );
-                    write_message(&mut writer, &resp)?;
-                    writer.flush()?;
-                }
-                continue;
-            }
-        };
-        let resp = match router.get(path) {
-            Some(handler) => match handler.handle(&req) {
-                Ok(m) => m,
-                Err(e) => create_error_response_like(&req, e.to_error_code(), e.to_string()),
-            },
-            None => create_error_response_like(
-                &req,
-                ErrorCode::MethodNotFound,
-                format!("Method not found: {path}"),
-            ),
-        };
-
-        if !notify {
+        if let Some(resp) = route_request(&router, &req) {
             write_message(&mut writer, &resp)?;
             writer.flush()?;
         }
@@ -944,12 +902,13 @@ fn handle_connection(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::{QueryFormat, REPE_VERSION};
     use serde::{Deserialize, Serialize};
     use std::io::Read;
-    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicBool, AtomicUsize};
 
     #[test]
     fn middleware_runs_for_registered_handlers() {

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -1,0 +1,61 @@
+use crate::constants::{ErrorCode, QueryFormat, REPE_VERSION};
+use crate::message::{Message, create_error_response_like};
+use crate::server::Router;
+
+pub(crate) fn route_request(router: &Router, req: &Message) -> Option<Message> {
+    let notify = req.header.notify == 1;
+
+    if req.header.version != REPE_VERSION {
+        return (!notify).then(|| {
+            create_error_response_like(
+                req,
+                ErrorCode::VersionMismatch,
+                format!("Unsupported REPE version {}", req.header.version),
+            )
+        });
+    }
+
+    let qf = QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary);
+    let path = match qf {
+        QueryFormat::JsonPointer => match req.query_str() {
+            Ok(path) => path,
+            Err(_) => {
+                return (!notify).then(|| {
+                    create_error_response_like(
+                        req,
+                        ErrorCode::InvalidQuery,
+                        "Query must be valid UTF-8",
+                    )
+                });
+            }
+        },
+        QueryFormat::RawBinary => {
+            return (!notify).then(|| {
+                create_error_response_like(
+                    req,
+                    ErrorCode::InvalidQuery,
+                    "Raw binary queries are not supported by this server",
+                )
+            });
+        }
+    };
+
+    if notify {
+        if let Some(handler) = router.get(path) {
+            let _ = handler.handle(req);
+        }
+        return None;
+    }
+
+    Some(match router.get(path) {
+        Some(handler) => match handler.handle(req) {
+            Ok(message) => message,
+            Err(err) => create_error_response_like(req, err.to_error_code(), err.to_string()),
+        },
+        None => create_error_response_like(
+            req,
+            ErrorCode::MethodNotFound,
+            format!("Method not found: {path}"),
+        ),
+    })
+}

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -1,72 +1,57 @@
-use crate::async_io::{read_message_async, write_message_async};
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
 use crate::message::{Message, MessageBuilder};
 use beve::from_slice as beve_from_slice;
+use futures_channel::oneshot;
+use futures_util::future::{Either, join_all, select};
+use js_sys::{ArrayBuffer, Uint8Array};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::future::Future;
 use std::io::ErrorKind;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
-use tokio::io::AsyncWriteExt;
-use tokio::io::{BufReader, BufWriter};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::{TcpStream, ToSocketAddrs};
-use tokio::sync::{Mutex, oneshot};
-use tokio::task::JoinError;
-use tokio::time::{Duration, timeout};
+use std::pin::Pin;
+use std::rc::{Rc, Weak};
+use std::task::{Context, Poll};
+use std::time::Duration;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+use wasm_bindgen::closure::Closure;
+use web_sys::{BinaryType, CloseEvent, Event, MessageEvent, WebSocket};
 
 type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
 
 #[derive(Clone)]
-pub struct AsyncClient {
-    inner: Arc<AsyncClientInner>,
+pub struct WasmClient {
+    inner: Rc<WasmClientInner>,
 }
 
-struct AsyncClientInner {
-    writer: Mutex<BufWriter<OwnedWriteHalf>>,
-    pending: StdMutex<PendingRequests>,
-    next_id: AtomicU64,
-    shutdown: StdMutex<Option<oneshot::Sender<()>>>,
-}
-
-impl Drop for AsyncClientInner {
-    fn drop(&mut self) {
-        if let Ok(mut tx) = self.shutdown.lock() {
-            if let Some(sender) = tx.take() {
-                let _ = sender.send(());
-            }
-        }
-    }
-}
-
-enum PendingDispatch {
-    Matched {
-        sender: PendingSender,
-        response: Message,
-    },
-    Unrecognized {
-        got_id: u64,
-    },
+struct WasmClientInner {
+    ws: WebSocket,
+    pending: RefCell<PendingRequests>,
+    next_id: Cell<u64>,
+    onmessage: Closure<dyn FnMut(MessageEvent)>,
+    onerror: Closure<dyn FnMut(Event)>,
+    onclose: Closure<dyn FnMut(CloseEvent)>,
 }
 
 struct PendingRequestGuard {
-    inner: Arc<AsyncClientInner>,
+    inner: Rc<WasmClientInner>,
     request_id: u64,
     disarmed: bool,
 }
 
 impl PendingRequestGuard {
     fn register(
-        inner: &Arc<AsyncClientInner>,
+        inner: &Rc<WasmClientInner>,
         request_id: u64,
         sender: PendingSender,
     ) -> Result<Self, RepeError> {
         {
-            let mut pending = lock_pending_map(&inner.pending);
+            let mut pending = inner.pending.borrow_mut();
             if pending.contains_key(&request_id) {
                 return Err(duplicate_request_id_error(request_id));
             }
@@ -74,7 +59,7 @@ impl PendingRequestGuard {
         }
 
         Ok(Self {
-            inner: Arc::clone(inner),
+            inner: Rc::clone(inner),
             request_id,
             disarmed: false,
         })
@@ -91,35 +76,69 @@ impl Drop for PendingRequestGuard {
             return;
         }
 
-        let mut pending = lock_pending_map(&self.inner.pending);
-        pending.remove(&self.request_id);
+        self.inner.pending.borrow_mut().remove(&self.request_id);
     }
 }
 
-impl AsyncClient {
-    pub async fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
-        let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        let (read_half, write_half) = stream.into_split();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let inner = Arc::new(AsyncClientInner {
-            writer: Mutex::new(BufWriter::new(write_half)),
-            pending: StdMutex::new(HashMap::new()),
-            next_id: AtomicU64::new(1),
-            shutdown: StdMutex::new(Some(shutdown_tx)),
-        });
+impl Drop for WasmClientInner {
+    fn drop(&mut self) {
+        self.ws.set_onmessage(None);
+        self.ws.set_onerror(None);
+        self.ws.set_onclose(None);
+        let _ = self.ws.close();
 
-        spawn_response_loop(
-            BufReader::new(read_half),
-            Arc::downgrade(&inner),
-            shutdown_rx,
-        );
+        let err = websocket_closed_error();
+        for (request_id, sender) in self.pending.get_mut().drain() {
+            let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
+        }
+    }
+}
+
+impl WasmClient {
+    pub async fn connect(url: &str) -> Result<Self, RepeError> {
+        let ws = WebSocket::new(url).map_err(js_to_io_error)?;
+        ws.set_binary_type(BinaryType::Arraybuffer);
+
+        let (open_tx, open_rx) = oneshot::channel::<Result<(), RepeError>>();
+        let open_tx = Rc::new(RefCell::new(Some(open_tx)));
+
+        let open_signal = Rc::clone(&open_tx);
+        let onopen = Closure::wrap(Box::new(move |_event: Event| {
+            if let Some(sender) = open_signal.borrow_mut().take() {
+                let _ = sender.send(Ok(()));
+            }
+        }) as Box<dyn FnMut(Event)>);
+        ws.set_onopen(Some(onopen.as_ref().unchecked_ref()));
+
+        let error_signal = Rc::clone(&open_tx);
+        let onerror = Closure::wrap(Box::new(move |_event: Event| {
+            if let Some(sender) = error_signal.borrow_mut().take() {
+                let _ = sender.send(Err(websocket_event_error("websocket connection failed")));
+            }
+        }) as Box<dyn FnMut(Event)>);
+        ws.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+
+        let connect_result = match open_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(websocket_event_error("websocket open channel closed")),
+        };
+
+        ws.set_onopen(None);
+        ws.set_onerror(None);
+        connect_result?;
+
+        let inner = Rc::new_cyclic(|weak| WasmClientInner::new(ws.clone(), weak.clone()));
+        inner
+            .ws
+            .set_onmessage(Some(inner.onmessage.as_ref().unchecked_ref()));
+        inner
+            .ws
+            .set_onerror(Some(inner.onerror.as_ref().unchecked_ref()));
+        inner
+            .ws
+            .set_onclose(Some(inner.onclose.as_ref().unchecked_ref()));
 
         Ok(Self { inner })
-    }
-
-    fn next_request_id(&self) -> u64 {
-        self.inner.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
     pub async fn call_json<P: AsRef<str>, T: Serialize>(
@@ -130,7 +149,6 @@ impl AsyncClient {
         self.call_json_with_optional_timeout(path, body, None).await
     }
 
-    /// Send a JSON request and fail if no response arrives before `timeout_duration`.
     pub async fn call_json_with_timeout<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -150,7 +168,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a typed JSON request and fail if no response arrives before `timeout_duration`.
     pub async fn call_typed_json_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
         &self,
         path: P,
@@ -170,7 +187,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a typed BEVE request and fail if no response arrives before `timeout_duration`.
     pub async fn call_typed_beve_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
         &self,
         path: P,
@@ -181,9 +197,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a JSON-pointer request with an empty body and return the full response message.
-    ///
-    /// This is useful for protocols that use empty-body semantics (for example, registry READs).
     pub async fn call_message<P: AsRef<str>>(&self, path: P) -> Result<Message, RepeError> {
         self.call_message_with_formats_and_timeout(
             path,
@@ -195,8 +208,6 @@ impl AsyncClient {
         .await
     }
 
-    /// Send a JSON-pointer request with an empty body, failing if no response arrives before
-    /// `timeout_duration`.
     pub async fn call_message_with_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -212,9 +223,6 @@ impl AsyncClient {
         .await
     }
 
-    /// Low-level call API that allows custom query/body format codes and optional raw body bytes.
-    ///
-    /// If `body` is `None`, the request body is empty (`body_length = 0`).
     pub async fn call_with_formats<P: AsRef<str>>(
         &self,
         path: P,
@@ -226,7 +234,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Timeout variant of [`AsyncClient::call_with_formats`].
     pub async fn call_with_formats_and_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -245,13 +252,11 @@ impl AsyncClient {
         .await
     }
 
-    /// Registry helper: send an empty-body request and decode the JSON response.
     pub async fn registry_read<P: AsRef<str>>(&self, path: P) -> Result<Value, RepeError> {
         let resp = self.call_message(path).await?;
         resp.json_body::<Value>()
     }
 
-    /// Registry helper: send an empty-body request and deserialize the JSON response as `R`.
     pub async fn registry_read_typed<P: AsRef<str>, R: DeserializeOwned>(
         &self,
         path: P,
@@ -260,7 +265,6 @@ impl AsyncClient {
         resp.json_body::<R>()
     }
 
-    /// Timeout variant of [`AsyncClient::registry_read`].
     pub async fn registry_read_with_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -272,7 +276,6 @@ impl AsyncClient {
         resp.json_body::<Value>()
     }
 
-    /// Timeout variant of [`AsyncClient::registry_read_typed`].
     pub async fn registry_read_typed_with_timeout<P: AsRef<str>, R: DeserializeOwned>(
         &self,
         path: P,
@@ -284,7 +287,6 @@ impl AsyncClient {
         resp.json_body::<R>()
     }
 
-    /// Registry helper: send a JSON body (WRITE semantics for non-function targets).
     pub async fn registry_write_json<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -293,7 +295,6 @@ impl AsyncClient {
         self.call_json(path, body).await
     }
 
-    /// Registry helper: send a JSON body (CALL semantics for function targets).
     pub async fn registry_call_json<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -329,9 +330,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Low-level notify API that allows custom query/body format codes and optional raw body bytes.
-    ///
-    /// If `body` is `None`, the notify request is sent with an empty body.
     pub async fn notify_with_formats<P: AsRef<str>>(
         &self,
         path: P,
@@ -343,26 +341,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Forward a prebuilt REPE message over this connection.
-    ///
-    /// This preserves the original query/body bytes, ids, notify flag, format codes, and upstream
-    /// error responses. If `msg` is a notify request, no response is awaited and `Ok(None)` is
-    /// returned.
-    pub async fn forward_message(&self, msg: &Message) -> Result<Option<Message>, RepeError> {
-        self.forward_message_with_optional_timeout(msg, None).await
-    }
-
-    /// Timeout variant of [`AsyncClient::forward_message`].
-    pub async fn forward_message_with_timeout(
-        &self,
-        msg: &Message,
-        timeout_duration: Duration,
-    ) -> Result<Option<Message>, RepeError> {
-        self.forward_message_with_optional_timeout(msg, Some(timeout_duration))
-            .await
-    }
-
-    /// Execute JSON calls in parallel over this single connection and keep request order.
     pub async fn batch_json(
         &self,
         requests: Vec<(String, Value)>,
@@ -370,7 +348,6 @@ impl AsyncClient {
         self.batch_json_inner(requests, None).await
     }
 
-    /// Execute JSON calls in parallel with a per-request timeout.
     pub async fn batch_json_with_timeout(
         &self,
         requests: Vec<(String, Value)>,
@@ -385,35 +362,28 @@ impl AsyncClient {
         requests: Vec<(String, Value)>,
         timeout_duration: Option<Duration>,
     ) -> Vec<Result<Value, RepeError>> {
-        let mut workers = Vec::with_capacity(requests.len());
-
-        for (index, (path, body)) in requests.into_iter().enumerate() {
+        join_all(requests.into_iter().map(|(path, body)| {
             let client = self.clone();
-            workers.push((
-                index,
-                tokio::spawn(async move {
-                    client
-                        .call_json_with_optional_timeout(path, &body, timeout_duration)
-                        .await
-                }),
-            ));
-        }
+            async move {
+                client
+                    .call_json_with_optional_timeout(path, &body, timeout_duration)
+                    .await
+            }
+        }))
+        .await
+    }
 
-        let mut out: Vec<Option<Result<Value, RepeError>>> = std::iter::repeat_with(|| None)
-            .take(workers.len())
-            .collect();
+    fn next_request_id(&self) -> u64 {
+        let id = self.inner.next_id.get();
+        self.inner.next_id.set(id + 1);
+        id
+    }
 
-        for (index, worker) in workers {
-            let result = match worker.await {
-                Ok(value) => value,
-                Err(err) => Err(batch_worker_join_error(err)),
-            };
-            out[index] = Some(result);
-        }
-
-        out.into_iter()
-            .map(|entry| entry.unwrap_or_else(|| Err(batch_worker_missing_result_error())))
-            .collect()
+    fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
+        self.inner
+            .ws
+            .send_with_u8_array(&msg.to_vec())
+            .map_err(js_to_io_error)
     }
 
     async fn call_json_with_optional_timeout<P: AsRef<str>, T: Serialize>(
@@ -496,30 +466,30 @@ impl AsyncClient {
         let (sender, receiver) = oneshot::channel();
         let mut pending_guard = PendingRequestGuard::register(&self.inner, id, sender)?;
 
-        self.write_request(&msg).await?;
+        self.write_request(&msg)?;
 
         let received = match timeout_duration {
-            Some(duration) => match timeout(duration, receiver).await {
-                Ok(Ok(value)) => value,
-                Ok(Err(_)) => return Err(response_channel_closed_error(id)),
-                Err(_) => return Err(request_timeout_error(id, duration)),
-            },
+            Some(duration) => {
+                let timeout_future = JsTimeout::new(duration)?;
+                futures_util::pin_mut!(receiver);
+                futures_util::pin_mut!(timeout_future);
+                match select(receiver, timeout_future).await {
+                    Either::Left((value, _)) => match value {
+                        Ok(value) => value,
+                        Err(_) => return Err(response_channel_closed_error(id)),
+                    },
+                    Either::Right(((), _)) => return Err(request_timeout_error(id, duration)),
+                }
+            }
             None => match receiver.await {
                 Ok(value) => value,
                 Err(_) => return Err(response_channel_closed_error(id)),
             },
         };
 
-        let resp = received?;
+        let response = received?;
         pending_guard.disarm();
-        Self::validate_response(id, resp)
-    }
-
-    async fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
-        let mut writer = self.inner.writer.lock().await;
-        write_message_async(&mut *writer, msg).await?;
-        writer.flush().await?;
-        Ok(())
+        Self::validate_response(id, response)
     }
 
     fn validate_response(expected_id: u64, resp: Message) -> Result<Message, RepeError> {
@@ -550,7 +520,7 @@ impl AsyncClient {
             Ok(BodyFormat::Beve) => beve_from_slice(&resp.body).map_err(RepeError::from),
             Ok(BodyFormat::RawBinary) => {
                 let io_err = std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
+                    ErrorKind::InvalidData,
                     "response body is neither JSON nor BEVE",
                 );
                 Err(RepeError::Json(serde_json::Error::io(io_err)))
@@ -585,7 +555,7 @@ impl AsyncClient {
             .query_str(path.as_ref())
             .query_format_code(query_format);
         let msg = body_fn(builder)?.build();
-        self.write_request(&msg).await
+        self.write_request(&msg)
     }
 
     async fn call_message_with_formats_and_timeout<P: AsRef<str>>(
@@ -628,122 +598,190 @@ impl AsyncClient {
         })
         .await
     }
+}
 
-    async fn forward_message_with_optional_timeout(
-        &self,
-        msg: &Message,
-        timeout_duration: Option<Duration>,
-    ) -> Result<Option<Message>, RepeError> {
-        if msg.header.notify == 1 {
-            self.write_request(msg).await?;
-            return Ok(None);
-        }
-
-        let request_id = msg.header.id;
-        let (sender, receiver) = oneshot::channel();
-        let mut pending_guard = PendingRequestGuard::register(&self.inner, request_id, sender)?;
-
-        self.write_request(msg).await?;
-
-        let received = match timeout_duration {
-            Some(duration) => match timeout(duration, receiver).await {
-                Ok(Ok(value)) => value,
-                Ok(Err(_)) => return Err(response_channel_closed_error(request_id)),
-                Err(_) => return Err(request_timeout_error(request_id, duration)),
-            },
-            None => match receiver.await {
-                Ok(value) => value,
-                Err(_) => return Err(response_channel_closed_error(request_id)),
-            },
+impl WasmClientInner {
+    fn new(ws: WebSocket, weak: Weak<WasmClientInner>) -> Self {
+        let onmessage = {
+            let weak = weak.clone();
+            Closure::wrap(Box::new(move |event: MessageEvent| {
+                if let Some(inner) = weak.upgrade() {
+                    inner.handle_message(event);
+                }
+            }) as Box<dyn FnMut(MessageEvent)>)
         };
 
-        let response = received?;
-        pending_guard.disarm();
-        if response.header.version != REPE_VERSION {
-            return Err(RepeError::VersionMismatch(response.header.version));
-        }
-        if response.header.id != request_id {
-            return Err(RepeError::ResponseIdMismatch {
-                expected: request_id,
-                got: response.header.id,
-            });
-        }
+        let onerror = {
+            let weak = weak.clone();
+            Closure::wrap(Box::new(move |_event: Event| {
+                if let Some(inner) = weak.upgrade() {
+                    inner.fail_all_pending(websocket_event_error("websocket error"));
+                }
+            }) as Box<dyn FnMut(Event)>)
+        };
 
-        Ok(Some(response))
+        let onclose = {
+            Closure::wrap(Box::new(move |_event: CloseEvent| {
+                if let Some(inner) = weak.upgrade() {
+                    inner.fail_all_pending(websocket_closed_error());
+                }
+            }) as Box<dyn FnMut(CloseEvent)>)
+        };
+
+        Self {
+            ws,
+            pending: RefCell::new(HashMap::new()),
+            next_id: Cell::new(1),
+            onmessage,
+            onerror,
+            onclose,
+        }
     }
-}
 
-fn spawn_response_loop(
-    mut reader: BufReader<OwnedReadHalf>,
-    inner: std::sync::Weak<AsyncClientInner>,
-    mut shutdown_rx: oneshot::Receiver<()>,
-) {
-    tokio::spawn(async move {
-        loop {
-            let response = tokio::select! {
-                _ = &mut shutdown_rx => {
-                    break;
-                }
-                read = read_message_async(&mut reader) => {
-                    match read {
-                        Ok(message) => message,
-                        Err(err) => {
-                            fail_all_pending(&inner, err).await;
-                            break;
-                        }
-                    }
-                }
-            };
+    fn handle_message(&self, event: MessageEvent) {
+        let response = match decode_message_event(event) {
+            Ok(message) => message,
+            Err(err) => {
+                self.fail_all_pending(err);
+                return;
+            }
+        };
 
-            let dispatch = {
-                let Some(inner_ref) = inner.upgrade() else {
-                    break;
-                };
-                let response_id = response.header.id;
-                let matched_sender = {
-                    let mut pending = lock_pending_map(&inner_ref.pending);
-                    pending.remove(&response_id)
-                };
-
-                if let Some(sender) = matched_sender {
-                    PendingDispatch::Matched { sender, response }
-                } else {
-                    PendingDispatch::Unrecognized {
-                        got_id: response_id,
-                    }
-                }
-            };
-
-            match dispatch {
-                PendingDispatch::Matched { sender, response } => {
-                    let _ = sender.send(Ok(response));
-                }
-                PendingDispatch::Unrecognized { got_id } => {
-                    eprintln!("[repe] dropping response for unrecognized request id {got_id}");
-                }
+        let sender = self.pending.borrow_mut().remove(&response.header.id);
+        match sender {
+            Some(sender) => {
+                let _ = sender.send(Ok(response));
+            }
+            None => {
+                eprintln!(
+                    "[repe] dropping websocket response for unrecognized request id {}",
+                    response.header.id
+                );
             }
         }
-    });
+    }
+
+    fn fail_all_pending(&self, err: RepeError) {
+        let waiters = self.pending.borrow_mut().drain().collect::<Vec<_>>();
+        for (request_id, sender) in waiters {
+            let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
+        }
+    }
 }
 
-async fn fail_all_pending(inner: &std::sync::Weak<AsyncClientInner>, err: RepeError) {
-    let Some(inner_ref) = inner.upgrade() else {
-        return;
-    };
+fn decode_message_event(event: MessageEvent) -> Result<Message, RepeError> {
+    let data = event.data();
+    let buffer = data
+        .dyn_into::<ArrayBuffer>()
+        .map_err(|_| websocket_invalid_data_error("websocket transport requires ArrayBuffer"))?;
+    let payload = Uint8Array::new(&buffer).to_vec();
+    Message::from_slice_exact(&payload)
+}
 
-    {
-        let mut writer = inner_ref.writer.lock().await;
-        let _ = writer.shutdown().await;
+struct JsTimeout {
+    receiver: oneshot::Receiver<()>,
+    handle: Option<i32>,
+    callback: Option<Closure<dyn FnMut()>>,
+}
+
+impl JsTimeout {
+    fn new(duration: Duration) -> Result<Self, RepeError> {
+        let window =
+            web_sys::window().ok_or_else(|| websocket_event_error("window is not available"))?;
+        let (sender, receiver) = oneshot::channel();
+        let sender = Rc::new(RefCell::new(Some(sender)));
+        let callback_sender = Rc::clone(&sender);
+        let callback = Closure::wrap(Box::new(move || {
+            if let Some(sender) = callback_sender.borrow_mut().take() {
+                let _ = sender.send(());
+            }
+        }) as Box<dyn FnMut()>);
+
+        let handle = window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                callback.as_ref().unchecked_ref(),
+                duration.as_millis().min(i32::MAX as u128) as i32,
+            )
+            .map_err(js_to_io_error)?;
+
+        Ok(Self {
+            receiver,
+            handle: Some(handle),
+            callback: Some(callback),
+        })
     }
 
-    let waiters = {
-        let mut pending = lock_pending_map(&inner_ref.pending);
-        pending.drain().collect::<Vec<_>>()
-    };
-
-    for (request_id, sender) in waiters {
-        let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
+    fn clear(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            if let Some(window) = web_sys::window() {
+                window.clear_timeout_with_handle(handle);
+            }
+        }
+        self.callback.take();
     }
+}
+
+impl Future for JsTimeout {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.receiver).poll(cx) {
+            Poll::Ready(_) => {
+                self.clear();
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for JsTimeout {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+fn request_timeout_error(request_id: u64, timeout: Duration) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::TimedOut,
+        format!(
+            "request {request_id} timed out after {}ms",
+            timeout.as_millis()
+        ),
+    ))
+}
+
+fn response_channel_closed_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::ConnectionAborted,
+        format!("response channel closed for request {request_id}"),
+    ))
+}
+
+fn duplicate_request_id_error(request_id: u64) -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::AlreadyExists,
+        format!("request id {request_id} is already pending"),
+    ))
+}
+
+fn websocket_closed_error() -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::ConnectionAborted,
+        "websocket connection closed",
+    ))
+}
+
+fn websocket_event_error(message: &str) -> RepeError {
+    RepeError::Io(std::io::Error::other(message))
+}
+
+fn websocket_invalid_data_error(message: &str) -> RepeError {
+    RepeError::Io(std::io::Error::new(ErrorKind::InvalidData, message))
+}
+
+fn js_to_io_error(value: JsValue) -> RepeError {
+    RepeError::Io(std::io::Error::other(format!("{value:?}")))
 }
 
 fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
@@ -780,132 +818,5 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             code: *code,
             message: message.clone(),
         },
-    }
-}
-
-fn request_timeout_error(request_id: u64, timeout: Duration) -> RepeError {
-    RepeError::Io(std::io::Error::new(
-        ErrorKind::TimedOut,
-        format!(
-            "request {request_id} timed out after {}ms",
-            timeout.as_millis()
-        ),
-    ))
-}
-
-fn response_channel_closed_error(request_id: u64) -> RepeError {
-    RepeError::Io(std::io::Error::new(
-        ErrorKind::ConnectionAborted,
-        format!("response channel closed for request {request_id}"),
-    ))
-}
-
-fn duplicate_request_id_error(request_id: u64) -> RepeError {
-    RepeError::Io(std::io::Error::new(
-        ErrorKind::AlreadyExists,
-        format!("request id {request_id} is already pending"),
-    ))
-}
-
-fn batch_worker_join_error(err: JoinError) -> RepeError {
-    RepeError::Io(std::io::Error::other(format!("batch worker failed: {err}")))
-}
-
-fn batch_worker_missing_result_error() -> RepeError {
-    RepeError::Io(std::io::Error::other("batch worker missing result"))
-}
-
-fn lock_pending_map(
-    pending: &StdMutex<PendingRequests>,
-) -> std::sync::MutexGuard<'_, PendingRequests> {
-    match pending.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::io::{read_message, write_message};
-    use serde_json::json;
-    use std::io::{BufReader, BufWriter, Write};
-    use std::net::TcpListener;
-    use std::sync::mpsc;
-    use std::thread;
-
-    fn json_response_for(req: &Message) -> Message {
-        Message::builder()
-            .id(req.header.id)
-            .query_bytes(req.query.clone())
-            .query_format(
-                QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
-            )
-            .body_json(&json!({"path": req.query_utf8()}))
-            .expect("json body")
-            .build()
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn cancelled_call_cleans_pending_entry() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (first_seen_tx, first_seen_rx) = mpsc::channel();
-
-        let server = thread::spawn(move || {
-            let (stream, _) = listener.accept().unwrap();
-            let mut reader = BufReader::new(stream.try_clone().unwrap());
-            let mut writer = BufWriter::new(stream);
-
-            let _first = read_message(&mut reader).unwrap();
-            first_seen_tx
-                .send(())
-                .expect("signal that first request arrived");
-
-            let second = read_message(&mut reader).unwrap();
-            let response = json_response_for(&second);
-            write_message(&mut writer, &response).unwrap();
-            writer.flush().unwrap();
-        });
-
-        let client = AsyncClient::connect(addr).await.unwrap();
-
-        let cancelled_client = client.clone();
-        let cancelled_call = tokio::spawn(async move {
-            cancelled_client
-                .call_json("/cancelled", &json!({"n": 1}))
-                .await
-        });
-
-        tokio::task::spawn_blocking(move || {
-            first_seen_rx
-                .recv_timeout(Duration::from_secs(2))
-                .expect("server should observe the first request");
-        })
-        .await
-        .unwrap();
-
-        cancelled_call.abort();
-        let join_err = cancelled_call.await.unwrap_err();
-        assert!(join_err.is_cancelled());
-
-        let pending_count = {
-            let pending = lock_pending_map(&client.inner.pending);
-            pending.len()
-        };
-        assert_eq!(
-            pending_count, 0,
-            "cancelled calls must not leak pending entries"
-        );
-
-        let out = client
-            .call_json_with_timeout("/ok", &json!({"n": 2}), Duration::from_secs(1))
-            .await
-            .unwrap();
-        assert_eq!(out["path"], "/ok");
-
-        tokio::task::spawn_blocking(move || server.join().unwrap())
-            .await
-            .unwrap();
     }
 }

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -1,8 +1,8 @@
-use crate::async_io::{read_message_async, write_message_async};
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
 use crate::message::{Message, MessageBuilder};
 use beve::from_slice as beve_from_slice;
+use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -10,37 +10,29 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
-use tokio::io::AsyncWriteExt;
-use tokio::io::{BufReader, BufWriter};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::net::TcpStream;
 use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinError;
 use tokio::time::{Duration, timeout};
+use tokio_tungstenite::tungstenite::{self, Message as WsMessage};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
+type WsWriter =
+    futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, WsMessage>;
+type WsReader =
+    futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Clone)]
-pub struct AsyncClient {
-    inner: Arc<AsyncClientInner>,
+pub struct WebSocketClient {
+    inner: Arc<WebSocketClientInner>,
 }
 
-struct AsyncClientInner {
-    writer: Mutex<BufWriter<OwnedWriteHalf>>,
+struct WebSocketClientInner {
+    writer: Mutex<WsWriter>,
     pending: StdMutex<PendingRequests>,
     next_id: AtomicU64,
-    shutdown: StdMutex<Option<oneshot::Sender<()>>>,
-}
-
-impl Drop for AsyncClientInner {
-    fn drop(&mut self) {
-        if let Ok(mut tx) = self.shutdown.lock() {
-            if let Some(sender) = tx.take() {
-                let _ = sender.send(());
-            }
-        }
-    }
 }
 
 enum PendingDispatch {
@@ -54,14 +46,14 @@ enum PendingDispatch {
 }
 
 struct PendingRequestGuard {
-    inner: Arc<AsyncClientInner>,
+    inner: Arc<WebSocketClientInner>,
     request_id: u64,
     disarmed: bool,
 }
 
 impl PendingRequestGuard {
     fn register(
-        inner: &Arc<AsyncClientInner>,
+        inner: &Arc<WebSocketClientInner>,
         request_id: u64,
         sender: PendingSender,
     ) -> Result<Self, RepeError> {
@@ -96,24 +88,32 @@ impl Drop for PendingRequestGuard {
     }
 }
 
-impl AsyncClient {
-    pub async fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
-        let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        let (read_half, write_half) = stream.into_split();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let inner = Arc::new(AsyncClientInner {
-            writer: Mutex::new(BufWriter::new(write_half)),
+impl Drop for WebSocketClient {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.inner) != 1 {
+            return;
+        }
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let inner = Arc::clone(&self.inner);
+            handle.spawn(async move {
+                let _ = close_writer(&inner).await;
+            });
+        }
+    }
+}
+
+impl WebSocketClient {
+    pub async fn connect(url: &str) -> std::io::Result<Self> {
+        let (stream, _response) = connect_async(url).await.map_err(websocket_connect_error)?;
+        let (writer, reader) = stream.split();
+        let inner = Arc::new(WebSocketClientInner {
+            writer: Mutex::new(writer),
             pending: StdMutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
-            shutdown: StdMutex::new(Some(shutdown_tx)),
         });
 
-        spawn_response_loop(
-            BufReader::new(read_half),
-            Arc::downgrade(&inner),
-            shutdown_rx,
-        );
+        spawn_response_loop(reader, Arc::downgrade(&inner));
 
         Ok(Self { inner })
     }
@@ -130,7 +130,6 @@ impl AsyncClient {
         self.call_json_with_optional_timeout(path, body, None).await
     }
 
-    /// Send a JSON request and fail if no response arrives before `timeout_duration`.
     pub async fn call_json_with_timeout<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -150,7 +149,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a typed JSON request and fail if no response arrives before `timeout_duration`.
     pub async fn call_typed_json_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
         &self,
         path: P,
@@ -170,7 +168,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a typed BEVE request and fail if no response arrives before `timeout_duration`.
     pub async fn call_typed_beve_with_timeout<P: AsRef<str>, T: Serialize, R: DeserializeOwned>(
         &self,
         path: P,
@@ -181,9 +178,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Send a JSON-pointer request with an empty body and return the full response message.
-    ///
-    /// This is useful for protocols that use empty-body semantics (for example, registry READs).
     pub async fn call_message<P: AsRef<str>>(&self, path: P) -> Result<Message, RepeError> {
         self.call_message_with_formats_and_timeout(
             path,
@@ -195,8 +189,6 @@ impl AsyncClient {
         .await
     }
 
-    /// Send a JSON-pointer request with an empty body, failing if no response arrives before
-    /// `timeout_duration`.
     pub async fn call_message_with_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -212,9 +204,6 @@ impl AsyncClient {
         .await
     }
 
-    /// Low-level call API that allows custom query/body format codes and optional raw body bytes.
-    ///
-    /// If `body` is `None`, the request body is empty (`body_length = 0`).
     pub async fn call_with_formats<P: AsRef<str>>(
         &self,
         path: P,
@@ -226,7 +215,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Timeout variant of [`AsyncClient::call_with_formats`].
     pub async fn call_with_formats_and_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -245,13 +233,11 @@ impl AsyncClient {
         .await
     }
 
-    /// Registry helper: send an empty-body request and decode the JSON response.
     pub async fn registry_read<P: AsRef<str>>(&self, path: P) -> Result<Value, RepeError> {
         let resp = self.call_message(path).await?;
         resp.json_body::<Value>()
     }
 
-    /// Registry helper: send an empty-body request and deserialize the JSON response as `R`.
     pub async fn registry_read_typed<P: AsRef<str>, R: DeserializeOwned>(
         &self,
         path: P,
@@ -260,7 +246,6 @@ impl AsyncClient {
         resp.json_body::<R>()
     }
 
-    /// Timeout variant of [`AsyncClient::registry_read`].
     pub async fn registry_read_with_timeout<P: AsRef<str>>(
         &self,
         path: P,
@@ -272,7 +257,6 @@ impl AsyncClient {
         resp.json_body::<Value>()
     }
 
-    /// Timeout variant of [`AsyncClient::registry_read_typed`].
     pub async fn registry_read_typed_with_timeout<P: AsRef<str>, R: DeserializeOwned>(
         &self,
         path: P,
@@ -284,7 +268,6 @@ impl AsyncClient {
         resp.json_body::<R>()
     }
 
-    /// Registry helper: send a JSON body (WRITE semantics for non-function targets).
     pub async fn registry_write_json<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -293,7 +276,6 @@ impl AsyncClient {
         self.call_json(path, body).await
     }
 
-    /// Registry helper: send a JSON body (CALL semantics for function targets).
     pub async fn registry_call_json<P: AsRef<str>, T: Serialize>(
         &self,
         path: P,
@@ -329,9 +311,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Low-level notify API that allows custom query/body format codes and optional raw body bytes.
-    ///
-    /// If `body` is `None`, the notify request is sent with an empty body.
     pub async fn notify_with_formats<P: AsRef<str>>(
         &self,
         path: P,
@@ -343,26 +322,6 @@ impl AsyncClient {
             .await
     }
 
-    /// Forward a prebuilt REPE message over this connection.
-    ///
-    /// This preserves the original query/body bytes, ids, notify flag, format codes, and upstream
-    /// error responses. If `msg` is a notify request, no response is awaited and `Ok(None)` is
-    /// returned.
-    pub async fn forward_message(&self, msg: &Message) -> Result<Option<Message>, RepeError> {
-        self.forward_message_with_optional_timeout(msg, None).await
-    }
-
-    /// Timeout variant of [`AsyncClient::forward_message`].
-    pub async fn forward_message_with_timeout(
-        &self,
-        msg: &Message,
-        timeout_duration: Duration,
-    ) -> Result<Option<Message>, RepeError> {
-        self.forward_message_with_optional_timeout(msg, Some(timeout_duration))
-            .await
-    }
-
-    /// Execute JSON calls in parallel over this single connection and keep request order.
     pub async fn batch_json(
         &self,
         requests: Vec<(String, Value)>,
@@ -370,7 +329,6 @@ impl AsyncClient {
         self.batch_json_inner(requests, None).await
     }
 
-    /// Execute JSON calls in parallel with a per-request timeout.
     pub async fn batch_json_with_timeout(
         &self,
         requests: Vec<(String, Value)>,
@@ -510,15 +468,17 @@ impl AsyncClient {
             },
         };
 
-        let resp = received?;
+        let response = received?;
         pending_guard.disarm();
-        Self::validate_response(id, resp)
+        Self::validate_response(id, response)
     }
 
     async fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
         let mut writer = self.inner.writer.lock().await;
-        write_message_async(&mut *writer, msg).await?;
-        writer.flush().await?;
+        writer
+            .send(WsMessage::Binary(msg.to_vec()))
+            .await
+            .map_err(websocket_transport_error)?;
         Ok(())
     }
 
@@ -550,7 +510,7 @@ impl AsyncClient {
             Ok(BodyFormat::Beve) => beve_from_slice(&resp.body).map_err(RepeError::from),
             Ok(BodyFormat::RawBinary) => {
                 let io_err = std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
+                    ErrorKind::InvalidData,
                     "response body is neither JSON nor BEVE",
                 );
                 Err(RepeError::Json(serde_json::Error::io(io_err)))
@@ -628,70 +588,29 @@ impl AsyncClient {
         })
         .await
     }
-
-    async fn forward_message_with_optional_timeout(
-        &self,
-        msg: &Message,
-        timeout_duration: Option<Duration>,
-    ) -> Result<Option<Message>, RepeError> {
-        if msg.header.notify == 1 {
-            self.write_request(msg).await?;
-            return Ok(None);
-        }
-
-        let request_id = msg.header.id;
-        let (sender, receiver) = oneshot::channel();
-        let mut pending_guard = PendingRequestGuard::register(&self.inner, request_id, sender)?;
-
-        self.write_request(msg).await?;
-
-        let received = match timeout_duration {
-            Some(duration) => match timeout(duration, receiver).await {
-                Ok(Ok(value)) => value,
-                Ok(Err(_)) => return Err(response_channel_closed_error(request_id)),
-                Err(_) => return Err(request_timeout_error(request_id, duration)),
-            },
-            None => match receiver.await {
-                Ok(value) => value,
-                Err(_) => return Err(response_channel_closed_error(request_id)),
-            },
-        };
-
-        let response = received?;
-        pending_guard.disarm();
-        if response.header.version != REPE_VERSION {
-            return Err(RepeError::VersionMismatch(response.header.version));
-        }
-        if response.header.id != request_id {
-            return Err(RepeError::ResponseIdMismatch {
-                expected: request_id,
-                got: response.header.id,
-            });
-        }
-
-        Ok(Some(response))
-    }
 }
 
-fn spawn_response_loop(
-    mut reader: BufReader<OwnedReadHalf>,
-    inner: std::sync::Weak<AsyncClientInner>,
-    mut shutdown_rx: oneshot::Receiver<()>,
-) {
+fn spawn_response_loop(mut reader: WsReader, inner: std::sync::Weak<WebSocketClientInner>) {
     tokio::spawn(async move {
         loop {
-            let response = tokio::select! {
-                _ = &mut shutdown_rx => {
+            let frame = match reader.next().await {
+                Some(Ok(frame)) => frame,
+                Some(Err(err)) => {
+                    fail_all_pending(&inner, websocket_transport_error(err)).await;
                     break;
                 }
-                read = read_message_async(&mut reader) => {
-                    match read {
-                        Ok(message) => message,
-                        Err(err) => {
-                            fail_all_pending(&inner, err).await;
-                            break;
-                        }
-                    }
+                None => {
+                    fail_all_pending(&inner, websocket_closed_error()).await;
+                    break;
+                }
+            };
+
+            let response = match decode_websocket_frame(frame) {
+                Ok(Some(message)) => message,
+                Ok(None) => continue,
+                Err(err) => {
+                    fail_all_pending(&inner, err).await;
+                    break;
                 }
             };
 
@@ -719,22 +638,33 @@ fn spawn_response_loop(
                     let _ = sender.send(Ok(response));
                 }
                 PendingDispatch::Unrecognized { got_id } => {
-                    eprintln!("[repe] dropping response for unrecognized request id {got_id}");
+                    eprintln!("[repe] dropping websocket response for unrecognized request id {got_id}");
                 }
             }
         }
     });
 }
 
-async fn fail_all_pending(inner: &std::sync::Weak<AsyncClientInner>, err: RepeError) {
+fn decode_websocket_frame(frame: WsMessage) -> Result<Option<Message>, RepeError> {
+    match frame {
+        WsMessage::Binary(payload) => Message::from_slice_exact(&payload).map(Some),
+        WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => Ok(None),
+        WsMessage::Close(_) => Err(websocket_closed_error()),
+        WsMessage::Text(_) => Err(websocket_invalid_data_error(
+            "websocket transport requires binary messages",
+        )),
+    }
+}
+
+async fn fail_all_pending(
+    inner: &std::sync::Weak<WebSocketClientInner>,
+    err: RepeError,
+) {
     let Some(inner_ref) = inner.upgrade() else {
         return;
     };
 
-    {
-        let mut writer = inner_ref.writer.lock().await;
-        let _ = writer.shutdown().await;
-    }
+    let _ = close_writer(&inner_ref).await;
 
     let waiters = {
         let mut pending = lock_pending_map(&inner_ref.pending);
@@ -744,6 +674,12 @@ async fn fail_all_pending(inner: &std::sync::Weak<AsyncClientInner>, err: RepeEr
     for (request_id, sender) in waiters {
         let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
     }
+}
+
+async fn close_writer(inner: &Arc<WebSocketClientInner>) -> Result<(), RepeError> {
+    let mut writer = inner.writer.lock().await;
+    let _ = writer.send(WsMessage::Close(None)).await;
+    writer.close().await.map_err(websocket_transport_error)
 }
 
 fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
@@ -815,6 +751,37 @@ fn batch_worker_missing_result_error() -> RepeError {
     RepeError::Io(std::io::Error::other("batch worker missing result"))
 }
 
+fn websocket_connect_error(err: tungstenite::Error) -> std::io::Error {
+    match err {
+        tungstenite::Error::Io(io_err) => io_err,
+        other => std::io::Error::other(other.to_string()),
+    }
+}
+
+fn websocket_transport_error(err: tungstenite::Error) -> RepeError {
+    match err {
+        tungstenite::Error::Io(io_err) => RepeError::Io(io_err),
+        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => {
+            RepeError::Io(std::io::Error::new(
+                ErrorKind::ConnectionAborted,
+                "websocket connection closed",
+            ))
+        }
+        other => RepeError::Io(std::io::Error::other(other.to_string())),
+    }
+}
+
+fn websocket_closed_error() -> RepeError {
+    RepeError::Io(std::io::Error::new(
+        ErrorKind::ConnectionAborted,
+        "websocket connection closed",
+    ))
+}
+
+fn websocket_invalid_data_error(message: &str) -> RepeError {
+    RepeError::Io(std::io::Error::new(ErrorKind::InvalidData, message))
+}
+
 fn lock_pending_map(
     pending: &StdMutex<PendingRequests>,
 ) -> std::sync::MutexGuard<'_, PendingRequests> {
@@ -827,85 +794,50 @@ fn lock_pending_map(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::io::{read_message, write_message};
-    use serde_json::json;
-    use std::io::{BufReader, BufWriter, Write};
-    use std::net::TcpListener;
-    use std::sync::mpsc;
-    use std::thread;
+    use crate::constants::QueryFormat;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
 
-    fn json_response_for(req: &Message) -> Message {
-        Message::builder()
-            .id(req.header.id)
-            .query_bytes(req.query.clone())
-            .query_format(
-                QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary),
-            )
-            .body_json(&json!({"path": req.query_utf8()}))
-            .expect("json body")
-            .build()
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn cancelled_call_cleans_pending_entry() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_client_rejects_trailing_bytes_in_binary_frame() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let (first_seen_tx, first_seen_rx) = mpsc::channel();
 
-        let server = thread::spawn(move || {
-            let (stream, _) = listener.accept().unwrap();
-            let mut reader = BufReader::new(stream.try_clone().unwrap());
-            let mut writer = BufWriter::new(stream);
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+            let request = ws.next().await.unwrap().unwrap();
+            let request = match request {
+                WsMessage::Binary(payload) => Message::from_slice_exact(&payload).unwrap(),
+                other => panic!("unexpected frame: {other:?}"),
+            };
 
-            let _first = read_message(&mut reader).unwrap();
-            first_seen_tx
-                .send(())
-                .expect("signal that first request arrived");
+            let mut response = Message::builder()
+                .id(request.header.id)
+                .query_str("/bad")
+                .query_format(QueryFormat::JsonPointer)
+                .body_json(&serde_json::json!({ "ok": true }))
+                .unwrap()
+                .build()
+                .to_vec();
+            response.extend_from_slice(&[0xAA, 0xBB]);
 
-            let second = read_message(&mut reader).unwrap();
-            let response = json_response_for(&second);
-            write_message(&mut writer, &response).unwrap();
-            writer.flush().unwrap();
+            ws.send(WsMessage::Binary(response)).await.unwrap();
         });
 
-        let client = AsyncClient::connect(addr).await.unwrap();
-
-        let cancelled_client = client.clone();
-        let cancelled_call = tokio::spawn(async move {
-            cancelled_client
-                .call_json("/cancelled", &json!({"n": 1}))
-                .await
-        });
-
-        tokio::task::spawn_blocking(move || {
-            first_seen_rx
-                .recv_timeout(Duration::from_secs(2))
-                .expect("server should observe the first request");
-        })
-        .await
-        .unwrap();
-
-        cancelled_call.abort();
-        let join_err = cancelled_call.await.unwrap_err();
-        assert!(join_err.is_cancelled());
-
-        let pending_count = {
-            let pending = lock_pending_map(&client.inner.pending);
-            pending.len()
-        };
-        assert_eq!(
-            pending_count, 0,
-            "cancelled calls must not leak pending entries"
-        );
-
-        let out = client
-            .call_json_with_timeout("/ok", &json!({"n": 2}), Duration::from_secs(1))
+        let client = WebSocketClient::connect(&format!("ws://{addr}/bad"))
             .await
             .unwrap();
-        assert_eq!(out["path"], "/ok");
-
-        tokio::task::spawn_blocking(move || server.join().unwrap())
+        let err = client
+            .call_json("/bad", &serde_json::json!({}))
             .await
-            .unwrap();
+            .unwrap_err();
+
+        match err {
+            RepeError::LengthMismatch { .. } => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        server_task.await.unwrap();
     }
 }

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -21,8 +21,7 @@ type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
 type WsWriter =
     futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, WsMessage>;
-type WsReader =
-    futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
+type WsReader = futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[derive(Clone)]
 pub struct WebSocketClient {
@@ -638,7 +637,9 @@ fn spawn_response_loop(mut reader: WsReader, inner: std::sync::Weak<WebSocketCli
                     let _ = sender.send(Ok(response));
                 }
                 PendingDispatch::Unrecognized { got_id } => {
-                    eprintln!("[repe] dropping websocket response for unrecognized request id {got_id}");
+                    eprintln!(
+                        "[repe] dropping websocket response for unrecognized request id {got_id}"
+                    );
                 }
             }
         }
@@ -656,10 +657,7 @@ fn decode_websocket_frame(frame: WsMessage) -> Result<Option<Message>, RepeError
     }
 }
 
-async fn fail_all_pending(
-    inner: &std::sync::Weak<WebSocketClientInner>,
-    err: RepeError,
-) {
+async fn fail_all_pending(inner: &std::sync::Weak<WebSocketClientInner>, err: RepeError) {
     let Some(inner_ref) = inner.upgrade() else {
         return;
     };
@@ -761,12 +759,9 @@ fn websocket_connect_error(err: tungstenite::Error) -> std::io::Error {
 fn websocket_transport_error(err: tungstenite::Error) -> RepeError {
     match err {
         tungstenite::Error::Io(io_err) => RepeError::Io(io_err),
-        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => {
-            RepeError::Io(std::io::Error::new(
-                ErrorKind::ConnectionAborted,
-                "websocket connection closed",
-            ))
-        }
+        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => RepeError::Io(
+            std::io::Error::new(ErrorKind::ConnectionAborted, "websocket connection closed"),
+        ),
         other => RepeError::Io(std::io::Error::other(other.to_string())),
     }
 }

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -6,7 +6,9 @@ use crate::server_request::route_request;
 use futures_util::{SinkExt, StreamExt};
 use std::io::ErrorKind;
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
-use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::handshake::server::{
+    Callback, ErrorResponse, Request, Response,
+};
 use tokio_tungstenite::tungstenite::{self, Message as WsMessage, http::StatusCode};
 use tokio_tungstenite::{WebSocketStream, accept_hdr_async};
 
@@ -93,14 +95,12 @@ async fn accept_repe_websocket(
     stream: TcpStream,
     expected_path: &str,
 ) -> Result<WebSocketStream<TcpStream>, RepeError> {
-    let expected = expected_path.to_owned();
-    accept_hdr_async(stream, move |request: &Request, response: Response| {
-        if request.uri().path() == expected {
-            Ok(response)
-        } else {
-            Err(path_not_found_response(request))
-        }
-    })
+    accept_hdr_async(
+        stream,
+        WebSocketPathValidator {
+            expected: expected_path.to_owned(),
+        },
+    )
     .await
     .map_err(websocket_transport_error)
 }
@@ -190,6 +190,25 @@ fn websocket_invalid_data_error(message: &str) -> RepeError {
     RepeError::Io(std::io::Error::new(ErrorKind::InvalidData, message))
 }
 
+struct WebSocketPathValidator {
+    expected: String,
+}
+
+impl Callback for WebSocketPathValidator {
+    #[allow(clippy::result_large_err)]
+    fn on_request(
+        self,
+        request: &Request,
+        response: Response,
+    ) -> Result<Response, ErrorResponse> {
+        if request.uri().path() == self.expected {
+            Ok(response)
+        } else {
+            Err(path_not_found_response(request))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,7 +247,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn websocket_proxy_forwards_raw_messages() {
-        let upstream_router = Router::new().with_json("/echo", |value| Ok(value));
+        let upstream_router = Router::new().with_json("/echo", Ok);
         let upstream_listener = crate::async_server::AsyncServer::listen(("127.0.0.1", 0))
             .await
             .unwrap();

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1,0 +1,265 @@
+use crate::async_client::AsyncClient;
+use crate::error::RepeError;
+use crate::message::Message;
+use crate::server::Router;
+use crate::server_request::route_request;
+use futures_util::{SinkExt, StreamExt};
+use std::io::ErrorKind;
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::{self, Message as WsMessage, http::StatusCode};
+use tokio_tungstenite::{WebSocketStream, accept_hdr_async};
+
+pub struct WebSocketServer {
+    router: Router,
+}
+
+impl WebSocketServer {
+    pub fn new(router: Router) -> Self {
+        Self { router }
+    }
+
+    pub async fn listen<A: ToSocketAddrs>(addr: A) -> std::io::Result<TcpListener> {
+        TcpListener::bind(addr).await
+    }
+
+    pub async fn serve<A: ToSocketAddrs>(self, addr: A, path: &str) -> std::io::Result<()> {
+        let listener = Self::listen(addr).await?;
+        self.serve_listener(listener, path).await
+    }
+
+    pub async fn serve_listener(
+        self,
+        listener: TcpListener,
+        path: &str,
+    ) -> std::io::Result<()> {
+        let expected_path = normalize_path(path);
+
+        loop {
+            let (stream, _addr) = listener.accept().await?;
+            let router = self.router.clone();
+            let expected_path = expected_path.clone();
+            tokio::spawn(async move {
+                match accept_repe_websocket(stream, &expected_path).await {
+                    Ok(ws_stream) => {
+                        if let Err(err) = handle_connection(ws_stream, router).await {
+                            eprintln!("[repe] websocket connection error: {err}");
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("[repe] websocket handshake error: {err}");
+                    }
+                }
+            });
+        }
+    }
+}
+
+pub async fn proxy_connection<S>(
+    ws_stream: WebSocketStream<S>,
+    upstream: AsyncClient,
+) -> Result<(), RepeError>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut writer, mut reader) = ws_stream.split();
+
+    loop {
+        let frame = match reader.next().await {
+            Some(Ok(frame)) => frame,
+            Some(Err(err)) => return Err(websocket_transport_error(err)),
+            None => break,
+        };
+
+        let request = match decode_request_frame(frame)? {
+            FrameAction::Message(message) => message,
+            FrameAction::Continue => continue,
+            FrameAction::Close => break,
+        };
+
+        if let Some(response) = upstream.forward_message(&request).await? {
+            writer
+                .send(WsMessage::Binary(response.to_vec()))
+                .await
+                .map_err(websocket_transport_error)?;
+        }
+    }
+
+    let _ = writer.send(WsMessage::Close(None)).await;
+    writer.close().await.map_err(websocket_transport_error)
+}
+
+async fn accept_repe_websocket(
+    stream: TcpStream,
+    expected_path: &str,
+) -> Result<WebSocketStream<TcpStream>, RepeError> {
+    let expected = expected_path.to_owned();
+    accept_hdr_async(stream, move |request: &Request, response: Response| {
+        if request.uri().path() == expected {
+            Ok(response)
+        } else {
+            Err(path_not_found_response(request))
+        }
+    })
+    .await
+    .map_err(websocket_transport_error)
+}
+
+async fn handle_connection(
+    ws_stream: WebSocketStream<TcpStream>,
+    router: Router,
+) -> Result<(), RepeError> {
+    let (mut writer, mut reader) = ws_stream.split();
+
+    loop {
+        let frame = match reader.next().await {
+            Some(Ok(frame)) => frame,
+            Some(Err(err)) => return Err(websocket_transport_error(err)),
+            None => break,
+        };
+
+        let request = match decode_request_frame(frame)? {
+            FrameAction::Message(message) => message,
+            FrameAction::Continue => continue,
+            FrameAction::Close => break,
+        };
+
+        if let Some(response) = route_request(&router, &request) {
+            writer
+                .send(WsMessage::Binary(response.to_vec()))
+                .await
+                .map_err(websocket_transport_error)?;
+        }
+    }
+
+    let _ = writer.send(WsMessage::Close(None)).await;
+    writer.close().await.map_err(websocket_transport_error)
+}
+
+enum FrameAction {
+    Message(Message),
+    Continue,
+    Close,
+}
+
+fn decode_request_frame(frame: WsMessage) -> Result<FrameAction, RepeError> {
+    match frame {
+        WsMessage::Binary(payload) => Message::from_slice_exact(&payload).map(FrameAction::Message),
+        WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => Ok(FrameAction::Continue),
+        WsMessage::Close(_) => Ok(FrameAction::Close),
+        WsMessage::Text(_) => Err(websocket_invalid_data_error(
+            "websocket transport requires binary messages",
+        )),
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    if path.is_empty() || path == "/" {
+        "/".to_string()
+    } else if path.starts_with('/') {
+        path.trim_end_matches('/').to_string()
+    } else {
+        format!("/{}", path.trim_end_matches('/'))
+    }
+}
+
+fn path_not_found_response(request: &Request) -> ErrorResponse {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Some(format!(
+            "REPE websocket endpoint not found: {}",
+            request.uri().path()
+        )))
+        .expect("valid handshake rejection response")
+}
+
+fn websocket_transport_error(err: tungstenite::Error) -> RepeError {
+    match err {
+        tungstenite::Error::Io(io_err) => RepeError::Io(io_err),
+        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => {
+            RepeError::Io(std::io::Error::new(
+                ErrorKind::ConnectionAborted,
+                "websocket connection closed",
+            ))
+        }
+        other => RepeError::Io(std::io::Error::other(other.to_string())),
+    }
+}
+
+fn websocket_invalid_data_error(message: &str) -> RepeError {
+    RepeError::Io(std::io::Error::new(ErrorKind::InvalidData, message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::websocket_client::WebSocketClient;
+    use serde_json::json;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_server_roundtrip() {
+        let router = Router::new().with_json("/mul", |value| {
+            let a = value.get("a").and_then(|v| v.as_i64()).unwrap_or_default();
+            let b = value.get("b").and_then(|v| v.as_i64()).unwrap_or_default();
+            Ok(json!({ "prod": a * b }))
+        });
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws_stream = accept_repe_websocket(stream, "/repe").await.unwrap();
+            handle_connection(ws_stream, router).await.unwrap();
+        });
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let out = client
+            .call_json("/mul", &json!({ "a": 6, "b": 7 }))
+            .await
+            .unwrap();
+        assert_eq!(out["prod"], 42);
+
+        drop(client);
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_proxy_forwards_raw_messages() {
+        let upstream_router = Router::new().with_json("/echo", |value| Ok(value));
+        let upstream_listener = crate::async_server::AsyncServer::listen(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let upstream_addr = upstream_listener.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            crate::async_server::AsyncServer::new(upstream_router)
+                .serve(upstream_listener)
+                .await
+                .unwrap();
+        });
+
+        let proxy_listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+        let proxy_task = tokio::spawn(async move {
+            let upstream = AsyncClient::connect(upstream_addr).await.unwrap();
+            let (stream, _) = proxy_listener.accept().await.unwrap();
+            let ws_stream = accept_repe_websocket(stream, "/repe").await.unwrap();
+            proxy_connection(ws_stream, upstream).await.unwrap();
+        });
+
+        let client = WebSocketClient::connect(&format!("ws://{proxy_addr}/repe"))
+            .await
+            .unwrap();
+        let out = client
+            .call_json("/echo", &json!({ "ok": true }))
+            .await
+            .unwrap();
+        assert_eq!(out, json!({ "ok": true }));
+
+        drop(client);
+        proxy_task.await.unwrap();
+        upstream_task.abort();
+    }
+}

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -30,11 +30,7 @@ impl WebSocketServer {
         self.serve_listener(listener, path).await
     }
 
-    pub async fn serve_listener(
-        self,
-        listener: TcpListener,
-        path: &str,
-    ) -> std::io::Result<()> {
+    pub async fn serve_listener(self, listener: TcpListener, path: &str) -> std::io::Result<()> {
         let expected_path = normalize_path(path);
 
         loop {
@@ -176,12 +172,9 @@ fn path_not_found_response(request: &Request) -> ErrorResponse {
 fn websocket_transport_error(err: tungstenite::Error) -> RepeError {
     match err {
         tungstenite::Error::Io(io_err) => RepeError::Io(io_err),
-        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => {
-            RepeError::Io(std::io::Error::new(
-                ErrorKind::ConnectionAborted,
-                "websocket connection closed",
-            ))
-        }
+        tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed => RepeError::Io(
+            std::io::Error::new(ErrorKind::ConnectionAborted, "websocket connection closed"),
+        ),
         other => RepeError::Io(std::io::Error::other(other.to_string())),
     }
 }
@@ -196,11 +189,7 @@ struct WebSocketPathValidator {
 
 impl Callback for WebSocketPathValidator {
     #[allow(clippy::result_large_err)]
-    fn on_request(
-        self,
-        request: &Request,
-        response: Response,
-    ) -> Result<Response, ErrorResponse> {
+    fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
         if request.uri().path() == self.expected {
             Ok(response)
         } else {

--- a/tests/async_client_format_apis.rs
+++ b/tests/async_client_format_apis.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{AsyncClient, BodyFormat, Message, QueryFormat, read_message, write_message};
 use serde::Deserialize;
 use serde_json::{Value, json};

--- a/tests/async_client_multiplexing.rs
+++ b/tests/async_client_multiplexing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{AsyncClient, Message, QueryFormat, RepeError, read_message, write_message};
 use serde_json::{Value, json};
 use std::io::{BufReader, BufWriter, Write};

--- a/tests/async_fleet_tests.rs
+++ b/tests/async_fleet_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 mod common;
 
 use common::{

--- a/tests/client_format_apis.rs
+++ b/tests/client_format_apis.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{BodyFormat, Client, Message, QueryFormat, read_message, write_message};
 use serde::Deserialize;
 use serde_json::{Value, json};

--- a/tests/client_id_mismatch.rs
+++ b/tests/client_id_mismatch.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::*;
 use serde::{Deserialize, Serialize};
 use std::io::{BufReader, BufWriter, Write};

--- a/tests/client_multiplexing.rs
+++ b/tests/client_multiplexing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{Client, Message, QueryFormat, RepeError, read_message, write_message};
 use serde_json::{Value, json};
 use std::io::{BufReader, BufWriter, Write};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{ErrorCode, Message, RepeError, read_message, write_message};
 use serde_json::{Value, json};
 use std::io::{BufReader, BufWriter, Write};

--- a/tests/fleet_tests.rs
+++ b/tests/fleet_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 mod common;
 
 use common::{

--- a/tests/json_pointer_tests.rs
+++ b/tests/json_pointer_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{eval_json_pointer, parse_json_pointer};
 use serde_json::json;
 

--- a/tests/registry_tests.rs
+++ b/tests/registry_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::{BodyFormat, ErrorCode, Message, QueryFormat, Registry, Router};
 use serde_json::{Value, json};
 use std::sync::Arc;

--- a/tests/repe_tests.rs
+++ b/tests/repe_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use repe::message::{create_error_message, create_error_response_like, create_response};
 use repe::*;
 

--- a/tests/struct_registration.rs
+++ b/tests/struct_registration.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 #![allow(unreachable_code)]
 
 use repe::constants::{ErrorCode, QueryFormat};

--- a/tests/uniudp_fleet_tests.rs
+++ b/tests/uniudp_fleet_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "fleet-udp")]
+#![cfg(all(not(target_arch = "wasm32"), feature = "fleet-udp"))]
 
 use repe::{FleetError, Message, UniUdpFleet, UniUdpNodeConfig};
 use serde_json::json;


### PR DESCRIPTION
## Summary
Add WebSocket transport support for REPE, including a native WebSocket client/server, a wasm browser client, and the crate refactors needed to make the shared protocol pieces compile on both native and `wasm32` targets.

## Changes From `main`
- Added a native `WebSocketClient` behind the `websocket` feature.
- Added a native `WebSocketServer` behind the `websocket` feature.
- Added `proxy_connection` support for forwarding full REPE `Message` values to an upstream `AsyncClient`.
- Added a `WasmClient` behind the `websocket-wasm` feature.
- Refactored crate exports and dependency gating so native TCP modules stay off `wasm32`, while shared protocol/types remain available on all targets.
- Extracted shared server request validation and routing into `src/server_request.rs` so TCP and WebSocket servers use the same handling path.
- Added exact-length WebSocket frame validation via `Message::from_slice_exact`, so bounded binary frames must match the REPE header length exactly.
- Gated existing native integration tests to `not(target_arch = "wasm32")` so wasm-target builds only compile wasm-relevant test targets.

## Testing
- `cargo check`
- `cargo check --features websocket`
- `cargo check --target wasm32-unknown-unknown --features websocket-wasm`
- `cargo test --features websocket`