### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install MkDocs
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ PR_DESCRIPTION.md
 dev/pr-description.md
 dev/feature-expansion-plan.md
 PR.md
+
+# MkDocs build output and local virtualenv
+/site/
+/.mkdocs-venv/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,73 @@
+# repe-rs
+
+Rust implementation of the [REPE RPC protocol](https://github.com/repe-org/REPE) with JSON and BEVE body support.
+
+[![crates.io](https://img.shields.io/crates/v/repe.svg)](https://crates.io/crates/repe)
+
+## What's in the box
+
+- REPE header and message types with correct little-endian wire encoding.
+- Streaming and zero-copy I/O (`MessageView`, `write_message_streaming`) for large bodies.
+- JSON bodies via `serde_json`; BEVE bodies via the [`beve`](https://crates.io/crates/beve) crate.
+- Sync and async (tokio) clients and servers, with multiplexed in-flight requests, per-call timeouts, batching, and notify support.
+- Dynamic [`Registry`](registry.md) routing with JSON Pointer semantics.
+- [`Fleet`](fleet.md) APIs for multi-node TCP and UDP fanout.
+- Optional [WebSocket transport](websocket.md), including a wasm browser client and server-pushed notify subscriptions.
+- Optional [`stream`](streaming.md) module for backpressure-controlled bulk transfers with reconnect-resume.
+- Optional [`repe` CLI](cli.md) for talking to any REPE server over TCP or WebSocket.
+
+## Install
+
+```toml
+[dependencies]
+repe = "2.3"
+```
+
+Or `cargo add repe`. The CLI ships under a feature flag: `cargo install repe --features cli`.
+
+## Quick start
+
+```rust
+use repe::{BodyFormat, Message, QueryFormat};
+
+let msg = Message::builder()
+    .id(42)
+    .query_str("/status")
+    .query_format(QueryFormat::JsonPointer)
+    .body_json(&serde_json::json!({"ping": true}))?
+    .build();
+
+let bytes = msg.to_vec();
+let parsed = repe::Message::from_slice(&bytes)?;
+
+assert_eq!(parsed.header.id, 42);
+assert_eq!(parsed.header.body_format, BodyFormat::Json as u16);
+let val: serde_json::Value = parsed.json_body()?;
+assert_eq!(val["ping"], true);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Replace `body_json` with `body_beve` to encode the body with BEVE; everything else is identical.
+
+## Where to next
+
+- New here? Start with the [wire format](protocol.md) for a quick mental model, then read the [server](server.md) and [client](client.md) pages.
+- Building dynamic routes? See [Registry](registry.md).
+- Multi-node deployments? See [Fleet](fleet.md).
+- Pushing through firewalls or browsers? See [WebSocket](websocket.md).
+- Moving large payloads with flow control? See [Streaming](streaming.md).
+- Debugging from a terminal? See the [CLI](cli.md).
+
+## Feature flags
+
+| Flag | Effect |
+| --- | --- |
+| `websocket` | Native `WebSocketClient`, `WebSocketServer`, and `proxy_connection`. |
+| `websocket-wasm` | Browser `WasmClient` on `wasm32-unknown-unknown`. |
+| `fleet-udp` | UDP fanout via `UniUdpFleet`. |
+| `parking-lot` | `Lockable` impls for `parking_lot::Mutex` / `RwLock`. |
+| `cli` | Builds the `repe` command-line client (pulls in `clap` and `websocket`). |
+
+## License
+
+MIT, see [`LICENSE`](https://github.com/repe-org/repe-rs/blob/main/LICENSE) in the repo.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: repe-rs
+site_description: Rust implementation of the REPE RPC protocol with JSON and BEVE body support.
+site_url: https://repe-org.github.io/repe-rs/
+repo_url: https://github.com/repe-org/repe-rs
+repo_name: repe-org/repe-rs
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - navigation.sections
+    - navigation.indexes
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+nav:
+  - Overview: index.md
+  - Wire Format: protocol.md
+  - Server: server.md
+  - Client: client.md
+  - Registry: registry.md
+  - Fleet: fleet.md
+  - WebSocket Transport: websocket.md
+  - Streaming: streaming.md
+  - Command-Line Client: cli.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/repe-org/repe-rs
+    - icon: fontawesome/brands/rust
+      link: https://crates.io/crates/repe


### PR DESCRIPTION
## What this is

Sets up an [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) site that publishes to GitHub Pages on every push to `main`. The existing `docs/*.md` files become the rendered pages, no rewrites needed.

Once this lands and Pages is enabled, the site will live at:

**https://repe-org.github.io/repe-rs/**

## What's in the PR

- **`mkdocs.yml`** — Material theme, light/dark palette toggle, the syntax-highlighting / code-copy / admonition extensions the existing docs already use, and an explicit nav so the sidebar reads in a sensible order rather than alphabetical-by-filename.
- **`docs/index.md`** — landing page with a one-screen overview, install snippet, quick-start example, and a "where to next" map into the per-feature pages.
- **`docs/requirements.txt`** — pinned `mkdocs` and `mkdocs-material` versions so CI builds are reproducible.
- **`.github/workflows/docs.yml`** — `mkdocs build --strict`, then `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`. Path-filtered to `docs/**`, `mkdocs.yml`, and the workflow itself, so unrelated commits don't trigger a redeploy.
- **`.gitignore`** — ignores the local `site/` build output and the `.mkdocs-venv/` I use to test builds locally.

Verified locally with `mkdocs build --strict`: all 9 pages render with no warnings.

## One manual step needed before this works

GitHub Pages has to be enabled with the modern "GitHub Actions" source. This is a repo-settings change only a maintainer can make:

> **Settings → Pages → Build and deployment → Source: GitHub Actions**

After that, merging this PR (or any future doc change) triggers a rebuild and the site goes live.

## Test plan

- [x] `mkdocs build --strict` clean locally (9 pages, no warnings).
- [ ] Pages enabled with "GitHub Actions" source.
- [ ] Workflow run succeeds on this PR's branch (visible in the Actions tab once the workflow file is on `main` — or manually triggered via `workflow_dispatch` after merge).
- [ ] Site loads at https://repe-org.github.io/repe-rs/ post-merge.

## Follow-ups not in this PR

- Update `README.md` to point doc links at the published site instead of `github.com/.../blob/main/docs/*.md`. Worth doing once we've confirmed the first deploy is healthy.
- Add a "Docs" badge to the README and to the crates.io page.