### PR TITLE
Add `repe` command-line client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- `cli` feature and `repe` binary: command-line client for REPE servers. Auto-detects transport from `--url` (`ws://` / `wss://` use the WebSocket transport, anything else uses TCP, with a default port of 5099). Supports `get` / `set` / `call` / `notify` subcommands, plus a C++-tool-compatible inferred mode (`repe /path` reads, `repe /path '<json>'` writes). Install with `cargo install repe --features cli`.
+- `cli` feature and `repe` binary: command-line client for REPE servers. Auto-detects transport from `--url` (`ws://` / `wss://` use the WebSocket transport, anything else uses TCP, with a default port of 5099). Supports `get` / `set` / `call` / `notify` subcommands, plus an inferred mode (`repe /path` reads, `repe /path '<json>'` writes). Install with `cargo install repe --features cli`.
 - CLI body sources: pass `-` as the positional body to read from stdin, or `--body-file PATH` to read from a file. The two sources are mutually exclusive with each other and with a literal positional body.
 - CLI response decoding handles all body formats: JSON and BEVE responses are pretty-printed (or compacted with `--raw`), UTF-8 bodies are surfaced as JSON strings (or printed verbatim under `--raw`, so `repe --raw get /motd` behaves like a plain text fetch), and unparseable raw-binary responses are surfaced as a clear RPC error rather than an opaque decode failure.
 - `REPE_URL` environment variable as a default for `--url`, so repeated invocations against the same server can drop the flag. An explicit `--url` always overrides the env var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `cli` feature and `repe` binary: command-line client for REPE servers. Auto-detects transport from `--url` (`ws://` / `wss://` use the WebSocket transport, anything else uses TCP, with a default port of 5099). Supports `get` / `set` / `call` / `notify` subcommands, plus a C++-tool-compatible inferred mode (`repe /path` reads, `repe /path '<json>'` writes). Install with `cargo install repe --features cli`.
+- CLI body sources: pass `-` as the positional body to read from stdin, or `--body-file PATH` to read from a file. The two sources are mutually exclusive with each other and with a literal positional body.
+- CLI response decoding handles all body formats: JSON and BEVE responses are pretty-printed (or compacted with `--raw`), UTF-8 bodies are surfaced as JSON strings (or printed verbatim under `--raw`, so `repe --raw get /motd` behaves like a plain text fetch), and unparseable raw-binary responses are surfaced as a clear RPC error rather than an opaque decode failure.
+- `REPE_URL` environment variable as a default for `--url`, so repeated invocations against the same server can drop the flag. An explicit `--url` always overrides the env var.
+- `repe completions <shell>` subcommand emits a clap-derived completion script for `bash`, `zsh`, `fish`, `elvish`, or `powershell`. Runs locally with no server or runtime.
+- `tests/cli.rs` end-to-end coverage of the binary against an in-process registry-backed `AsyncServer` and `WebSocketServer`, exercising every subcommand, raw output, stdin/`--body-file` body sources, the body-source conflict rule, both error-exit paths, `--timeout` enforcement, BEVE response decoding, `REPE_URL` precedence, and the completions subcommand.
+
+### Fixed
+- Bare bracketed IPv6 literals in `--url` (`[::1]`) now have the default port `:5099` appended, matching the IPv4 hostname behavior. Previously they were left untouched and produced invalid socket addresses.
+- `--` is now an explicit opt-out from inferred mode: `repe -- /foo` no longer rewrites to `repe -- get /foo` (which clap would then misparse), it leaves argv untouched.
+- `--timeout` is now honored by `notify`. The flag was previously declared global but had no plumbing through to `Transport::notify`, so `repe --timeout 1 notify /x '{}'` silently ignored the bound.
+- `--timeout` rejects negative and non-finite values (NaN, `+/-inf`) with a clear usage error instead of silently clamping to zero (which then fired immediately).
+- `--body-file` is rejected for `get` before the connect attempt, so misconfigured invocations against an unreachable server surface the usage error instead of the connect failure.
+
+### Notes
+- CLI bodies are validated as syntactically-valid JSON client-side before the request is sent. Semantic validation (does this value match the schema for `/foo`?) remains the server's responsibility.
+
 ## [2.2.0] - 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +148,61 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -262,6 +367,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +426,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -409,6 +526,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
@@ -602,6 +725,8 @@ name = "repe"
 version = "2.3.0"
 dependencies = [
  "beve",
+ "clap",
+ "clap_complete",
  "futures-channel",
  "futures-util",
  "js-sys",
@@ -768,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1044,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ websocket-wasm = [
     "dep:wasm-bindgen-futures",
     "dep:web-sys",
 ]
+cli = ["websocket", "dep:clap", "dep:clap_complete"]
+
+[[bin]]
+name = "repe"
+path = "src/bin/repe.rs"
+required-features = ["cli"]
 
 [dependencies]
 beve = "0.1"
@@ -43,6 +49,8 @@ parking_lot = { version = "0.12", optional = true }
 uniudp = { version = "1.0.0", optional = true }
 futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
+clap = { version = "4", features = ["derive", "env"], optional = true }
+clap_complete = { version = "4", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time", "io-util", "sync"] }

--- a/README.md
+++ b/README.md
@@ -176,6 +176,99 @@ Feature flags
 - `websocket-wasm` - browser `WasmClient` on `wasm32-unknown-unknown`
 - `fleet-udp` - UDP fanout support via `UniUdpFleet`
 - `parking-lot` - `Lockable` support for `parking_lot::Mutex` / `RwLock`
+- `cli` - build the `repe` command-line client (pulls in `clap` and the `websocket` feature)
+
+Command-line client
+
+Enable the `cli` feature to build a `repe` binary that talks to any REPE server
+over TCP or WebSocket:
+
+```
+cargo install repe --features cli
+```
+
+Transport is auto-detected from `--url`. `ws://` and `wss://` URLs use the
+WebSocket transport; anything else (including bare `host` or `host:port`) uses
+TCP. The default port is 5099.
+
+```
+repe --url 127.0.0.1:8082 get /counter
+repe --url 127.0.0.1:8082 set /counter 42
+repe --url 127.0.0.1:8082 call /add '{"a":1,"b":2}'
+repe --url ws://127.0.0.1:8081/repe call /echo '"hello"'
+```
+
+A bare path triggers the C++-tool-compatible inferred mode: `repe /path` reads
+(empty body, response printed) and `repe /path '<json>'` writes (JSON body,
+response suppressed). Run `repe --help` for the full subcommand list,
+`--raw`/`--timeout` flags, and exit codes (`0` success, `1` connection or
+usage error, `2` server-returned RPC error).
+
+For larger or piped payloads, pass `-` as the positional body to read from
+stdin, or `--body-file PATH` to read from a file. The three body sources are
+mutually exclusive.
+
+```
+echo '{"a":3,"b":4}' | repe call /api/v1/add -
+repe set /api/v1/config --body-file config.json
+```
+
+JSON bodies are validated client-side as syntactically valid JSON before the
+request is sent, so a typo gets a parse error locally rather than a round-trip
+to the server. Semantic validation (does this value match the schema for
+`/foo`?) remains the server's responsibility.
+
+Responses are decoded uniformly across body formats: JSON and BEVE bodies are
+both rendered as pretty-printed JSON (or compact with `--raw`), UTF-8 bodies
+become JSON strings, and unparseable raw-binary responses surface as an RPC
+error rather than a silent decode failure.
+
+Set `REPE_URL` in your environment to skip `--url` for repeated calls against
+the same server:
+
+```
+export REPE_URL=ws://127.0.0.1:8081/repe
+repe get /api/v1/counter
+repe set /api/v1/counter 42
+```
+
+An explicit `--url` flag always overrides `REPE_URL`.
+
+Generate shell completions with `repe completions <shell>` (where `<shell>` is
+one of `bash`, `zsh`, `fish`, `elvish`, or `powershell`); pipe the output into
+the location your shell expects, e.g. `repe completions zsh > ~/.zsh/_repe`.
+
+JSON Pointer paths
+
+Method paths follow [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901):
+each `/`-separated segment names a step into the server's value tree, so
+`/api/v1/counter` reaches the field `counter` inside the object `v1` inside the
+object `api`. The empty path `""` (or just `/`) refers to the root. Two
+characters need escaping inside a segment: `~` becomes `~0` and `/` becomes
+`~1`. Most REPE servers expose a flat namespace where the path is just a
+function or value name, but registry-backed servers may nest values arbitrarily
+deep.
+
+Troubleshooting
+
+- **`tcp connect to … failed: Connection refused`** — nothing is listening on
+  that host:port. Check that the server is running and that `REPE_URL` /
+  `--url` point at the right endpoint.
+- **`websocket connect to … failed`** — same idea, plus the server's WebSocket
+  path must match (registry servers usually mount under something like
+  `/repe`). The path is the part after `host:port` in the URL.
+- **`server error (Method not found): Method not found: /foo`** — the server
+  does not have a handler at that path. Registry-backed servers prefix all
+  routes with their mount point, so `/foo` may need to be `/api/v1/foo`.
+- **`server error (Invalid body): Expected JSON body`** — the server's handler
+  required a body but the CLI sent none (this is the typical failure when
+  `repe /path` is used against a function endpoint). Use `repe call /path '{}'`
+  instead, or pass an explicit body.
+- **`invalid JSON body: …`** — client-side parse error before any bytes hit
+  the wire. Quote your JSON properly; on most shells single quotes are
+  safest: `repe call /add '{"a":1,"b":2}'`.
+- **`request … timed out after Nms`** — the server didn't respond inside the
+  `--timeout` window. Either raise `--timeout` or remove it.
 
 WebSocket transport
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
 # repe-rs
 
-Rust implementation of the REPE RPC protocol with JSON and BEVE body support.
+Rust implementation of the [REPE RPC protocol](https://github.com/repe-org/REPE) with JSON and BEVE body support.
 
-- Spec reference: <https://github.com/repe-org/REPE>
-- Crate: [repe on crates.io](https://crates.io/crates/repe)
+[![crates.io](https://img.shields.io/crates/v/repe.svg)](https://crates.io/crates/repe)
 
-This crate provides:
+## Features
 
-- REPE header and message types with correct little-endian encoding
-- Message encode/decode to/from bytes and I/O helpers for streams
-- JSON body helpers using `serde`/`serde_json`
-- BEVE binary body helpers via the [`beve`](https://crates.io/crates/beve) crate
-- Dynamic registry routing with JSON Pointer semantics
-- Error codes and formats aligned with the spec
-- Optional native WebSocket transport (`websocket` feature)
-- Optional browser WebSocket transport for wasm (`websocket-wasm` feature)
+- REPE header and message types with correct little-endian wire encoding.
+- Streaming and zero-copy I/O (`MessageView`, `write_message_streaming`) for large bodies.
+- JSON bodies via `serde_json`; BEVE bodies via the [`beve`](https://crates.io/crates/beve) crate.
+- Sync and async (tokio) clients and servers, with multiplexed in-flight requests, per-call timeouts, batching, and notify support.
+- Dynamic [`Registry`](https://github.com/repe-org/repe-rs/blob/main/docs/registry.md) routing with JSON Pointer semantics.
+- [`Fleet`](https://github.com/repe-org/repe-rs/blob/main/docs/fleet.md) APIs for multi-node TCP and UDP fanout.
+- Optional [WebSocket transport](https://github.com/repe-org/repe-rs/blob/main/docs/websocket.md), including a wasm browser client and server-pushed notify subscriptions.
+- Optional [`stream`](https://github.com/repe-org/repe-rs/blob/main/docs/streaming.md) module for backpressure-controlled bulk transfers with reconnect-resume.
+- Optional [`repe` CLI](https://github.com/repe-org/repe-rs/blob/main/docs/cli.md) for talking to any REPE server over TCP or WebSocket.
 
-Installation
+## Installation
 
 Add to your `Cargo.toml`:
 
-```
+```toml
 [dependencies]
-repe = "1.1"
+repe = "2.3"
 ```
 
-> Tip: run `cargo add repe` to automatically pull the latest compatible release.
+Or run `cargo add repe`.
 
-Quick start
+## Quick Start
+
+Build, serialize, and parse a JSON message:
 
 ```rust
-use repe::{Message, QueryFormat, BodyFormat};
+use repe::{BodyFormat, Message, QueryFormat};
 
-// Build a JSON message
 let msg = Message::builder()
     .id(42)
     .query_str("/status")
@@ -40,7 +41,6 @@ let msg = Message::builder()
     .body_json(&serde_json::json!({"ping": true}))?
     .build();
 
-// Serialize to bytes and back
 let bytes = msg.to_vec();
 let parsed = repe::Message::from_slice(&bytes)?;
 
@@ -48,754 +48,58 @@ assert_eq!(parsed.header.id, 42);
 assert_eq!(parsed.header.body_format, BodyFormat::Json as u16);
 let val: serde_json::Value = parsed.json_body()?;
 assert_eq!(val["ping"], true);
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+Replace `body_json` with `body_beve` to encode the body with BEVE; everything else is identical.
+
+## Server and Client
+
+A minimal TCP server with one route, plus a client call:
 
 ```rust
-use repe::{Message, QueryFormat, BodyFormat};
-
-// Build a BEVE message
-let msg = Message::builder()
-    .id(43)
-    .query_str("/status")
-    .query_format(QueryFormat::JsonPointer)
-    .body_beve(&serde_json::json!({"ping": true}))?
-    .build();
-
-let bytes = msg.to_vec();
-let parsed = repe::Message::from_slice(&bytes)?;
-
-assert_eq!(parsed.header.body_format, BodyFormat::Beve as u16);
-let val: serde_json::Value = parsed.beve_body()?;
-assert_eq!(val["ping"], true);
-```
-
-Streaming and zero-copy I/O
-
-For large bodies (e.g. multi-MiB binary chunks), `Message::to_vec` /
-`Message::from_slice` add a full-body memcpy you may not want. The streaming
-APIs below let the body flow directly between the wire and a user-supplied
-encoder/decoder.
-
-```rust
-use repe::{write_message_streaming, BodyFormat, Header, QueryFormat};
-use std::io::Write;
-
-// Send: BEVE-encode a body straight into the writer with no intermediate Vec.
-let mut header = Header::new();
-header.id = 99;
-header.query_format = QueryFormat::JsonPointer as u16;
-header.body_format = BodyFormat::Beve as u16;
-let body_len = beve_chunk_size(&chunk); // computed up front
-
-write_message_streaming(&mut socket, header, b"/collect/file_chunk", body_len, |w| {
-    beve::to_writer_streaming(w, &chunk).map_err(std::io::Error::other)
-})?;
-```
-
-```rust
-use repe::MessageView;
-
-// Receive: borrow into the WS frame buffer instead of copying out of it.
-let view = MessageView::from_slice(&frame_bytes)?;
-let path = view.query_str()?;
-// view.body is &[u8] pointing inside frame_bytes; pair with serde_bytes::Bytes<'a>
-// on a Deserialize struct to keep the chunk payload borrowed end-to-end.
-```
-
-`Message::write_to` and `Message::serialized_len` are the owned-`Message`
-counterparts: emit a `Message` to a `Write` without going through `to_vec`,
-or query its wire size in `O(1)`.
-
-Peer-aware handlers
-
-When a handler needs to push more than one message back to the calling
-client (e.g. server-pushed file chunks after a single `/run_collection`
-call), it needs a typed handle to that specific connection. `PeerSink` /
-`PeerHandle` / `CallContext` provide that handle; `Registry::dispatch_with_ctx`
-threads it through to handlers.
-
-Repe-rs's built-in TCP/WebSocket servers do not yet construct `PeerHandle`s
-themselves. Embedders that want peer routing wire their own `PeerSink`
-(typically a bounded channel drained by a writer task) against their
-server's outbound side.
-
-```rust
-use repe::{
-    CallContext, NotifyBody, PeerHandle, PeerId, PeerSendError, PeerSink,
-    Registry, WithContext,
-};
-use serde_json::{json, Value};
-use std::sync::Arc;
-
-// Implement PeerSink against your server's outbound mechanism.
-struct OutboundChannel(/* tx: mpsc::Sender<...> */);
-impl PeerSink for OutboundChannel {
-    fn send_notify(&self, _method: &str, _body: NotifyBody) -> Result<(), PeerSendError> {
-        // push a notify Message onto the peer's outbound queue.
-        Ok(())
-    }
-}
-
-// Register a context-aware handler. WithContext is the marker that opts
-// into the &CallContext parameter; plain Fn(Option<Value>) -> Result<...>
-// closures keep working unchanged.
-let registry = Registry::new();
-registry.register_function("/run", WithContext(|ctx: &CallContext, _params| {
-    if let Some(peer) = ctx.peer() {
-        peer.send_notify("/progress", NotifyBody::Json(b"{\"step\":1}".to_vec())).ok();
-    }
-    Ok::<_, (repe::ErrorCode, String)>(json!({"status": "ok"}))
-})).unwrap();
-
-// At dispatch time, build a CallContext for the calling peer and invoke
-// dispatch_with_ctx. Plain dispatch() supplies CallContext::detached.
-let peer = PeerHandle::new(PeerId(1), Arc::new(OutboundChannel(/* ... */)));
-let ctx = CallContext::new("/run", &peer);
-let _ = registry.dispatch_with_ctx("/run", Some(json!({})), &ctx);
-```
-
-Examples
-
-- `examples/json_roundtrip.rs` – construct/serialize/parse a JSON message.
-- `examples/server.rs` – run a JSON-pointer server (TCP).
-- `examples/client.rs` – call the server routes.
-- `examples/registry_server.rs` – serve a dynamic registry under a path prefix.
-- `examples/registry_roundtrip.rs` – local registry READ/WRITE/CALL roundtrip.
-- `examples/async_server.rs` – tokio-based async server.
-- `examples/async_client.rs` – tokio-based async client.
-
-Notes
-
-- BEVE helpers encode/decode via serde, so your existing request/response types continue to work.
-- The header `reserved` field is validated and must be zero.
-- The header length is validated to be `48 + query_length + body_length`.
-
-Feature flags
-
-- `websocket` - native `WebSocketClient`, `WebSocketServer`, and `proxy_connection`
-- `websocket-wasm` - browser `WasmClient` on `wasm32-unknown-unknown`
-- `fleet-udp` - UDP fanout support via `UniUdpFleet`
-- `parking-lot` - `Lockable` support for `parking_lot::Mutex` / `RwLock`
-- `cli` - build the `repe` command-line client (pulls in `clap` and the `websocket` feature)
-
-Command-line client
-
-Enable the `cli` feature to build a `repe` binary that talks to any REPE server
-over TCP or WebSocket:
-
-```
-cargo install repe --features cli
-```
-
-Transport is auto-detected from `--url`. `ws://` and `wss://` URLs use the
-WebSocket transport; anything else (including bare `host` or `host:port`) uses
-TCP. The default port is 5099.
-
-```
-repe --url 127.0.0.1:8082 get /counter
-repe --url 127.0.0.1:8082 set /counter 42
-repe --url 127.0.0.1:8082 call /add '{"a":1,"b":2}'
-repe --url ws://127.0.0.1:8081/repe call /echo '"hello"'
-```
-
-A bare path triggers the C++-tool-compatible inferred mode: `repe /path` reads
-(empty body, response printed) and `repe /path '<json>'` writes (JSON body,
-response suppressed). Run `repe --help` for the full subcommand list,
-`--raw`/`--timeout` flags, and exit codes (`0` success, `1` connection or
-usage error, `2` server-returned RPC error).
-
-For larger or piped payloads, pass `-` as the positional body to read from
-stdin, or `--body-file PATH` to read from a file. The three body sources are
-mutually exclusive.
-
-```
-echo '{"a":3,"b":4}' | repe call /api/v1/add -
-repe set /api/v1/config --body-file config.json
-```
-
-JSON bodies are validated client-side as syntactically valid JSON before the
-request is sent, so a typo gets a parse error locally rather than a round-trip
-to the server. Semantic validation (does this value match the schema for
-`/foo`?) remains the server's responsibility.
-
-Responses are decoded uniformly across body formats: JSON and BEVE bodies are
-both rendered as pretty-printed JSON (or compact with `--raw`), UTF-8 bodies
-become JSON strings, and unparseable raw-binary responses surface as an RPC
-error rather than a silent decode failure.
-
-Set `REPE_URL` in your environment to skip `--url` for repeated calls against
-the same server:
-
-```
-export REPE_URL=ws://127.0.0.1:8081/repe
-repe get /api/v1/counter
-repe set /api/v1/counter 42
-```
-
-An explicit `--url` flag always overrides `REPE_URL`.
-
-Generate shell completions with `repe completions <shell>` (where `<shell>` is
-one of `bash`, `zsh`, `fish`, `elvish`, or `powershell`); pipe the output into
-the location your shell expects, e.g. `repe completions zsh > ~/.zsh/_repe`.
-
-JSON Pointer paths
-
-Method paths follow [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901):
-each `/`-separated segment names a step into the server's value tree, so
-`/api/v1/counter` reaches the field `counter` inside the object `v1` inside the
-object `api`. The empty path `""` (or just `/`) refers to the root. Two
-characters need escaping inside a segment: `~` becomes `~0` and `/` becomes
-`~1`. Most REPE servers expose a flat namespace where the path is just a
-function or value name, but registry-backed servers may nest values arbitrarily
-deep.
-
-Troubleshooting
-
-- **`tcp connect to … failed: Connection refused`** — nothing is listening on
-  that host:port. Check that the server is running and that `REPE_URL` /
-  `--url` point at the right endpoint.
-- **`websocket connect to … failed`** — same idea, plus the server's WebSocket
-  path must match (registry servers usually mount under something like
-  `/repe`). The path is the part after `host:port` in the URL.
-- **`server error (Method not found): Method not found: /foo`** — the server
-  does not have a handler at that path. Registry-backed servers prefix all
-  routes with their mount point, so `/foo` may need to be `/api/v1/foo`.
-- **`server error (Invalid body): Expected JSON body`** — the server's handler
-  required a body but the CLI sent none (this is the typical failure when
-  `repe /path` is used against a function endpoint). Use `repe call /path '{}'`
-  instead, or pass an explicit body.
-- **`invalid JSON body: …`** — client-side parse error before any bytes hit
-  the wire. Quote your JSON properly; on most shells single quotes are
-  safest: `repe call /add '{"a":1,"b":2}'`.
-- **`request … timed out after Nms`** — the server didn't respond inside the
-  `--timeout` window. Either raise `--timeout` or remove it.
-
-WebSocket transport
-
-- Each REPE message maps to exactly one WebSocket binary message.
-- WebSocket decoding enforces exact message length within each bounded binary frame.
-
-```rust
-use repe::WebSocketClient;
+use repe::{Client, Router, Server};
 use serde_json::json;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = WebSocketClient::connect("ws://127.0.0.1:8081/repe").await?;
-    let pong = client.call_json("/ping", &json!({})).await?;
-    assert_eq!(pong["pong"], true);
-    Ok(())
-}
-```
-
-Receiving server-pushed notifies
-
-`WebSocketClient::subscribe_notifies()` returns a tokio mpsc receiver
-that yields every inbound `Message` whose `notify` header flag is set.
-The response loop checks the notify flag *before* the request/response
-correlation map, so server-pushed notifies never collide with an
-in-flight request that happens to share the same id.
-
-At most one subscriber may be active at a time. If a live subscription
-already exists, `subscribe_notifies` returns `Err(AlreadySubscribed)`
-without disturbing the existing receiver; this matters because
-`WebSocketClient` is `Clone`, and the loud-replace contract keeps two
-holders of the same client from silently stealing each other's
-subscription. Call `unsubscribe_notifies()` first to take over. A
-stale slot whose receiver was already dropped does not block a new
-subscription; in that case `subscribe_notifies` silently installs the
-new sender.
-
-Notifies that arrive while no subscriber is registered are silently
-dropped (logging every drop would avalanche under high-rate notifies
-like server-pushed binary chunks).
-
-The channel is unbounded. The transport read loop pushes every
-inbound notify into the channel without backpressure, so a slow or
-stalled consumer plus a high-rate producer will grow the buffer until
-the process OOMs. Application-level backpressure (e.g. ACK windows in
-a chunk protocol) is the right fix; the consumer must drain the
-receiver promptly. The API deliberately does not offer a bounded
-variant: dropping notifies on overflow corrupts chunk streams, and
-blocking the read loop on overflow stalls the request/response
-correlation path that shares the same socket.
-
-The receiver yields raw `Message` values; decode the body using
-`Message::json_body::<T>()`, `beve::from_slice(&msg.body)`, or
-`MessageView::from_slice(&frame_bytes)` as appropriate for the wire
-`body_format`.
-
-```rust
-use repe::WebSocketClient;
-use serde_json::Value;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = WebSocketClient::connect("ws://127.0.0.1:8081/repe").await?;
-    let mut notifies = client.subscribe_notifies()?;
-    tokio::spawn(async move {
-        while let Some(msg) = notifies.recv().await {
-            let path = msg.query_str().unwrap_or("");
-            let body: Value = msg.json_body().unwrap_or(Value::Null);
-            println!("notify {path}: {body}");
-        }
-    });
-    let _ = client.call_json("/start", &serde_json::json!({})).await?;
-    Ok(())
-}
-```
-
-Streaming large payloads with backpressure (`repe::stream`)
-
-When you need to push multi-GB blobs (capture files, log streams,
-paginated query results) from the server to a peer over notify
-messages, the bare notify primitive doesn't give you flow control
-or reconnect-resume. The `repe::stream` module adds three pieces:
-
-- **ACK-driven window credit.** The producer waits before sending if
-  the receiver is more than `window_bytes` behind on ACKs; an ACK
-  releases the window and unparks the producer. Defaults to 64 MiB.
-- **Idle watchdog.** A transfer that has gone silent for longer than
-  `idle_timeout` (default 60 s) is force-cancelled.
-- **Replay ring + reconnect.** Each emitted body lands in a
-  byte-bounded ring (default 64 MiB). On a brief disconnect the
-  producer parks; an inbound resume handler validates a
-  `last_received_offset` against the ring and swaps in the new peer,
-  after which the producer replays the ring tail and continues.
-
-The wire shape (`transfer_begin`, chunk body fields, ACK / cancel /
-resume bodies) is up to you: this module only deals in offsets,
-ACKs, and opaque body bytes. See `TransferControl`,
-`TransferRegistry<K>`, and `spawn_watchdog` for the full surface.
-The soul-rs `WsSink` is a worked example of an embedding.
-
-Sketch (treats `make_peer()` as your embedder-supplied function that
-hands out a `PeerHandle` for each accepted connection):
-
-```rust
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use repe::{NotifyBody, PeerSendError, ReconnectOutcome,
-    TransferControl, TransferRegistry, spawn_watchdog};
-
-#[derive(Hash, Eq, PartialEq, Copy, Clone)]
-struct TransferId(u64);
-
-let registry: Arc<TransferRegistry<TransferId>> = Arc::new(TransferRegistry::new());
-spawn_watchdog(Arc::clone(&registry), Duration::from_secs(60));
-
-let peer = make_peer();           // your embedder-side PeerHandle factory
-let control = TransferControl::new(64 * 1024 * 1024);
-control.set_peer(peer);
-registry.register(TransferId(1), Arc::clone(&control));
-
-// Producer: for each chunk, gate on credit, push to ring, send,
-// on disconnect park for resume.
-let chunk_offset: u64 = 0;
-let chunk_len: u64 = 4 * 1024 * 1024;
-let body: Vec<u8> = body_for_chunk(chunk_offset);
-
-control.wait_for_credit(chunk_len, Instant::now() + Duration::from_secs(30))?;
-control.push_replay(chunk_offset, false, body.clone());
-let p = control.peer().expect("peer installed");
-match p.send_notify("/file_chunk", NotifyBody::Beve(body)) {
-    Ok(()) => control.record_sent(chunk_offset + chunk_len),
-    Err(PeerSendError::Disconnected) => match control.wait_for_reconnect(Duration::from_secs(30)) {
-        ReconnectOutcome::ResumeReady => {
-            let resume = control.take_pending_resume().unwrap();
-            // request_resume installed the new peer into the slot;
-            // read it back via control.peer() and replay every
-            // ring chunk at offset >= resume.resume_at_offset.
-        }
-        ReconnectOutcome::Cancelled(_) | ReconnectOutcome::Timeout => { /* abort */ }
-    },
-    Err(_) => { /* application policy */ }
-}
-
-// Inbound handlers (run in your existing dispatch path):
-//   ack:    registry.get(id).map(|c| c.record_ack(file_index, offset));
-//   cancel: registry.get(id).map(|c| c.cancel("client cancelled"));
-//   resume: registry.get(id).and_then(|c|
-//             c.request_resume(new_peer, file_index, offset).ok());
-```
-
-JSON Pointer Routing and Typed Handlers
-
-- Router keys are JSON Pointer paths (e.g., `/ping`, `/echo`, `/status`). Raw-binary queries are rejected with an explicit `Invalid query` error.
-- Add JSON Value handlers with `.with("/path", |v: serde_json::Value| -> Result<Value, (ErrorCode,String)>)`.
-- Add typed handlers with `.with_typed("/path", |req: T| -> Result<R, (ErrorCode,String)>)` where `T: Deserialize`, `R: Serialize`.
-  - Typed handlers auto-deserialize JSON, UTF-8, or BEVE bodies into `T`. Responses default to JSON.
-  - Wrap the return value with `TypedResponse::beve(...)` / `TypedResponse::utf8(...)` / etc. to pick a different response [`BodyFormat`].
-  - If a body arrives with an unsupported format for typed handlers, the server returns `Invalid body`.
-- Attach pre-request middleware with `.with_middleware(|req, next| { /* auth/logging */ next.run(req) })` to centralize auth, validation, or tracing without hand-wrapping handlers.
-
-- Implement the pluggable trait `JsonTypedHandler` to attach methods from a service type:
-
-```rust
-use repe::{Router, JsonTypedHandler, ErrorCode};
-use serde::{Deserialize, Serialize};
-
-#[derive(Deserialize)]
-struct Input { name: String }
-#[derive(Serialize)]
-struct Output { greeting: String }
-
-struct Greeter;
-impl JsonTypedHandler for Greeter {
-    type In = Input;
-    type Out = Output;
-    fn call(&self, input: Self::In) -> Result<Self::Out, (ErrorCode, String)> {
-        Ok(Output { greeting: format!("Hello, {}!", input.name) })
-    }
-}
-
-let router = Router::new().with_handler("/greet", Greeter);
-```
-
-Async (tokio)
-
-- Use `AsyncServer` and `AsyncClient` for asynchronous operation with tokio.
-- See `examples/async_server.rs` and `examples/async_client.rs`.
-
-Fleet (Multi-Node Control)
-
-- Use `Fleet` / `AsyncFleet` to manage multiple TCP REPE servers as one logical unit.
-- Use `UniUdpFleet` for fire-and-forget UDP fanout (enable with `--features fleet-udp`).
-- TCP retry policy retries transport/I/O failures only; application-level server errors are returned without retry.
-- See [docs/fleet.md](docs/fleet.md) for complete API details.
-
-```rust
-use repe::{Fleet, FleetOptions, NodeConfig, RetryPolicy};
-use serde_json::json;
-use std::time::Duration;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let fleet = Fleet::with_options(
-        vec![
-            NodeConfig::new("127.0.0.1", 8081)?
-                .with_name("node-1")?
-                .with_tags(["compute"]),
-            NodeConfig::new("127.0.0.1", 8082)?
-                .with_name("node-2")?
-                .with_tags(["compute", "primary"]),
-        ],
-        FleetOptions {
-            default_timeout: Duration::from_secs(2),
-            retry_policy: RetryPolicy {
-                max_attempts: 3,
-                delay: Duration::from_millis(100),
-            },
-        },
-    )?;
-
-    let _ = fleet.connect_all();
-    let status = fleet.broadcast_json("/status", None, &[] as &[&str]);
-    let total = fleet.map_reduce_json(
-        "/compute",
-        Some(&json!({"value": 10})),
-        &["compute"],
-        |results| {
-            results
-                .into_iter()
-                .filter_map(|r| r.value.and_then(|v| v["result"].as_i64()))
-                .sum::<i64>()
-        },
-    );
-    println!("total={total}, nodes={}", status.len());
-    Ok(())
-}
-```
-
-```rust
-use repe::{AsyncFleet, FleetOptions, NodeConfig, RetryPolicy};
-use serde_json::json;
-use std::time::Duration;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let fleet = AsyncFleet::with_options(
-        vec![NodeConfig::new("127.0.0.1", 8081)?.with_name("node-1")?],
-        FleetOptions {
-            default_timeout: Duration::from_secs(2),
-            retry_policy: RetryPolicy {
-                max_attempts: 3,
-                delay: Duration::from_millis(100),
-            },
-        },
-    )?;
-
-    let _ = fleet.connect_all().await;
-    let res = fleet
-        .call_json("node-1", "/status", Some(&json!({})))
-        .await?;
-    assert!(res.succeeded());
-    Ok(())
-}
-```
-
-```rust
-use repe::{UniUdpFleet, UniUdpNodeConfig};
-use serde_json::json;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let fleet = UniUdpFleet::new(vec![
-        UniUdpNodeConfig::new("127.0.0.1", 5001)?
-            .with_name("edge-a")?
-            .with_tags(["edge"]),
-        UniUdpNodeConfig::new("127.0.0.1", 5002)?
-            .with_name("edge-b")?
-            .with_tags(["edge"]),
-    ])?;
-
-    let sent = fleet.send_notify("/heartbeat", Some(&json!({"source": "controller"})), &["edge"]);
-    assert!(sent.values().all(|result| result.succeeded()));
-    Ok(())
-}
-```
-
-Server
-
-- Build a router and serve TCP:
-
-```rust
-use repe::{Router, Server};
-use serde_json::json;
-use std::time::Duration;
-
-let router = Router::new()
-    .with_middleware(|req, next| {
-        if let Ok(path) = req.query_str() {
-            println!("incoming request for {path}");
-        }
-        next.run(req)
-    })
-    .with("/ping", |_v| Ok(json!({"pong": true})))
-    .with("/echo", |v| Ok(json!({"echo": v})))
-    .with("/status", |_v| Ok(json!({"status": "ok"})));
-
-let server = Server::new(router)
-    .read_timeout(Some(Duration::from_secs(120)))
-    .write_timeout(Some(Duration::from_secs(120)));
-let listener = server.listen("127.0.0.1:8081")?;
-server.serve(listener)?;
-```
-
-- Register a struct and expose its fields/methods through JSON pointer paths:
-
-```rust
-use repe::Router;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-#[derive(Default, Serialize, Deserialize, repe::RepeStruct)]
-#[repe(methods(
-    greet(&self) -> String,
-    set_status(&mut self, new_status: String) -> (),
-    reset_metrics(&mut self) -> ()
-))]
-struct Device {
-    id: String,
-    status: String,
-    #[repe(nested)]
-    metrics: Metrics,
-}
-
-#[derive(Default, Serialize, Deserialize, repe::RepeStruct)]
-struct Metrics {
-    temperature: f64,
-    humidity: f64,
-}
-
-impl Device {
-    fn greet(&self) -> String {
-        format!("device {} reporting {}", self.id, self.status)
-    }
-
-    fn set_status(&mut self, new_status: String) {
-        self.status = new_status;
-    }
-
-    fn reset_metrics(&mut self) {
-        self.metrics = Metrics::default();
-    }
-}
-
-let mut router = Router::new();
-let device_handle = router.register_struct("/device", Device::default());
-
-// Update initial state before serving.
-{
-    let mut device = device_handle.lock().unwrap();
-    device.id = "sensor-42".into();
-    device.status = "online".into();
-    device.metrics.temperature = 21.5;
-    device.metrics.humidity = 0.55;
-}
-
-// Example calls (JSON Pointer paths):
-// - `/device/greet` -> "device sensor-42 reporting online"
-// - `/device/status` with body "offline" writes the field and returns null
-// - `/device/metrics/temperature` reads the nested value (21.5)
-// - `/device/reset_metrics` zeroes out the metrics
-
-Router handles `Arc<L>` for any lock implementing `repe::Lockable<T>`, so you can swap in
-`tokio::sync::Mutex`/`RwLock` (via their `blocking_*` APIs) or enable the optional
-`parking-lot` feature to use `parking_lot::Mutex`/`RwLock` without extra wrapper types.
-```
-
-Registry (Dynamic Routing)
-
-- Mount a `Registry` on any path prefix with `Router::with_registry("/api/v1", registry)`.
-- Registry request semantics:
-  - Empty body => READ value.
-  - Non-empty body + function target => CALL function.
-  - Non-empty body + non-function target => WRITE value.
-- See [docs/registry.md](docs/registry.md) for full behavior, format decoding details, and client examples.
-
-```rust
-use repe::{ErrorCode, Registry, Router, Server};
-use serde_json::{Value, json};
-use std::sync::Arc;
-
-let registry = Arc::new(Registry::new());
-registry.register_value("/counter", json!(0))?;
-registry.register_function("/add", |params| {
-    let Some(Value::Object(map)) = params else {
-        return Err((ErrorCode::InvalidBody, "expected object body".into()));
-    };
-    let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
-    let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
-    Ok(json!({"result": a + b}))
-})?;
-
-let router = Router::new().with_registry("/api/v1", Arc::clone(&registry));
+let router = Router::new().with("/ping", |_v| Ok(json!({"pong": true})));
 let server = Server::new(router);
-let listener = server.listen("127.0.0.1:8082")?;
-server.serve(listener)?;
-```
+let listener = server.listen("127.0.0.1:0")?;
+let addr = listener.local_addr()?;
+std::thread::spawn(move || { let _ = server.serve(listener); });
 
-Client
-
-- Connect and call JSON-pointer routes with JSON bodies:
-
-```rust
-use repe::Client;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-#[derive(Serialize)]
-struct AddReq {
-    a: i64,
-    b: i64,
-}
-
-#[derive(Deserialize)]
-struct AddResp {
-    sum: i64,
-}
-
-let client = Client::connect("127.0.0.1:8081")?;
+let client = Client::connect(addr)?;
 let pong = client.call_json("/ping", &json!({}))?;
 assert_eq!(pong["pong"], true);
-
-let typed: AddResp = client.call_typed_json("/add", &AddReq { a: 2, b: 3 })?;
-assert_eq!(typed.sum, 5);
-
-client.notify_typed_json("/jobs/refresh", &AddReq { a: 0, b: 0 })?;
-client.notify_typed_beve("/jobs/refresh_beve", &AddReq { a: 1, b: 2 })?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-Typed helpers work for BEVE payloads too:
+The async (`tokio`) variant uses `AsyncServer` and `AsyncClient` and exposes the same shape. See [docs/server.md](https://github.com/repe-org/repe-rs/blob/main/docs/server.md) for routers, typed handlers, middleware, struct registration, and peer-aware handlers, and [docs/client.md](https://github.com/repe-org/repe-rs/blob/main/docs/client.md) for the full client surface (typed and BEVE helpers, multiplexing, timeouts, batches, notifies, error handling).
 
-```rust
-let beve_sum: AddResp = client.call_typed_beve("/add", &AddReq { a: 4, b: 5 })?;
-assert_eq!(beve_sum.sum, 9);
-```
+## Feature Flags
 
-Registry-oriented client helpers:
+| Flag | Effect |
+| --- | --- |
+| `websocket` | Native `WebSocketClient`, `WebSocketServer`, and `proxy_connection`. |
+| `websocket-wasm` | Browser `WasmClient` on `wasm32-unknown-unknown`. |
+| `fleet-udp` | UDP fanout via `UniUdpFleet`. |
+| `parking-lot` | `Lockable` impls for `parking_lot::Mutex` / `RwLock`. |
+| `cli` | Builds the `repe` command-line client (pulls in `clap` and `websocket`). |
 
-- Empty-body READs: `registry_read("/api/v1/counter")` or `call_message(...)`
-- Typed READs: `registry_read_typed::<_, MyType>(...)`
-- JSON WRITE/CALL helpers: `registry_write_json(...)` and `registry_call_json(...)`
-- Custom wire formats: `call_with_formats(...)` and `notify_with_formats(...)`
+## Documentation
 
-Multiplexed calls, timeouts, and batching
+- [Server, routers, and handlers](https://github.com/repe-org/repe-rs/blob/main/docs/server.md)
+- [Client APIs](https://github.com/repe-org/repe-rs/blob/main/docs/client.md)
+- [Registry (dynamic routing)](https://github.com/repe-org/repe-rs/blob/main/docs/registry.md)
+- [Fleet (multi-node control)](https://github.com/repe-org/repe-rs/blob/main/docs/fleet.md)
+- [WebSocket transport](https://github.com/repe-org/repe-rs/blob/main/docs/websocket.md)
+- [Streaming with backpressure](https://github.com/repe-org/repe-rs/blob/main/docs/streaming.md)
+- [Command-line client](https://github.com/repe-org/repe-rs/blob/main/docs/cli.md)
+- [Wire format and JSON Pointer helpers](https://github.com/repe-org/repe-rs/blob/main/docs/protocol.md)
 
-- `Client` and `AsyncClient` can run multiple in-flight requests on one connection.
-- Clone the client handle and issue calls concurrently; responses are matched by request `id` even if the server replies out of order.
-- Use per-call timeout helpers:
-  - `call_json_with_timeout`
-  - `call_typed_json_with_timeout`
-  - `call_typed_beve_with_timeout`
-- Use batch helpers for JSON calls:
-  - `batch_json(Vec<(String, Value)>)`
-  - `batch_json_with_timeout(Vec<(String, Value)>, Duration)`
-
-Notify semantics
-
-- If a request is marked `notify = true`, the server will process the handler but will not send a response.
-- In the protocol, the `id` still increments client-side, but no matching response should be expected.
-- The `Client::notify_json` and `AsyncClient::notify_json` helpers set the flag accordingly.
-- `Client::notify_typed_json` / `Client::notify_typed_beve` and their async counterparts send typed payloads without waiting for a response, mirroring the call helpers.
-
-Error handling
-
-- Errors are returned “in-band” as responses with `ec != Ok` and a UTF‑8 body describing the error.
-- Common mappings:
-  - Header parse/validation issues → `InvalidHeader` or `ParseError`.
-  - JSON deserialization/serialization issues → `ParseError`.
-  - Missing routes → `MethodNotFound` with the requested path in the message.
-  - Application failures from handlers → return `(ErrorCode, String)` to control both fields.
-- Clients surface mismatched protocol versions as `RepeError::VersionMismatch`.
-- Responses with unknown request IDs are logged and dropped by default (including late responses for timed-out requests).
-- For bounded latency, prefer `call_*_with_timeout` APIs so a dropped response ID cannot leave a call waiting indefinitely.
-
-Async usage (minimal end‑to‑end)
-
-```rust
-use repe::{Router, AsyncServer, AsyncClient};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-# #[tokio::main]
-# async fn main() -> std::io::Result<()> {
-let router = Router::new().with_json("/ping", |_v| Ok(json!({"pong": true})));
-let listener = AsyncServer::listen(("127.0.0.1", 0)).await?;
-let addr = listener.local_addr()?;
-tokio::spawn(async move { let _ = AsyncServer::new(router).serve(listener).await; });
-
-#[derive(Serialize)]
-struct AddReq {
-    a: i64,
-    b: i64,
-}
-
-#[derive(Deserialize)]
-struct AddResp {
-    sum: i64,
-}
-
-let client = AsyncClient::connect(addr).await.unwrap();
-let pong = client.call_json("/ping", &json!({})).await.unwrap();
-assert_eq!(pong["pong"], true);
-
-let typed: AddResp = client
-    .call_typed_json("/add", &AddReq { a: 8, b: 1 })
-    .await
-    .unwrap();
-assert_eq!(typed.sum, 9);
-
-let beve: AddResp = client
-    .call_typed_beve("/add", &AddReq { a: 5, b: 6 })
-    .await
-    .unwrap();
-assert_eq!(beve.sum, 11);
-# Ok(()) }
-```
-
-Running the examples
+## Examples
 
 ```
+cargo run --example json_roundtrip
 cargo run --example server
 cargo run --example client
 cargo run --example registry_server
@@ -804,23 +108,10 @@ cargo run --example async_server
 cargo run --example async_client
 ```
 
-Design overview
+## Testing
 
-- Fixed header size is `48` bytes (`HEADER_SIZE`) followed by `query` and `body` payloads.
-- All numeric fields are little‑endian. Header `length` equals `48 + query_length + body_length` and is validated.
-- `query_format`/`body_format` use the enums in `repe::constants`.
-- Suggested query format is JSON Pointer (`/path/to/resource`).
+Run `cargo test` to execute unit and integration tests. The crate denies warnings and includes async tests, so a recent tokio is required. Integration tests cover sync and async server/client calls, unknown routes, handler error mapping, ID mismatches, and timeouts.
 
-JSON Pointer helpers
+## License
 
-- `parse_json_pointer` splits a pointer into unescaped tokens.
-- `eval_json_pointer` indexes into a `serde_json::Value` using array indices or object keys.
-
-Testing
-
-- Run `cargo test` to execute unit and integration tests. The crate denies warnings and includes async tests; you’ll need a recent tokio.
-- Example integration tests cover sync/async server + client calls, unknown routes, handler error mapping, ID mismatches, and timeouts.
-
-License
-
-- MIT, see `LICENSE`.
+MIT, see `LICENSE`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,64 @@
+# Command-Line Client
+
+Enable the `cli` feature to build a `repe` binary that talks to any REPE server over TCP or WebSocket:
+
+```
+cargo install repe --features cli
+```
+
+## Transports and URLs
+
+Transport is auto-detected from `--url`. `ws://` and `wss://` URLs use the WebSocket transport; anything else (including bare `host` or `host:port`) uses TCP. The default port is 5099.
+
+```
+repe --url 127.0.0.1:8082 get /counter
+repe --url 127.0.0.1:8082 set /counter 42
+repe --url 127.0.0.1:8082 call /add '{"a":1,"b":2}'
+repe --url ws://127.0.0.1:8081/repe call /echo '"hello"'
+```
+
+A bare path triggers inferred mode: `repe /path` reads (empty body, response printed) and `repe /path '<json>'` writes (JSON body, response suppressed). Run `repe --help` for the full subcommand list, `--raw` / `--timeout` flags, and exit codes (`0` success, `1` connection or usage error, `2` server-returned RPC error).
+
+## Body Sources
+
+For larger or piped payloads, pass `-` as the positional body to read from stdin, or `--body-file PATH` to read from a file. The three body sources are mutually exclusive.
+
+```
+echo '{"a":3,"b":4}' | repe call /api/v1/add -
+repe set /api/v1/config --body-file config.json
+```
+
+JSON bodies are validated client-side as syntactically valid JSON before the request is sent, so a typo gets a parse error locally rather than a round-trip to the server. Semantic validation (does this value match the schema for `/foo`?) remains the server's responsibility.
+
+## Response Decoding
+
+Responses are decoded uniformly across body formats: JSON and BEVE bodies are both rendered as pretty-printed JSON (or compact with `--raw`), UTF-8 bodies become JSON strings by default and print verbatim under `--raw` (so `repe --raw get /motd` behaves like a plain text fetch), and unparseable raw-binary responses surface as an RPC error rather than a silent decode failure.
+
+## `REPE_URL` Environment Variable
+
+Set `REPE_URL` to skip `--url` for repeated calls against the same server:
+
+```
+export REPE_URL=ws://127.0.0.1:8081/repe
+repe get /api/v1/counter
+repe set /api/v1/counter 42
+```
+
+An explicit `--url` flag always overrides `REPE_URL`.
+
+## Shell Completions
+
+```
+repe completions zsh > ~/.zsh/_repe
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`. Pipe the output into the location your shell expects.
+
+## Troubleshooting
+
+- **`tcp connect to ... failed: Connection refused`**: nothing is listening on that host:port. Check that the server is running and that `REPE_URL` / `--url` point at the right endpoint.
+- **`websocket connect to ... failed`**: same idea, plus the server's WebSocket path must match (registry servers usually mount under something like `/repe`). The path is the part after `host:port` in the URL.
+- **`server error (Method not found): Method not found: /foo`**: the server does not have a handler at that path. Registry-backed servers prefix all routes with their mount point, so `/foo` may need to be `/api/v1/foo`.
+- **`server error (Invalid body): Expected JSON body`**: the server's handler required a body but the CLI sent none (the typical failure when `repe /path` is used against a function endpoint). Use `repe call /path '{}'` instead, or pass an explicit body.
+- **`invalid JSON body: ...`**: client-side parse error before any bytes hit the wire. Quote your JSON properly; on most shells single quotes are safest: `repe call /add '{"a":1,"b":2}'`.
+- **`request ... timed out after Nms`**: the server didn't respond inside the `--timeout` window. Either raise `--timeout` or remove it.

--- a/src/bin/repe.rs
+++ b/src/bin/repe.rs
@@ -1,0 +1,868 @@
+//! `repe` — command-line client for REPE RPC servers.
+//!
+//! Auto-detects transport from the URL: `ws://` / `wss://` use the WebSocket
+//! transport, anything else (including bare `host:port`) uses TCP. The wire
+//! protocol has no operation type, so `get` / `set` / `call` all dispatch the
+//! same request; the only difference is whether a body is sent and whether
+//! the response is printed.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
+use repe::{AsyncClient, BodyFormat, Message, QueryFormat, RepeError, WebSocketClient};
+use serde_json::Value;
+
+const DEFAULT_PORT: u16 = 5099;
+const DEFAULT_HOST: &str = "localhost";
+
+/// Global flags that take a value (`--foo VALUE`). The argv rewriter must skip
+/// over both the flag and its value when scanning for the first positional, or
+/// it will treat the value as the inferred path. Kept in sync with the global
+/// `ArgAction::Set` flags on `Cli` by the `value_flag_list_matches_clap_globals`
+/// unit test below.
+const VALUE_FLAGS: &[&str] = &["--url", "--timeout", "--body-file"];
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "repe",
+    version,
+    about = "Command-line client for REPE RPC servers",
+    long_about = None,
+    after_help = "Examples:\n  \
+        repe /status                                  # inferred get\n  \
+        repe /counter 42                              # inferred set\n  \
+        repe get /config\n  \
+        repe set /counter 0\n  \
+        repe call /add '{\"a\":1,\"b\":2}'\n  \
+        repe call /add - < payload.json               # body from stdin\n  \
+        repe set /config --body-file config.json      # body from file\n  \
+        repe notify /events/refresh '{}'\n  \
+        repe --url 127.0.0.1:9000 get /status\n  \
+        repe --url ws://localhost:8080 call /echo '\"hello\"'\n\n\
+        Exit codes:\n  \
+        0  success\n  \
+        1  connection or usage error\n  \
+        2  RPC error returned by server\n"
+)]
+struct Cli {
+    /// Server URL. Accepts `host:port`, `tcp://host:port`, `ws://host:port[/path]`,
+    /// or `wss://host:port[/path]`. If only a host is given, port 5099 is used.
+    /// Defaults from the `REPE_URL` environment variable, then `localhost:5099`.
+    #[arg(
+        long,
+        global = true,
+        env = "REPE_URL",
+        default_value = "localhost:5099"
+    )]
+    url: String,
+
+    /// Print response bodies as compact JSON (default is pretty-printed).
+    #[arg(long, global = true)]
+    raw: bool,
+
+    /// Per-call timeout in seconds. Disabled when omitted.
+    #[arg(long, global = true)]
+    timeout: Option<f64>,
+
+    /// Read the request body from a file. Mutually exclusive with a positional body.
+    #[arg(long, global = true, value_name = "PATH")]
+    body_file: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Read a value: send an empty body, print the response.
+    Get(MethodOnly),
+    /// Write a value: send a JSON body, suppress the response.
+    Set(MethodWithBody),
+    /// Generic RPC call with optional JSON body; prints the response.
+    Call(MethodMaybeBody),
+    /// Fire-and-forget: send a notify with optional JSON body. No response.
+    Notify(MethodMaybeBody),
+    /// Print a shell completion script to stdout. Pipe it into the right place
+    /// for your shell, e.g. `repe completions zsh > _repe`.
+    Completions(CompletionsArgs),
+}
+
+#[derive(Args, Debug)]
+struct CompletionsArgs {
+    /// Target shell.
+    #[arg(value_enum)]
+    shell: Shell,
+}
+
+#[derive(Args, Debug)]
+struct MethodOnly {
+    /// JSON-pointer method path (e.g. `/status`).
+    method: String,
+}
+
+#[derive(Args, Debug)]
+struct MethodWithBody {
+    /// JSON-pointer method path.
+    method: String,
+    /// JSON body. Pass `-` to read from stdin. Validated client-side as syntactically
+    /// valid JSON.
+    body: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct MethodMaybeBody {
+    /// JSON-pointer method path.
+    method: String,
+    /// Optional JSON body. Pass `-` to read from stdin. Validated client-side as
+    /// syntactically valid JSON.
+    body: Option<String>,
+}
+
+/// Pre-process argv to support the inferred-mode shortcut from the C++ tool:
+/// `repe /path` -> `repe get /path` and `repe /path '<json>'` -> `repe set /path '<json>'`.
+/// We rewrite only when the first non-flag positional starts with `/`, so existing
+/// subcommand invocations are untouched. A literal `--` is the user explicitly
+/// opting out of inferred mode: bail without inserting anything.
+fn rewrite_inferred(mut argv: Vec<String>) -> Vec<String> {
+    let mut idx = 1;
+    while idx < argv.len() {
+        let arg = &argv[idx];
+        if arg == "--" {
+            return argv;
+        }
+        if !arg.starts_with('-') {
+            break;
+        }
+        if VALUE_FLAGS.contains(&arg.as_str()) {
+            idx += 2;
+        } else {
+            idx += 1;
+        }
+    }
+    if idx < argv.len() && argv[idx].starts_with('/') {
+        let inferred = if idx + 1 < argv.len() && !argv[idx + 1].starts_with('-') {
+            "set"
+        } else {
+            "get"
+        };
+        argv.insert(idx, inferred.to_string());
+    }
+    argv
+}
+
+fn main() -> ExitCode {
+    let argv = rewrite_inferred(std::env::args().collect());
+    let cli = Cli::parse_from(argv);
+
+    // Completions don't need a runtime, network, or the global flags. Handle
+    // them before we spin up tokio so users don't pay startup cost for shell
+    // shellouts and so the subcommand can be invoked even with no server up.
+    if let Command::Completions(CompletionsArgs { shell }) = &cli.command {
+        print_completions(*shell);
+        return ExitCode::SUCCESS;
+    }
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(err) => {
+            eprintln!("failed to start runtime: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    match runtime.block_on(run(cli)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(CliError::Usage(msg)) => {
+            eprintln!("{msg}");
+            ExitCode::from(1)
+        }
+        Err(CliError::Connection(msg)) => {
+            eprintln!("{msg}");
+            ExitCode::from(1)
+        }
+        Err(CliError::Rpc(msg)) => {
+            eprintln!("{msg}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CliError {
+    Usage(String),
+    Connection(String),
+    Rpc(String),
+}
+
+enum Transport {
+    Tcp(AsyncClient),
+    WebSocket(WebSocketClient),
+}
+
+impl Transport {
+    /// Send a request and return the raw response message. The body bytes (if any)
+    /// are sent verbatim with the supplied `body_format`; the caller is responsible
+    /// for ensuring they parse correctly.
+    async fn send(
+        &self,
+        method: &str,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        let qf = QueryFormat::JsonPointer as u16;
+        match self {
+            Transport::Tcp(c) => match timeout {
+                Some(d) => {
+                    c.call_with_formats_and_timeout(method, qf, body, body_format, d)
+                        .await
+                }
+                None => c.call_with_formats(method, qf, body, body_format).await,
+            },
+            Transport::WebSocket(c) => match timeout {
+                Some(d) => {
+                    c.call_with_formats_and_timeout(method, qf, body, body_format, d)
+                        .await
+                }
+                None => c.call_with_formats(method, qf, body, body_format).await,
+            },
+        }
+    }
+
+    async fn notify(
+        &self,
+        method: &str,
+        body: Option<&[u8]>,
+        body_format: u16,
+        timeout: Option<Duration>,
+    ) -> Result<(), RepeError> {
+        let qf = QueryFormat::JsonPointer as u16;
+        let send = async {
+            match self {
+                Transport::Tcp(c) => c.notify_with_formats(method, qf, body, body_format).await,
+                Transport::WebSocket(c) => {
+                    c.notify_with_formats(method, qf, body, body_format).await
+                }
+            }
+        };
+        match timeout {
+            Some(d) => match tokio::time::timeout(d, send).await {
+                Ok(result) => result,
+                Err(_) => Err(RepeError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("notify timed out after {}ms", d.as_millis()),
+                ))),
+            },
+            None => send.await,
+        }
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), CliError> {
+    let timeout = parse_timeout(cli.timeout)?;
+
+    // Pre-flight: any flag-combination check that doesn't need a live server
+    // runs before connect(), so a misconfigured invocation against a down
+    // server still surfaces the usage error instead of the connect failure.
+    if let Command::Get(_) = &cli.command {
+        if cli.body_file.is_some() {
+            return Err(CliError::Usage(
+                "--body-file is not valid with `get`".into(),
+            ));
+        }
+    }
+
+    let transport = connect(&cli.url).await?;
+
+    match cli.command {
+        Command::Get(MethodOnly { method }) => {
+            let response = transport
+                .send(&method, None, BodyFormat::RawBinary as u16, timeout)
+                .await
+                .map_err(map_call_error)?;
+            print_response(&response, cli.raw)?;
+        }
+        Command::Set(MethodWithBody { method, body }) => {
+            let body_text = resolve_body(body.as_deref(), cli.body_file.as_deref())?
+                .ok_or_else(|| CliError::Usage("`set` requires a body".into()))?;
+            // Mirrors the C++ tool: set suppresses the response body on success.
+            let _ = transport
+                .send(
+                    &method,
+                    Some(body_text.as_bytes()),
+                    BodyFormat::Json as u16,
+                    timeout,
+                )
+                .await
+                .map_err(map_call_error)?;
+        }
+        Command::Call(MethodMaybeBody { method, body }) => {
+            let body_text = resolve_body(body.as_deref(), cli.body_file.as_deref())?;
+            let response = match body_text.as_deref() {
+                Some(text) => {
+                    transport
+                        .send(
+                            &method,
+                            Some(text.as_bytes()),
+                            BodyFormat::Json as u16,
+                            timeout,
+                        )
+                        .await
+                }
+                None => {
+                    transport
+                        .send(&method, None, BodyFormat::RawBinary as u16, timeout)
+                        .await
+                }
+            }
+            .map_err(map_call_error)?;
+            print_response(&response, cli.raw)?;
+        }
+        Command::Notify(MethodMaybeBody { method, body }) => {
+            let body_text = resolve_body(body.as_deref(), cli.body_file.as_deref())?;
+            match body_text.as_deref() {
+                Some(text) => {
+                    transport
+                        .notify(
+                            &method,
+                            Some(text.as_bytes()),
+                            BodyFormat::Json as u16,
+                            timeout,
+                        )
+                        .await
+                }
+                None => {
+                    transport
+                        .notify(&method, None, BodyFormat::RawBinary as u16, timeout)
+                        .await
+                }
+            }
+            .map_err(map_call_error)?;
+        }
+        Command::Completions(_) => {
+            // Handled in `main` before the runtime is even built so that
+            // `repe completions <shell>` works without a server, a runtime,
+            // or even network permissions.
+            unreachable!("completions should be intercepted in main()");
+        }
+    }
+
+    Ok(())
+}
+
+/// Write a clap-derived completion script for `shell` to stdout. Invoked from
+/// `main` before the tokio runtime is constructed; runs synchronously and
+/// performs no network I/O.
+fn print_completions(shell: Shell) {
+    let mut cmd = Cli::command();
+    clap_complete::generate(shell, &mut cmd, "repe", &mut std::io::stdout());
+}
+
+/// Resolve the request body from the three possible sources, validating it as JSON.
+/// Precedence: positional argument (with `-` meaning stdin) wins over `--body-file`.
+/// Returns `None` only when no source was supplied.
+fn resolve_body(
+    positional: Option<&str>,
+    body_file: Option<&Path>,
+) -> Result<Option<String>, CliError> {
+    match (positional, body_file) {
+        (Some(_), Some(_)) => Err(CliError::Usage(
+            "cannot combine a positional body with --body-file".into(),
+        )),
+        (Some("-"), None) => {
+            let mut text = String::new();
+            std::io::stdin()
+                .read_to_string(&mut text)
+                .map_err(|e| CliError::Usage(format!("could not read stdin: {e}")))?;
+            validate_json(&text)?;
+            Ok(Some(text))
+        }
+        (Some(text), None) => {
+            validate_json(text)?;
+            Ok(Some(text.to_owned()))
+        }
+        (None, Some(path)) => {
+            let text = std::fs::read_to_string(path).map_err(|e| {
+                CliError::Usage(format!(
+                    "could not read --body-file {}: {e}",
+                    path.display()
+                ))
+            })?;
+            validate_json(&text)?;
+            Ok(Some(text))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_json(text: &str) -> Result<(), CliError> {
+    serde_json::from_str::<Value>(text)
+        .map(|_| ())
+        .map_err(|err| CliError::Usage(format!("invalid JSON body: {err}")))
+}
+
+/// Convert the raw `--timeout` value into a `Duration`, rejecting NaN, +/-inf,
+/// and negative numbers explicitly. The previous behavior silently clamped
+/// negatives to zero, which then fired immediately - a user-mistake outcome
+/// that masquerades as a working configuration.
+fn parse_timeout(secs: Option<f64>) -> Result<Option<Duration>, CliError> {
+    match secs {
+        None => Ok(None),
+        Some(v) if !v.is_finite() || v < 0.0 => Err(CliError::Usage(format!(
+            "--timeout must be a non-negative finite number, got {v}"
+        ))),
+        Some(v) => Ok(Some(Duration::from_secs_f64(v))),
+    }
+}
+
+fn print_response(msg: &Message, raw: bool) -> Result<(), CliError> {
+    let Some(decoded) = decode_response(msg)? else {
+        // Empty bodies are common for void methods. Suppress them so the
+        // user doesn't see a stray blank line on success. Note: a body
+        // containing literal JSON `null` still decodes and prints as "null".
+        return Ok(());
+    };
+    match decoded {
+        DecodedBody::Json(value) => {
+            let rendered = if raw {
+                serde_json::to_string(&value)
+            } else {
+                serde_json::to_string_pretty(&value)
+            };
+            // serde_json::to_string is infallible for `Value`: every variant
+            // has a defined serialization and no I/O is involved. If this
+            // ever does fail we want a panic, not a silently-zero exit code.
+            let s = rendered.expect("serde_json cannot fail to render a Value");
+            println!("{s}");
+        }
+        DecodedBody::Utf8Raw(text) => {
+            // `--raw` on a UTF-8 body emits the bytes verbatim, so
+            // `repe --raw get /motd` behaves like a normal text fetch.
+            print!("{text}");
+        }
+    }
+    Ok(())
+}
+
+/// Decoded response body, after dispatching on the wire body format. UTF-8
+/// stays separate from `Json(Value::String(..))` so callers can opt out of
+/// JSON quoting (e.g. `--raw` printing a plain `/motd` body).
+#[derive(Debug)]
+enum DecodedBody {
+    Json(Value),
+    Utf8Raw(String),
+}
+
+/// Decode a response message body for printing. Returns `None` for empty
+/// bodies (void responses); see [`print_response`].
+fn decode_response(msg: &Message) -> Result<Option<DecodedBody>, CliError> {
+    if msg.body.is_empty() {
+        return Ok(None);
+    }
+    match BodyFormat::try_from(msg.header.body_format) {
+        Ok(BodyFormat::Json) => Ok(Some(DecodedBody::Json(msg.json_body::<Value>().map_err(
+            |e| CliError::Rpc(format!("server returned malformed JSON body: {e}")),
+        )?))),
+        Ok(BodyFormat::Beve) => Ok(Some(DecodedBody::Json(msg.beve_body::<Value>().map_err(
+            |e| CliError::Rpc(format!("server returned malformed BEVE body: {e}")),
+        )?))),
+        Ok(BodyFormat::Utf8) => Ok(Some(DecodedBody::Utf8Raw(msg.body_utf8()))),
+        Ok(BodyFormat::RawBinary) | Err(_) => Err(CliError::Rpc(format!(
+            "server returned {} raw-binary bytes (cannot render as JSON)",
+            msg.body.len()
+        ))),
+    }
+}
+
+fn map_call_error(err: RepeError) -> CliError {
+    match err {
+        RepeError::ServerError { code, message } => {
+            CliError::Rpc(format!("server error ({code}): {message}"))
+        }
+        RepeError::Io(io) => CliError::Connection(format!("io error: {io}")),
+        other => CliError::Rpc(format!("{other}")),
+    }
+}
+
+async fn connect(url: &str) -> Result<Transport, CliError> {
+    let scheme = detect_scheme(url);
+    match scheme {
+        Scheme::WebSocket(full_url) => WebSocketClient::connect(&full_url)
+            .await
+            .map(Transport::WebSocket)
+            .map_err(|e| {
+                CliError::Connection(format!("websocket connect to {full_url} failed: {e}"))
+            }),
+        Scheme::Tcp(addr) => AsyncClient::connect(&addr)
+            .await
+            .map(Transport::Tcp)
+            .map_err(|e| CliError::Connection(format!("tcp connect to {addr} failed: {e}"))),
+    }
+}
+
+enum Scheme {
+    Tcp(String),
+    WebSocket(String),
+}
+
+fn detect_scheme(url: &str) -> Scheme {
+    if url.starts_with("ws://") || url.starts_with("wss://") {
+        return Scheme::WebSocket(url.to_string());
+    }
+    let stripped = url.strip_prefix("tcp://").unwrap_or(url);
+    let addr = if stripped.is_empty() {
+        format!("{DEFAULT_HOST}:{DEFAULT_PORT}")
+    } else if has_port(stripped) {
+        stripped.to_string()
+    } else {
+        format!("{stripped}:{DEFAULT_PORT}")
+    };
+    Scheme::Tcp(addr)
+}
+
+/// True if `s` already includes a port number. For IPv4/hostname inputs that
+/// means a single literal `:`. For bracketed IPv6 the port lives after the
+/// closing `]` (e.g. `[::1]:7000`); a bare `[::1]` is treated as portless so
+/// the caller can append the default.
+fn has_port(s: &str) -> bool {
+    if s.starts_with('[') {
+        s.split_once(']')
+            .is_some_and(|(_, after)| after.starts_with(':'))
+    } else {
+        s.contains(':')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_get_when_only_path_given() {
+        let argv = vec!["repe".into(), "/foo".into()];
+        let out = rewrite_inferred(argv);
+        assert_eq!(out, vec!["repe", "get", "/foo"]);
+    }
+
+    #[test]
+    fn rewrites_set_when_path_and_body_given() {
+        let argv = vec!["repe".into(), "/foo".into(), "42".into()];
+        let out = rewrite_inferred(argv);
+        assert_eq!(out, vec!["repe", "set", "/foo", "42"]);
+    }
+
+    #[test]
+    fn skips_url_value_when_inferring() {
+        let argv = vec![
+            "repe".into(),
+            "--url".into(),
+            "ws://x".into(),
+            "/foo".into(),
+        ];
+        let out = rewrite_inferred(argv);
+        assert_eq!(out, vec!["repe", "--url", "ws://x", "get", "/foo"]);
+    }
+
+    #[test]
+    fn skips_body_file_value_when_inferring() {
+        let argv = vec![
+            "repe".into(),
+            "--body-file".into(),
+            "/tmp/x.json".into(),
+            "/foo".into(),
+        ];
+        let out = rewrite_inferred(argv);
+        // Inferred mode picks `get` because no positional body follows; `--body-file`
+        // is invalid with `get` and will be rejected at run-time, but the rewriter's
+        // job is just to not get confused by the file path.
+        assert_eq!(
+            out,
+            vec!["repe", "--body-file", "/tmp/x.json", "get", "/foo"]
+        );
+    }
+
+    #[test]
+    fn leaves_explicit_subcommand_alone() {
+        let argv = vec!["repe".into(), "call".into(), "/foo".into()];
+        let out = rewrite_inferred(argv.clone());
+        assert_eq!(out, argv);
+    }
+
+    #[test]
+    fn detects_websocket_url() {
+        match detect_scheme("ws://localhost:9001/repe") {
+            Scheme::WebSocket(s) => assert_eq!(s, "ws://localhost:9001/repe"),
+            _ => panic!("expected websocket"),
+        }
+    }
+
+    #[test]
+    fn defaults_port_for_bare_host() {
+        match detect_scheme("example.com") {
+            Scheme::Tcp(s) => assert_eq!(s, "example.com:5099"),
+            _ => panic!("expected tcp"),
+        }
+    }
+
+    #[test]
+    fn strips_tcp_prefix() {
+        match detect_scheme("tcp://10.0.0.1:8080") {
+            Scheme::Tcp(s) => assert_eq!(s, "10.0.0.1:8080"),
+            _ => panic!("expected tcp"),
+        }
+    }
+
+    #[test]
+    fn resolve_body_rejects_double_source() {
+        let err = resolve_body(Some("42"), Some(Path::new("/tmp/x"))).unwrap_err();
+        match err {
+            CliError::Usage(_) => (),
+            _ => panic!("expected usage error"),
+        }
+    }
+
+    #[test]
+    fn resolve_body_returns_none_when_unspecified() {
+        assert!(resolve_body(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_body_validates_positional() {
+        let err = resolve_body(Some("not-json"), None).unwrap_err();
+        match err {
+            CliError::Usage(_) => (),
+            _ => panic!("expected usage error"),
+        }
+    }
+
+    #[test]
+    fn resolve_body_reads_from_file() {
+        let path =
+            std::env::temp_dir().join(format!("repe-cli-resolve-body-{}.json", std::process::id()));
+        std::fs::write(&path, br#"{"x":1}"#).unwrap();
+        let result = resolve_body(None, Some(&path)).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(result.unwrap(), r#"{"x":1}"#);
+    }
+
+    #[test]
+    fn resolve_body_rejects_missing_file() {
+        let path = std::env::temp_dir().join(format!(
+            "repe-cli-missing-{}-{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let err = resolve_body(None, Some(&path)).unwrap_err();
+        match err {
+            CliError::Usage(msg) => assert!(msg.contains("could not read")),
+            _ => panic!("expected usage error"),
+        }
+    }
+
+    // ---------- detect_scheme ----------
+
+    #[test]
+    fn detects_secure_websocket_url() {
+        match detect_scheme("wss://example.com:443/repe") {
+            Scheme::WebSocket(s) => assert_eq!(s, "wss://example.com:443/repe"),
+            _ => panic!("expected websocket"),
+        }
+    }
+
+    #[test]
+    fn empty_url_uses_default_host_and_port() {
+        match detect_scheme("") {
+            Scheme::Tcp(s) => assert_eq!(s, format!("{DEFAULT_HOST}:{DEFAULT_PORT}")),
+            _ => panic!("expected tcp"),
+        }
+    }
+
+    #[test]
+    fn bare_ipv6_literal_gets_default_port_appended() {
+        match detect_scheme("[::1]") {
+            Scheme::Tcp(s) => assert_eq!(s, format!("[::1]:{DEFAULT_PORT}")),
+            _ => panic!("expected tcp"),
+        }
+    }
+
+    #[test]
+    fn ipv6_literal_with_port_passes_through() {
+        match detect_scheme("[::1]:7000") {
+            Scheme::Tcp(s) => assert_eq!(s, "[::1]:7000"),
+            _ => panic!("expected tcp"),
+        }
+    }
+
+    #[test]
+    fn has_port_recognizes_ipv4_and_ipv6() {
+        assert!(has_port("127.0.0.1:8080"));
+        assert!(!has_port("example.com"));
+        assert!(has_port("[::1]:9000"));
+        assert!(!has_port("[::1]"));
+        // A trailing colon with nothing after still counts as "has a port"
+        // for our purposes; let the OS reject it on bind.
+        assert!(has_port("host:"));
+    }
+
+    // ---------- rewrite_inferred edge cases ----------
+
+    #[test]
+    fn does_not_rewrite_non_slash_first_arg() {
+        let argv = vec!["repe".into(), "status".into()];
+        let out = rewrite_inferred(argv.clone());
+        assert_eq!(out, argv, "no `/` prefix means no rewrite");
+    }
+
+    #[test]
+    fn does_not_rewrite_when_help_flag_first() {
+        let argv = vec!["repe".into(), "--help".into()];
+        let out = rewrite_inferred(argv.clone());
+        assert_eq!(out, argv);
+    }
+
+    #[test]
+    fn dash_dash_disables_inferred_mode() {
+        // `--` is the user explicitly opting out of inferred mode. The rewriter
+        // must not insert `get`/`set` after it; clap then sees the path as a
+        // literal positional and rejects it (the user can still invoke the
+        // explicit `repe get /foo` form).
+        let argv = vec!["repe".into(), "--".into(), "/foo".into()];
+        let out = rewrite_inferred(argv.clone());
+        assert_eq!(out, argv);
+    }
+
+    #[test]
+    fn value_flag_list_matches_clap_globals() {
+        // `VALUE_FLAGS` drives how the argv rewriter skips values. If a new
+        // global value-taking flag is added to `Cli`, this test catches the
+        // omission before users hit a confused inferred-mode rewrite.
+        use clap::ArgAction;
+        let cmd = Cli::command();
+        let mut expected: Vec<String> = cmd
+            .get_arguments()
+            .filter(|a| a.is_global_set() && matches!(a.get_action(), ArgAction::Set))
+            .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
+            .collect();
+        expected.sort();
+        let mut actual: Vec<String> = VALUE_FLAGS.iter().map(|s| (*s).to_string()).collect();
+        actual.sort();
+        assert_eq!(actual, expected);
+    }
+
+    // ---------- decode_response ----------
+
+    #[test]
+    fn decode_response_returns_none_for_empty_body() {
+        let msg = repe::Message::builder()
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        assert!(decode_response(&msg).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_response_handles_json() {
+        let msg = repe::Message::builder()
+            .body_json(&serde_json::json!({"k": 1}))
+            .unwrap()
+            .build();
+        match decode_response(&msg).unwrap().unwrap() {
+            DecodedBody::Json(value) => assert_eq!(value["k"], 1),
+            DecodedBody::Utf8Raw(text) => panic!("expected Json variant, got Utf8Raw({text:?})"),
+        }
+    }
+
+    #[test]
+    fn decode_response_handles_beve() {
+        let msg = repe::Message::builder()
+            .body_beve(&serde_json::json!({"k": 2}))
+            .unwrap()
+            .build();
+        match decode_response(&msg).unwrap().unwrap() {
+            DecodedBody::Json(value) => assert_eq!(value["k"], 2),
+            DecodedBody::Utf8Raw(text) => panic!("expected Json variant, got Utf8Raw({text:?})"),
+        }
+    }
+
+    #[test]
+    fn decode_response_keeps_utf8_separate_from_json() {
+        // The CLI prints UTF-8 bodies verbatim under `--raw`, so the decoder
+        // must surface them distinctly from `Json(Value::String(..))`.
+        let msg = repe::Message::builder().body_utf8("hello").build();
+        match decode_response(&msg).unwrap().unwrap() {
+            DecodedBody::Utf8Raw(text) => assert_eq!(text, "hello"),
+            DecodedBody::Json(value) => panic!("expected Utf8Raw, got Json({value})"),
+        }
+    }
+
+    #[test]
+    fn decode_response_errors_on_nonempty_raw_binary() {
+        let msg = repe::Message::builder()
+            .body_format(BodyFormat::RawBinary)
+            .body_bytes(vec![1, 2, 3])
+            .build();
+        match decode_response(&msg) {
+            Err(CliError::Rpc(msg)) => assert!(msg.contains("raw-binary")),
+            other => panic!("expected Rpc error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_response_errors_on_unknown_body_format() {
+        let msg = repe::Message::builder()
+            .body_format_code(0xBEEF)
+            .body_bytes(vec![1, 2, 3])
+            .build();
+        // Unknown format codes fall through to the same raw-binary diagnostic
+        // path; the user just gets a clear "cannot render as JSON" message.
+        match decode_response(&msg) {
+            Err(CliError::Rpc(_)) => (),
+            other => panic!("expected Rpc error, got {other:?}"),
+        }
+    }
+
+    // ---------- parse_timeout ----------
+
+    #[test]
+    fn parse_timeout_passes_through_none() {
+        assert!(parse_timeout(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_timeout_accepts_zero_and_positive() {
+        // `0` is allowed: it is a valid `Duration` and the user may legitimately
+        // want a "fire immediately" probe. We document, not reject.
+        assert_eq!(parse_timeout(Some(0.0)).unwrap(), Some(Duration::ZERO));
+        assert_eq!(
+            parse_timeout(Some(1.5)).unwrap(),
+            Some(Duration::from_secs_f64(1.5))
+        );
+    }
+
+    #[test]
+    fn parse_timeout_rejects_negative() {
+        match parse_timeout(Some(-0.5)) {
+            Err(CliError::Usage(msg)) => assert!(msg.contains("non-negative")),
+            other => panic!("expected Usage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_timeout_rejects_non_finite() {
+        for v in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            match parse_timeout(Some(v)) {
+                Err(CliError::Usage(msg)) => assert!(msg.contains("non-negative")),
+                other => panic!("expected Usage error for {v}, got {other:?}"),
+            }
+        }
+    }
+}

--- a/src/bin/repe.rs
+++ b/src/bin/repe.rs
@@ -122,7 +122,7 @@ struct MethodMaybeBody {
     body: Option<String>,
 }
 
-/// Pre-process argv to support the inferred-mode shortcut from the C++ tool:
+/// Pre-process argv to support the inferred-mode shortcut:
 /// `repe /path` -> `repe get /path` and `repe /path '<json>'` -> `repe set /path '<json>'`.
 /// We rewrite only when the first non-flag positional starts with `/`, so existing
 /// subcommand invocations are untouched. A literal `--` is the user explicitly
@@ -292,7 +292,9 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Command::Set(MethodWithBody { method, body }) => {
             let body_text = resolve_body(body.as_deref(), cli.body_file.as_deref())?
                 .ok_or_else(|| CliError::Usage("`set` requires a body".into()))?;
-            // Mirrors the C++ tool: set suppresses the response body on success.
+            // `set` suppresses the response body on success: a successful write
+            // doesn't have anything interesting to print, and silence makes the
+            // command pleasant to use in scripts.
             let _ = transport
                 .send(
                     &method,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,582 @@
+//! End-to-end tests for the `repe` CLI binary.
+//!
+//! These spin up an in-process registry-backed `AsyncServer` on an ephemeral
+//! port, then invoke the compiled `repe` binary via `Command` and assert on
+//! its stdout, stderr, and exit code. The unit tests in `src/bin/repe.rs`
+//! cover argv rewriting and URL parsing in isolation; this file covers the
+//! actual wire path.
+
+#![cfg(feature = "cli")]
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+use std::sync::Arc;
+
+use repe::{AsyncServer, ErrorCode, Registry, Router, TypedResponse, WebSocketServer};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+/// Path to the freshly-built `repe` binary. Cargo populates this for
+/// `[[bin]]` targets when the integration test compiles.
+const REPE_BIN: &str = env!("CARGO_BIN_EXE_repe");
+
+/// Build the registry-backed router used by both the TCP and WebSocket test
+/// servers. Centralizing this keeps the two transports exercising the same
+/// surface area; any added endpoint becomes testable on both immediately.
+fn build_router() -> Router {
+    let registry = Arc::new(Registry::new());
+    registry.register_value("/counter", json!(0)).unwrap();
+    registry
+        .register_value("/config", json!({"timeout": 30, "retries": 3}))
+        .unwrap();
+    registry
+        .register_function("/add", |params| {
+            let Some(Value::Object(map)) = params else {
+                return Err((ErrorCode::InvalidBody, "expected object body".into()));
+            };
+            let a = map.get("a").and_then(Value::as_i64).unwrap_or(0);
+            let b = map.get("b").and_then(Value::as_i64).unwrap_or(0);
+            Ok(json!({"result": a + b}))
+        })
+        .unwrap();
+    registry
+        .register_function("/refresh", |_params| Ok(Value::Null))
+        .unwrap();
+    // Sleeps long enough that any reasonable `--timeout` setting will trip.
+    // Uses std::thread::sleep because the registry's callable signature is
+    // synchronous; with `worker_threads = 2`, the second worker keeps the
+    // server's accept loop and CLI subprocess responsive while the handler
+    // blocks.
+    registry
+        .register_function("/slow_call", |_params| {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            Ok(Value::Null)
+        })
+        .unwrap();
+
+    // `/beve_echo` exists specifically to exercise the CLI's BEVE response
+    // decoding: it accepts a JSON body and replies with the same payload
+    // re-encoded as BEVE.
+    Router::new()
+        // Turbofish on `with_typed` is required: `TypedResponse<Value>` matches
+        // both blanket `IntoTypedResponse` impls, so `R` cannot be inferred.
+        .with_typed::<Value, Value, _>(
+            "/beve_echo",
+            |params: Value| -> Result<TypedResponse<Value>, (ErrorCode, String)> {
+                Ok(TypedResponse::beve(json!({
+                    "format": "beve",
+                    "echo": params,
+                })))
+            },
+        )
+        .with_registry("/api/v1", registry)
+}
+
+/// Bind a TCP `AsyncServer` to an ephemeral port and return its `host:port`.
+async fn spawn_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = AsyncServer::new(build_router());
+    tokio::spawn(async move {
+        let _ = server.serve(listener).await;
+    });
+    format!("{}:{}", addr.ip(), addr.port())
+}
+
+/// Bind a WebSocket `WebSocketServer` to an ephemeral port and return its
+/// `ws://host:port/repe` URL.
+async fn spawn_ws_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = WebSocketServer::new(build_router());
+    tokio::spawn(async move {
+        let _ = server.serve_listener(listener, "/repe").await;
+    });
+    format!("ws://{}:{}/repe", addr.ip(), addr.port())
+}
+
+/// Run the binary with the given args (server URL is prepended automatically)
+/// and return the captured output. The blocking `Command::output` call is
+/// dispatched to a tokio blocking thread so the server task running on the
+/// same runtime stays responsive.
+async fn run_cli(url: &str, args: &[&str]) -> Output {
+    let url = url.to_string();
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    tokio::task::spawn_blocking(move || {
+        let mut cmd = Command::new(REPE_BIN);
+        cmd.arg("--url").arg(&url).args(&args);
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        cmd.output().expect("spawn repe binary")
+    })
+    .await
+    .expect("blocking task panicked")
+}
+
+fn stdout_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_returns_registered_value() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["get", "/api/v1/counter"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "0");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn set_then_inferred_get_roundtrip() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["set", "/api/v1/counter", "42"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert!(
+        stdout_of(&out).is_empty(),
+        "set should suppress response body"
+    );
+
+    // Inferred-mode get: bare path with no body.
+    let out = run_cli(&url, &["/api/v1/counter"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "42");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn call_with_json_body_returns_object() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["call", "/api/v1/add", r#"{"a":17,"b":25}"#]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let value: Value = serde_json::from_str(stdout_of(&out).trim()).unwrap();
+    assert_eq!(value["result"], 42);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn raw_flag_emits_compact_json() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["--raw", "get", "/api/v1/config"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let stdout = stdout_of(&out);
+    let trimmed = stdout.trim();
+    assert!(
+        !trimmed.contains('\n'),
+        "expected single-line raw output, got: {stdout:?}"
+    );
+    let value: Value = serde_json::from_str(trimmed).unwrap();
+    assert_eq!(value["timeout"], 30);
+    assert_eq!(value["retries"], 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn notify_emits_no_output() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["notify", "/api/v1/refresh", "{}"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert!(stdout_of(&out).is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalid_client_side_json_exits_one() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["set", "/api/v1/counter", "not-json"]).await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("invalid JSON body"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_method_exits_two() {
+    let url = spawn_server().await;
+
+    // Inferred get against a path the registry does not know about.
+    let out = run_cli(&url, &["/api/v1/does_not_exist"]).await;
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("server error") || stderr.contains("Method not found"),
+        "stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn body_from_stdin_dash() {
+    let url = spawn_server().await;
+
+    let out = tokio::task::spawn_blocking(move || {
+        let mut child = Command::new(REPE_BIN)
+            .args(["--url", &url, "call", "/api/v1/add", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn repe");
+        child
+            .stdin
+            .as_mut()
+            .expect("piped stdin")
+            .write_all(br#"{"a":3,"b":4}"#)
+            .unwrap();
+        // Closing stdin signals EOF so the CLI's read_to_string returns.
+        drop(child.stdin.take());
+        child.wait_with_output().expect("collect output")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let value: Value = serde_json::from_str(stdout_of(&out).trim()).unwrap();
+    assert_eq!(value["result"], 7);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn body_from_file() {
+    let url = spawn_server().await;
+
+    let path = std::env::temp_dir().join(format!(
+        "repe-cli-body-{}-{}.json",
+        std::process::id(),
+        rand_token()
+    ));
+    std::fs::write(&path, br#"{"a":11,"b":31}"#).unwrap();
+
+    let out = run_cli(
+        &url,
+        &["--body-file", path.to_str().unwrap(), "call", "/api/v1/add"],
+    )
+    .await;
+    let _ = std::fs::remove_file(&path);
+
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let value: Value = serde_json::from_str(stdout_of(&out).trim()).unwrap();
+    assert_eq!(value["result"], 42);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beve_response_is_decoded_to_json() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["call", "/beve_echo", r#"{"n":7}"#]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let value: Value = serde_json::from_str(stdout_of(&out).trim()).unwrap();
+    assert_eq!(value["format"], "beve");
+    assert_eq!(value["echo"]["n"], 7);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn body_file_and_positional_conflict() {
+    let url = spawn_server().await;
+
+    let out = run_cli(
+        &url,
+        &[
+            "--body-file",
+            "/dev/null",
+            "call",
+            "/api/v1/add",
+            r#"{"a":1,"b":2}"#,
+        ],
+    )
+    .await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("cannot combine"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_get_set_call_roundtrip() {
+    // Exercises the `Transport::WebSocket` arms of send() against a live
+    // WebSocketServer; previously every integration test used TCP.
+    let url = spawn_ws_server().await;
+
+    let out = run_cli(&url, &["get", "/api/v1/counter"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "0");
+
+    let out = run_cli(&url, &["set", "/api/v1/counter", "99"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert!(stdout_of(&out).is_empty());
+
+    // Inferred mode against a WebSocket URL exercises the rewriter + WS path.
+    let out = run_cli(&url, &["/api/v1/counter"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "99");
+
+    let out = run_cli(&url, &["call", "/api/v1/add", r#"{"a":40,"b":2}"#]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let value: Value = serde_json::from_str(stdout_of(&out).trim()).unwrap();
+    assert_eq!(value["result"], 42);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timeout_flag_aborts_slow_call() {
+    // The /slow_call handler sleeps 500 ms; --timeout 0.1 should fire well
+    // before that, surfacing the timeout as a connection-class error (exit 1).
+    let url = spawn_server().await;
+
+    let out = run_cli(
+        &url,
+        &["--timeout", "0.1", "call", "/api/v1/slow_call", "{}"],
+    )
+    .await;
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = stderr_of(&out).to_lowercase();
+    assert!(
+        stderr.contains("timed out") || stderr.contains("timeout"),
+        "stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_with_body_file_is_rejected() {
+    let url = spawn_server().await;
+
+    let out = run_cli(
+        &url,
+        &["--body-file", "/dev/null", "get", "/api/v1/counter"],
+    )
+    .await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("not valid with `get`"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn set_without_body_is_rejected() {
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["set", "/api/v1/counter"]).await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("`set` requires a body"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn body_file_pointing_to_missing_path_exits_one() {
+    let url = spawn_server().await;
+    let missing = format!(
+        "/tmp/repe-cli-definitely-missing-{}-{}.json",
+        std::process::id(),
+        rand_token()
+    );
+
+    let out = run_cli(&url, &["--body-file", &missing, "call", "/api/v1/add"]).await;
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("could not read --body-file"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_stdin_body_fails_validation() {
+    // The CLI dials the server before reading stdin, so this test needs a
+    // live server even though the failure path is purely client-side.
+    let url = spawn_server().await;
+
+    let out = tokio::task::spawn_blocking(move || {
+        let mut child = Command::new(REPE_BIN)
+            .args(["--url", &url, "call", "/api/v1/add", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn repe");
+        // Closing stdin immediately gives the CLI an empty body.
+        drop(child.stdin.take());
+        child.wait_with_output().expect("collect output")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("invalid JSON body"),
+        "stderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connection_failure_exits_one() {
+    // Bind a TcpListener just long enough to learn the OS-assigned port,
+    // then drop it. The kernel may briefly TIME_WAIT-protect the slot, but
+    // a fresh connect will still fail with "connection refused" because
+    // nothing is accepting.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let out = run_cli(&format!("127.0.0.1:{port}"), &["get", "/api/v1/counter"]).await;
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("tcp connect to") && stderr.contains("failed"),
+        "stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completions_writes_zsh_script_without_server() {
+    // Completions must not require a running server or even a reachable URL.
+    let out = tokio::task::spawn_blocking(|| {
+        Command::new(REPE_BIN)
+            .args(["completions", "zsh"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("spawn repe")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    let stdout = stdout_of(&out);
+    assert!(
+        stdout.starts_with("#compdef repe"),
+        "expected zsh completion header, got: {stdout:.80}"
+    );
+    assert!(
+        stdout.contains("_repe"),
+        "expected the zsh function name in the script"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repe_url_env_var_is_honored() {
+    let url = spawn_server().await;
+
+    // Run without `--url`; REPE_URL should fill it in.
+    let out = tokio::task::spawn_blocking(move || {
+        Command::new(REPE_BIN)
+            .env("REPE_URL", &url)
+            .args(["get", "/api/v1/counter"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("spawn repe")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "0");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_url_overrides_repe_url_env() {
+    let url = spawn_server().await;
+
+    let out = tokio::task::spawn_blocking(move || {
+        Command::new(REPE_BIN)
+            // Bogus env var: if the explicit flag didn't win, we'd see a
+            // connection failure here.
+            .env("REPE_URL", "127.0.0.1:1")
+            .args(["--url", &url, "get", "/api/v1/counter"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("spawn repe")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert_eq!(stdout_of(&out).trim(), "0");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn notify_accepts_timeout_flag() {
+    // `--timeout` bounds how long the client waits for the kernel to accept
+    // the notify bytes. Under healthy conditions the send completes in
+    // microseconds, so we can't reliably trip the timeout - this test just
+    // pins down that the flag is accepted with notify (it used to be silently
+    // ignored: --timeout was a global flag with no plumbing through to
+    // Transport::notify).
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["--timeout", "5", "notify", "/api/v1/refresh", "{}"]).await;
+    assert!(out.status.success(), "stderr: {}", stderr_of(&out));
+    assert!(stdout_of(&out).is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dash_dash_disables_inferred_mode() {
+    // `--` is the user opting out of the inferred-mode rewrite. clap then sees
+    // `/api/v1/counter` as a literal positional and rejects the invocation;
+    // exit code 2 is clap's default for argv-parse failures.
+    let url = spawn_server().await;
+
+    let out = run_cli(&url, &["--", "/api/v1/counter"]).await;
+    assert!(!out.status.success(), "stderr: {}", stderr_of(&out));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn negative_timeout_is_rejected_as_usage_error() {
+    let url = spawn_server().await;
+
+    // Use `--timeout=-1` so clap parses `-1` as the value rather than a flag;
+    // our `parse_timeout` then rejects it with a Usage error (exit 1).
+    let out = run_cli(&url, &["--timeout=-1", "get", "/api/v1/counter"]).await;
+    assert_eq!(out.status.code(), Some(1), "stderr: {}", stderr_of(&out));
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("--timeout") && stderr.contains("non-negative"),
+        "stderr: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_with_body_file_is_rejected_without_connecting() {
+    // Pre-flight validation should fire before the connect attempt, so a
+    // misconfigured `get --body-file` against an unreachable server still
+    // surfaces the usage error rather than a connect failure.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let out = run_cli(
+        &format!("127.0.0.1:{port}"),
+        &["--body-file", "/dev/null", "get", "/api/v1/counter"],
+    )
+    .await;
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("not valid with `get`"),
+        "expected usage error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("tcp connect"),
+        "should not have attempted connect, got: {stderr}"
+    );
+}
+
+/// Tiny non-cryptographic disambiguator so concurrent tests on the same PID
+/// pick distinct temp paths without pulling in a UUID dependency.
+fn rand_token() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## What this is

A `repe` command-line client, so you can poke at REPE servers without writing a Rust program. Think `curl` but for REPE: read a value, write a value, call a function, fire a notify.

```sh
cargo install repe --features cli
```

## What it looks like

```sh
# Read a value (inferred mode: bare path = `get`)
$ repe /counter
0

# Write a value (path + body = `set`; response suppressed on success)
$ repe /counter 42

# Round-trip
$ repe /counter
42

# Call a function and pretty-print the response
$ repe call /add '{"a":17,"b":25}'
{
  "result": 42
}

# Same call, compact output for piping into jq
$ repe --raw call /add '{"a":17,"b":25}' | jq .result
42

# Body from a file or stdin
$ repe set /config --body-file config.json
$ jq '.requests[0]' < spec.json | repe call /process -

# Fire-and-forget notify (no response)
$ repe notify /events/refresh '{}'

# Talk to a WebSocket server
$ repe --url ws://localhost:8080/repe call /echo '"hello"'
"hello"

# Different server? Set it once, drop the flag.
$ export REPE_URL=tcp://api.internal:9000
$ repe /status
{"healthy": true}
```

The bare-path shortcut (`repe /foo` is the same as `repe get /foo`) keeps quick interactive use one token shorter; the explicit `repe get /foo` form works exactly the same.

## What you get

- **Subcommands:** `get`, `set`, `call`, `notify`, plus `completions <shell>` for bash / zsh / fish / elvish / powershell.
- **Transport auto-detection from `--url`:** `ws://` and `wss://` use WebSocket; anything else (`host:port`, `tcp://...`, a bare hostname) uses TCP. Default port is 5099. IPv6 literals work too (`[::1]`, `[::1]:7000`).
- **Three body sources, mutually exclusive:** positional JSON, stdin (`-`), or `--body-file PATH`. JSON is validated client-side, so a typo gets caught before any bytes go on the wire.
- **`REPE_URL` env var** for the common case of "I'm always talking to the same server."
- **Smart response printing:** JSON/BEVE pretty-print (or compact with `--raw`); UTF-8 bodies print as JSON strings normally and verbatim under `--raw`, so `repe --raw get /motd` works like a normal text fetch; raw-binary responses become a clear error instead of an opaque decode failure.
- **Three exit codes worth scripting against:** `0` success, `1` connection or usage error, `2` server returned an RPC error. Useful for CI pipelines that want to retry on `1` but fail on `2`.
- **`--timeout SECS`** bounds calls and notifies. Negative or non-finite values are rejected with a clear message, not silently clamped.
- **`repe completions zsh > _repe`** runs synchronously with no runtime, network, or server. Works inside a Dockerfile build step.

## Under the hood

A small `Transport` enum hides the `AsyncClient` vs. `WebSocketClient` split so the subcommand code stays readable, and adding a future transport is one new arm in two methods. Body decoding splits `Json(Value)` from `Utf8Raw(String)` so the `--raw` UTF-8 path can skip JSON quoting cleanly. Argv rewriting for the bare-path shortcut lives in a single `rewrite_inferred` function with its own unit tests, and the value-flag skip list is locked to `Cli`'s globals by an invariant test so the next person to add a global flag can't accidentally break inferred mode.

## Test plan

- [x] **32 unit tests** in `src/bin/repe.rs`: argv rewriting, URL parsing (including IPv6 quirks), body-source resolution, timeout validation, response decoding for every body format, and the rewriter/clap-globals invariant.
- [x] **25 end-to-end tests** in `tests/cli.rs` against in-process `AsyncServer` and `WebSocketServer` instances: every subcommand, raw output, all three body sources, body-source conflicts, both error-exit paths, `--timeout` on call and notify, BEVE response decoding, `REPE_URL` precedence in both directions, the `--` opt-out, negative-timeout rejection, the connect-vs-validate ordering for `get --body-file`, and the completions subcommand.
- [x] `cargo build --features cli --bin repe`
- [x] `cargo test --features cli` (204 tests pass: bin + library + integration + doctests)
- [x] `cargo clippy --features cli --bin repe --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`