### PR TITLE
Add push-capable WebSocket server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 PR_DESCRIPTION.md
 dev/pr-description.md
 dev/feature-expansion-plan.md
+dev/push-capable-websocket-server.md
 PR.md
 
 # MkDocs build output and local virtualenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+- `PeerRegistry`: cloneable live set of connected peers, with `broadcast_notify_json` / `broadcast_notify_beve` / `broadcast_notify_utf8` / `broadcast_notify_raw` helpers. Each broadcast encodes (or copies, for the pre-encoded variants) the body once on the caller's task and returns a `HashMap<PeerId, Result<(), PeerSendError>>` so callers can prune dead peers (`PeerSendError::Disconnected`) or surface backpressure (`PeerSendError::Full`). Owns its own `PeerId` allocator (`PeerRegistry::next_peer_id`), so two `WebSocketServer`s sharing one registry never mint colliding ids.
+- `WebSocketServer::with_peer_registry(registry)`: attach a `PeerRegistry` so accepted peers are inserted on connect and removed on disconnect. The disconnect cleanup runs from a `Drop` guard so it fires on every exit path (clean close, transport error, handler panic).
+- `WebSocketServer::on_peer_connect(f)` / `on_peer_disconnect(f)`: lower-level lifecycle hooks. Both compose: every registered closure fires in registration order, so `with_peer_registry` can coexist with logging or metrics callbacks. The connect hook runs synchronously before the reader/writer tasks start, so a notify queued from inside it is guaranteed to reach the wire before any response.
+- `WebSocketServer::with_outbound_capacity(n)`: per-connection outbound channel capacity (default `DEFAULT_OUTBOUND_CAPACITY = 256`). A full channel returns `PeerSendError::Full` from `PeerHandle::send_notify`; the embedder picks the retry/prune policy.
+
+### Changed
+- `WebSocketServer::handle_connection` is now a reader/writer task pair coordinated by a bounded `tokio::sync::mpsc` channel. The writer task is the sole point that touches the outbound `SplitSink`, so any code path that holds a `PeerHandle` can push notifies onto the wire alongside in-flight responses. Existing request-response servers see no behavior change.
+
+### Notes
+- The push path is strictly opt-in. `WebSocketServer::new(router).serve(...)` callers compile and run unchanged. No protocol changes: notify frames are the same shape they have always been.
+- Broadcast cost: one encode plus one `Vec<u8>` clone per peer. Sharing a single `Arc<[u8]>` across peers for very large broadcast bodies is left as future work.
+- In-handler notifies (handlers reaching the calling peer's `PeerHandle`) are still out of scope. Surfacing the peer to handlers requires a router/handler signature change; `Registry::dispatch_with_ctx` already threads `CallContext` for the registry-backed path.
+
 ## [2.4.0] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@
 - `WebSocketServer::with_peer_registry(registry)`: attach a `PeerRegistry` so accepted peers are inserted on connect and removed on disconnect. The disconnect cleanup runs from a `Drop` guard so it fires on every exit path (clean close, transport error, handler panic).
 - `WebSocketServer::on_peer_connect(f)` / `on_peer_disconnect(f)`: lower-level lifecycle hooks. Both compose: every registered closure fires in registration order, so `with_peer_registry` can coexist with logging or metrics callbacks. The connect hook runs synchronously before the reader/writer tasks start, so a notify queued from inside it is guaranteed to reach the wire before any response.
 - `WebSocketServer::with_outbound_capacity(n)`: per-connection outbound channel capacity (default `DEFAULT_OUTBOUND_CAPACITY = 256`). A full channel returns `PeerSendError::Full` from `PeerHandle::send_notify`; the embedder picks the retry/prune policy.
+- `Router::with_json_ctx` and `Router::with_typed_ctx`: register handlers that take a `&CallContext` alongside the body. Inside the handler, `ctx.peer()` is the calling `PeerHandle` (when the request came in over a transport that produces peers; `WebSocketServer` does), so handlers can push notifies back to the originator mid-request (progress updates, streaming chunks, server-initiated state mirroring).
+- `HandlerErased::handle_with_ctx(&self, req, ctx)`: new trait method threading the `CallContext` to the leaf handler. Defaults to ignoring the context and calling `handle`, so existing implementors (embedder custom handlers) compile unchanged.
+- `TypedHandlerFnCtx` in `repe::server`: trait shape mirroring `TypedHandlerFn` for `Fn(&CallContext, T) -> Result<R, ...>` closures.
+- `route_request_with_ctx` (crate-internal): peer-threaded dispatch path used by `WebSocketServer`. TCP-backed servers continue to use the existing context-free `route_request`.
 
 ### Changed
 - `WebSocketServer::handle_connection` is now a reader/writer task pair coordinated by a bounded `tokio::sync::mpsc` channel. The writer task is the sole point that touches the outbound `SplitSink`, so any code path that holds a `PeerHandle` can push notifies onto the wire alongside in-flight responses. Existing request-response servers see no behavior change.
+- `WebSocketServer` now dispatches each request through `HandlerErased::handle_with_ctx` with a `CallContext` carrying the calling peer. Handlers registered via `with_json` / `with_typed` are unaffected (they inherit the default `handle_with_ctx` that drops the context). TCP servers continue to dispatch via the existing context-free path.
 
 ### Notes
 - The push path is strictly opt-in. `WebSocketServer::new(router).serve(...)` callers compile and run unchanged. No protocol changes: notify frames are the same shape they have always been.
 - Broadcast cost: one encode plus one `Vec<u8>` clone per peer. Sharing a single `Arc<[u8]>` across peers for very large broadcast bodies is left as future work.
-- In-handler notifies (handlers reaching the calling peer's `PeerHandle`) are still out of scope. Surfacing the peer to handlers requires a router/handler signature change; `Registry::dispatch_with_ctx` already threads `CallContext` for the registry-backed path.
 
 ## [2.4.0] - 2026-04-27
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -126,6 +126,42 @@ Each accepted connection allocates a bounded `tokio::sync::mpsc` channel for out
 
 When the channel is full, `PeerHandle::send_notify` (and thus `broadcast_notify_*`) returns `PeerSendError::Full` for that peer; other peers are unaffected. A slow consumer cannot stall delivery to the broadcast set. The embedder chooses the policy: retry on the next tick, prune the peer, or escalate.
 
+### In-Handler Notifies
+
+Request handlers can also push notifies back to the calling peer mid-request. Register a handler via `Router::with_json_ctx` (or `with_typed_ctx`) and the closure receives a `CallContext` carrying the `PeerHandle`:
+
+```rust
+use repe::server::Router;
+use repe::websocket_server::WebSocketServer;
+use repe::NotifyBody;
+use serde_json::json;
+
+let router = Router::new().with_json_ctx("/run", |ctx, _params| {
+    if let Some(peer) = ctx.peer() {
+        let _ = peer.send_notify(
+            "/progress",
+            NotifyBody::Json(serde_json::to_vec(&json!({ "stage": "begin" })).unwrap()),
+        );
+        // ... do work ...
+        let _ = peer.send_notify(
+            "/progress",
+            NotifyBody::Json(serde_json::to_vec(&json!({ "stage": "end" })).unwrap()),
+        );
+    }
+    Ok(json!({ "ok": true }))
+});
+
+let server = WebSocketServer::new(router);
+```
+
+Registry-backed handlers reach the same `CallContext`: wrap a closure with `repe::registry::WithContext` before registering it. `WebSocketServer` automatically calls `Registry::dispatch_with_ctx` so the registered callable receives the peer.
+
+Middleware does not need to be aware of `CallContext` to forward it. `Next::run(req)` threads whatever the upstream caller attached, so existing middleware composes transparently with new context-aware handlers. Handlers registered via `with_json` / `with_typed` (the legacy non-`_ctx` variants) keep working unchanged; they simply do not receive the context.
+
+Calls dispatched through the TCP transports (`Client`, `AsyncClient`, `Server`, `AsyncServer`) do not carry a peer today; `ctx.peer()` returns `None` for those. Context-aware handlers should treat `None` as the no-push case rather than relying on the peer always being present.
+
 ### Compatibility
 
 The push path is strictly opt-in. Existing `WebSocketServer::new(router).serve(addr, path)` callers see no behavior change, no new error variants, and no protocol changes. Notify frames are the same shape they have always been (`Message::builder().notify(true)`).
+
+Adding `handle_with_ctx` to `HandlerErased` is source-compatible because the trait provides a default implementation that delegates to `handle`. Existing implementors of `HandlerErased` (embedder custom handler types) compile unchanged.

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -56,3 +56,76 @@ The receiver yields raw `Message` values; decode the body using `Message::json_b
 The notify channel is unbounded by design. The transport read loop pushes every inbound notify into the channel without backpressure, so a slow consumer plus a high-rate producer will grow the buffer until the process OOMs. Application-level backpressure (e.g. ACK windows in a chunk protocol; see [streaming.md](streaming.md)) is the right fix; the consumer must drain the receiver promptly.
 
 A bounded variant is not offered: dropping notifies on overflow corrupts chunk streams, and blocking the read loop on overflow stalls the request/response correlation path that shares the same socket.
+
+## Server-Initiated Notifies
+
+`WebSocketServer` can push REPE notifies to connected clients without an embedder having to rebuild the per-connection transport loop. Attach a `PeerRegistry` (or register raw connect/disconnect hooks) and the server tracks each accepted peer's outbound channel for you.
+
+```rust
+use repe::PeerRegistry;
+use repe::server::Router;
+use repe::websocket_server::WebSocketServer;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+
+    let peers = PeerRegistry::new();
+    let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+
+    // Background task fans out a notify to every connected client.
+    let publisher = peers.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            let _ = publisher.broadcast_notify_json("/heartbeat", &json!({ "t": 1 }));
+        }
+    });
+
+    server.serve("0.0.0.0:8081", "/repe").await
+}
+```
+
+### `PeerRegistry`
+
+`PeerRegistry::new()` builds an empty, cloneable handle. `with_peer_registry` wires accept/close to `insert`/`remove`. Background tasks clone the registry and broadcast.
+
+Per-peer broadcast helpers all encode the body once on the caller's task and clone the encoded bytes into each peer's outbound channel:
+
+- `broadcast_notify_json<P, T: Serialize>(path, body)` — JSON body.
+- `broadcast_notify_beve<P, T: Serialize>(path, body)` — BEVE body.
+- `broadcast_notify_utf8<P, S: AsRef<str>>(path, text)` — UTF-8 body.
+- `broadcast_notify_raw<P>(path, body_format, body_bytes)` — raw bytes with the caller-chosen `BodyFormat` tag.
+
+Each helper returns a `HashMap<PeerId, Result<(), PeerSendError>>` so callers can prune dead peers (`PeerSendError::Disconnected`) or surface backpressure (`PeerSendError::Full`).
+
+### Lifecycle hooks
+
+`with_peer_registry` is sugar over two lower-level hooks:
+
+```rust
+let server = WebSocketServer::new(router)
+    .on_peer_connect(|peer| { /* metrics: connection opened */ })
+    .on_peer_disconnect(|id| { /* metrics: connection closed */ });
+```
+
+Both hooks compose: every registered closure fires in registration order, so `with_peer_registry` can coexist with logging or metrics callbacks instead of replacing them.
+
+The connect hook runs synchronously on the accept task **before** the reader/writer tasks start processing traffic. A notify queued via `peer.send_notify(...)` from inside the hook is guaranteed to land on the wire before any response to a client request on that connection.
+
+After the hook returns, the outbound channel is strict FIFO across both notifies and responses on the same connection: a notify pushed by a background broadcaster at time T arrives on the wire in the order it was enqueued relative to any handler response also enqueued at time T. Clients de-multiplex by the `notify` header flag (`WebSocketClient::subscribe_notifies()`); notifies do not "cut the line" past in-flight responses.
+
+The disconnect hook fires from a `Drop` guard, so it runs on every exit path: clean Close frame, transport error, handler panic, or a panic in a *later* connect hook (the guard is built before the connect-hook loop). Exactly once per accepted connection.
+
+`PeerHandle::send_notify` returning `Ok(())` means the message was queued onto the outbound channel, not that it was written to the wire. During concurrent disconnect, a late-arriving send may queue successfully but be dropped when the writer task exits and the bounded receiver is released. This is intrinsic to async shutdown; treat `Ok` as best-effort delivery, not as confirmation.
+
+### Backpressure on the server outbound channel
+
+Each accepted connection allocates a bounded `tokio::sync::mpsc` channel for outbound messages (responses plus pushed notifies). The default capacity is `DEFAULT_OUTBOUND_CAPACITY` (256). Tune per server with `with_outbound_capacity(n)`.
+
+When the channel is full, `PeerHandle::send_notify` (and thus `broadcast_notify_*`) returns `PeerSendError::Full` for that peer; other peers are unaffected. A slow consumer cannot stall delivery to the broadcast set. The embedder chooses the policy: retry on the next tick, prune the peer, or escalate.
+
+### Compatibility
+
+The push path is strictly opt-in. Existing `WebSocketServer::new(router).serve(addr, path)` callers see no behavior change, no new error variants, and no protocol changes. Notify frames are the same shape they have always been (`Message::builder().notify(true)`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@ pub use header::Header;
 pub use io::{read_message, write_message, write_message_streaming};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::{Message, MessageView};
-pub use peer::{CallContext, NotifyBody, PeerHandle, PeerId, PeerSendError, PeerSink};
+pub use peer::{
+    CallContext, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink,
+};
 pub use registry::{Registry, RegistryCallable, RegistryError, WithContext};
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::Server;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -22,7 +22,11 @@
 //! with a populated [`CallContext`].
 
 use crate::constants::BodyFormat;
-use std::sync::Arc;
+use crate::error::RepeError;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 /// Server-assigned identifier for a connected peer.
 ///
@@ -119,6 +123,16 @@ pub trait PeerSink: Send + Sync {
     /// bounded channel that returns [`PeerSendError::Full`] when saturated
     /// is the recommended shape; embedders that prefer to block until the
     /// channel has capacity may do so.
+    ///
+    /// **Query format is currently fixed at `QueryFormat::JsonPointer`.**
+    /// The built-in [`WebSocketServer`](crate::websocket_server::WebSocketServer)
+    /// sink and the present trait shape both assume `method` is a JSON
+    /// pointer; pushing notifies that should advertise a different
+    /// query format (custom binary protocols, embedder-defined codes)
+    /// requires building the [`Message`](crate::Message) by hand and
+    /// writing it through a parallel mechanism. A future revision will
+    /// thread a `QueryFormat` through this signature; for now the
+    /// limitation is by design, not an oversight.
     fn send_notify(&self, method: &str, body: NotifyBody) -> Result<(), PeerSendError>;
 
     /// Returns `true` if the peer's transport is still open.
@@ -209,10 +223,235 @@ impl<'a> CallContext<'a> {
     }
 }
 
+/// Live set of peers attached to one server instance.
+///
+/// Inserted on accept, removed on close. Cheap to clone (`Arc` inside)
+/// so background tasks can hold a handle for broadcasting. The registry
+/// is transport-agnostic: anything that produces [`PeerHandle`]s can
+/// feed it, not just the built-in `WebSocketServer`.
+///
+/// Typical wiring:
+///
+/// ```ignore
+/// let peers = PeerRegistry::new();
+/// let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+///
+/// let publisher = peers.clone();
+/// tokio::spawn(async move {
+///     publisher.broadcast_notify_json("/state/changed", &snapshot);
+/// });
+/// ```
+#[derive(Clone)]
+pub struct PeerRegistry {
+    inner: Arc<Mutex<HashMap<PeerId, PeerHandle>>>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl Default for PeerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PeerRegistry {
+    /// Build an empty registry.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Mint a fresh, monotonically increasing [`PeerId`] from this
+    /// registry's id counter.
+    ///
+    /// Embedders that build their own [`PeerHandle`]s (rather than
+    /// going through `WebSocketServer::with_peer_registry`) can call
+    /// this to keep ids unique across every server feeding the
+    /// registry. `WebSocketServer::with_peer_registry` adopts this
+    /// counter internally, so two servers sharing one registry never
+    /// mint colliding ids.
+    pub fn next_peer_id(&self) -> PeerId {
+        let value = self.next_id.fetch_add(1, Ordering::Relaxed);
+        debug_assert!(
+            value != PeerId::DETACHED.0,
+            "PeerRegistry id counter collided with PeerId::DETACHED sentinel \
+             (this requires ~2^64 connections; debug-only tripwire, not a contract)"
+        );
+        PeerId(value)
+    }
+
+    /// Internal counter handle shared with `WebSocketServer` so that
+    /// all servers wired to one registry mint unique ids.
+    pub(crate) fn id_counter(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.next_id)
+    }
+
+    /// Current number of connected peers.
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// `true` if no peers are connected.
+    pub fn is_empty(&self) -> bool {
+        self.lock().is_empty()
+    }
+
+    /// Snapshot of currently-connected peer handles.
+    ///
+    /// The registry lock is held only long enough to clone the values
+    /// into the returned `Vec`; callers can iterate freely without
+    /// blocking inserts or removals.
+    pub fn peers(&self) -> Vec<PeerHandle> {
+        self.lock().values().cloned().collect()
+    }
+
+    /// Look up a peer by id. Returns `None` if the peer has
+    /// disconnected.
+    pub fn get(&self, id: PeerId) -> Option<PeerHandle> {
+        self.lock().get(&id).cloned()
+    }
+
+    /// Insert a peer.
+    ///
+    /// Callers are responsible for ensuring `PeerId`s are unique
+    /// within one registry. `WebSocketServer::with_peer_registry`
+    /// already does this for you (it adopts the registry's id
+    /// counter); embedders rolling their own pipeline should mint ids
+    /// via [`PeerRegistry::next_peer_id`]. Overwriting an existing
+    /// entry trips a `debug_assert!` so the silent-corruption mode
+    /// (two servers minting `PeerId(0)` against a shared registry)
+    /// fires loudly in tests.
+    pub fn insert(&self, peer: PeerHandle) {
+        let prev = self.lock().insert(peer.peer_id(), peer);
+        debug_assert!(
+            prev.is_none(),
+            "PeerRegistry::insert overwrote an existing peer; \
+             two PeerHandles minted the same PeerId. If you wired multiple \
+             WebSocketServers to one PeerRegistry without using with_peer_registry, \
+             share PeerRegistry::next_peer_id across them."
+        );
+    }
+
+    /// Remove a peer. Returns the removed handle if it was present.
+    pub fn remove(&self, id: PeerId) -> Option<PeerHandle> {
+        self.lock().remove(&id)
+    }
+
+    /// Broadcast a JSON-bodied notify to every connected peer.
+    ///
+    /// The body is encoded once on the caller's task; the encoded
+    /// bytes are cloned into each peer's outbound channel. Returns a
+    /// per-peer result map so callers can surface backpressure
+    /// ([`PeerSendError::Full`]) or prune dead peers
+    /// ([`PeerSendError::Disconnected`]). The registry's lock is held
+    /// only long enough to snapshot the peer map; per-peer sends run
+    /// outside the lock, so a slow peer cannot stall delivery to the
+    /// others.
+    pub fn broadcast_notify_json<P, T>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<HashMap<PeerId, Result<(), PeerSendError>>, RepeError>
+    where
+        P: AsRef<str>,
+        T: Serialize + ?Sized,
+    {
+        let encoded = serde_json::to_vec(body)?;
+        Ok(self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Json(encoded.clone())))
+    }
+
+    /// BEVE-bodied broadcast. See [`broadcast_notify_json`] for
+    /// semantics.
+    ///
+    /// [`broadcast_notify_json`]: PeerRegistry::broadcast_notify_json
+    pub fn broadcast_notify_beve<P, T>(
+        &self,
+        path: P,
+        body: &T,
+    ) -> Result<HashMap<PeerId, Result<(), PeerSendError>>, RepeError>
+    where
+        P: AsRef<str>,
+        T: Serialize,
+    {
+        let encoded = beve::to_vec(body)?;
+        Ok(self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Beve(encoded.clone())))
+    }
+
+    /// UTF-8-bodied broadcast. Plain text is advertised with
+    /// [`BodyFormat::Utf8`].
+    pub fn broadcast_notify_utf8<P, S>(
+        &self,
+        path: P,
+        text: S,
+    ) -> HashMap<PeerId, Result<(), PeerSendError>>
+    where
+        P: AsRef<str>,
+        S: AsRef<str>,
+    {
+        let text = text.as_ref().to_owned();
+        self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Utf8(text.clone()))
+    }
+
+    /// Raw-body broadcast. The caller supplies the body bytes and the
+    /// [`BodyFormat`] tag the wire should advertise.
+    pub fn broadcast_notify_raw<P>(
+        &self,
+        path: P,
+        body_format: BodyFormat,
+        body: &[u8],
+    ) -> HashMap<PeerId, Result<(), PeerSendError>>
+    where
+        P: AsRef<str>,
+    {
+        let bytes = body.to_vec();
+        self.broadcast_each(path.as_ref(), move |_peer| {
+            NotifyBody::Raw(bytes.clone(), body_format)
+        })
+    }
+
+    fn broadcast_each<F>(
+        &self,
+        path: &str,
+        mut body_for: F,
+    ) -> HashMap<PeerId, Result<(), PeerSendError>>
+    where
+        F: FnMut(&PeerHandle) -> NotifyBody,
+    {
+        let snapshot = self.peers();
+        let mut out = HashMap::with_capacity(snapshot.len());
+        for peer in snapshot {
+            let body = body_for(&peer);
+            let result = peer.send_notify(path, body);
+            out.insert(peer.peer_id(), result);
+        }
+        out
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<PeerId, PeerHandle>> {
+        // Recover from poison: the map's invariants (an `Arc`-keyed
+        // `HashMap<PeerId, PeerHandle>` with no cross-entry coupling)
+        // cannot be left inconsistent by any single insert/remove, so
+        // honoring the poison would block the registry forever on the
+        // strength of an unrelated panic in some other code path.
+        match self.inner.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+impl std::fmt::Debug for PeerRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeerRegistry")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     #[derive(Default)]
     struct CapturingSink {
@@ -268,7 +507,7 @@ mod tests {
         let err = peer
             .send_notify("/z", NotifyBody::Json(b"{}".to_vec()))
             .unwrap_err();
-        matches!(err, PeerSendError::Disconnected);
+        assert!(matches!(err, PeerSendError::Disconnected));
         assert!(!peer.is_connected());
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -44,11 +44,7 @@ pub trait HandlerErased: Send + Sync {
     /// `handle` directly, so context-aware handlers also need to
     /// behave correctly when no peer is available (see
     /// [`CallContext::detached`]).
-    fn handle_with_ctx(
-        &self,
-        req: &Message,
-        _ctx: &CallContext,
-    ) -> Result<Message, RepeError> {
+    fn handle_with_ctx(&self, req: &Message, _ctx: &CallContext) -> Result<Message, RepeError> {
         self.handle(req)
     }
 }
@@ -129,11 +125,7 @@ impl HandlerErased for MiddlewarePipeline {
         Next::new(self.middlewares.as_ref(), self.handler.as_ref()).run(req)
     }
 
-    fn handle_with_ctx(
-        &self,
-        req: &Message,
-        ctx: &CallContext,
-    ) -> Result<Message, RepeError> {
+    fn handle_with_ctx(&self, req: &Message, ctx: &CallContext) -> Result<Message, RepeError> {
         Next::with_ctx(self.middlewares.as_ref(), self.handler.as_ref(), ctx).run(req)
     }
 }
@@ -188,11 +180,7 @@ where
         self.handle_with_ctx(req, &ctx)
     }
 
-    fn handle_with_ctx(
-        &self,
-        req: &Message,
-        ctx: &CallContext,
-    ) -> Result<Message, RepeError> {
+    fn handle_with_ctx(&self, req: &Message, ctx: &CallContext) -> Result<Message, RepeError> {
         let param = match decode_json_param(req)? {
             Ok(v) => v,
             Err(err) => return Ok(err),
@@ -362,11 +350,7 @@ where
         self.handle_with_ctx(req, &ctx)
     }
 
-    fn handle_with_ctx(
-        &self,
-        req: &Message,
-        ctx: &CallContext,
-    ) -> Result<Message, RepeError> {
+    fn handle_with_ctx(&self, req: &Message, ctx: &CallContext) -> Result<Message, RepeError> {
         let t: T = match decode_typed_param(req)? {
             Ok(v) => v,
             Err(err) => return Ok(err),
@@ -609,10 +593,7 @@ impl Router {
     /// [`with_json`]: Self::with_json
     pub fn with_json_ctx<F>(mut self, path: &str, handler: F) -> Self
     where
-        F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)>
-            + Send
-            + Sync
-            + 'static,
+        F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
     {
         let mut map = self.inner.as_ref().clone();
         map.insert(
@@ -850,11 +831,7 @@ impl HandlerErased for RegistryRequestHandler {
         }
     }
 
-    fn handle_with_ctx(
-        &self,
-        req: &Message,
-        ctx: &CallContext,
-    ) -> Result<Message, RepeError> {
+    fn handle_with_ctx(&self, req: &Message, ctx: &CallContext) -> Result<Message, RepeError> {
         let body = match Registry::decode_body(req) {
             Ok(value) => value,
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@ use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
 use crate::message::{Message, create_error_response_like, create_response};
+use crate::peer::CallContext;
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::server_request::route_request;
@@ -30,11 +31,32 @@ use std::{
 
 pub trait HandlerErased: Send + Sync {
     fn handle(&self, req: &Message) -> Result<Message, RepeError>;
+
+    /// Context-aware dispatch. Default implementation ignores the
+    /// context and delegates to [`handle`](Self::handle), so existing
+    /// implementors compile unchanged.
+    ///
+    /// Override this for handlers that need the calling peer (e.g.
+    /// push notifies to the originator during request handling) or
+    /// the dispatched method. The built-in
+    /// `WebSocketServer` invokes this method per request with a
+    /// [`CallContext`] carrying the peer; the TCP servers invoke
+    /// `handle` directly, so context-aware handlers also need to
+    /// behave correctly when no peer is available (see
+    /// [`CallContext::detached`]).
+    fn handle_with_ctx(
+        &self,
+        req: &Message,
+        _ctx: &CallContext,
+    ) -> Result<Message, RepeError> {
+        self.handle(req)
+    }
 }
 
 pub struct Next<'a> {
     middlewares: &'a [Arc<dyn Middleware>],
     handler: &'a dyn HandlerErased,
+    ctx: Option<&'a CallContext<'a>>,
 }
 
 impl<'a> Next<'a> {
@@ -42,15 +64,44 @@ impl<'a> Next<'a> {
         Self {
             middlewares,
             handler,
+            ctx: None,
+        }
+    }
+
+    fn with_ctx(
+        middlewares: &'a [Arc<dyn Middleware>],
+        handler: &'a dyn HandlerErased,
+        ctx: &'a CallContext<'a>,
+    ) -> Self {
+        Self {
+            middlewares,
+            handler,
+            ctx: Some(ctx),
         }
     }
 
     /// Continue to the next middleware (or final handler if this was the last middleware).
+    ///
+    /// If a [`CallContext`] was attached upstream (via
+    /// `WebSocketServer`'s peer-aware dispatch path), it is threaded
+    /// through to the leaf handler automatically. Middleware authors
+    /// do not need to be aware of the context to forward it; calling
+    /// `next.run(req)` preserves whatever the caller provided.
     pub fn run(self, req: &Message) -> Result<Message, RepeError> {
         if let Some((first, rest)) = self.middlewares.split_first() {
-            first.handle(req, Next::new(rest, self.handler))
+            first.handle(
+                req,
+                Next {
+                    middlewares: rest,
+                    handler: self.handler,
+                    ctx: self.ctx,
+                },
+            )
         } else {
-            self.handler.handle(req)
+            match self.ctx {
+                Some(ctx) => self.handler.handle_with_ctx(req, ctx),
+                None => self.handler.handle(req),
+            }
         }
     }
 }
@@ -77,6 +128,30 @@ impl HandlerErased for MiddlewarePipeline {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
         Next::new(self.middlewares.as_ref(), self.handler.as_ref()).run(req)
     }
+
+    fn handle_with_ctx(
+        &self,
+        req: &Message,
+        ctx: &CallContext,
+    ) -> Result<Message, RepeError> {
+        Next::with_ctx(self.middlewares.as_ref(), self.handler.as_ref(), ctx).run(req)
+    }
+}
+
+fn decode_json_param(req: &Message) -> Result<Result<Value, Message>, RepeError> {
+    let value: Value = match BodyFormat::try_from(req.header.body_format) {
+        Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
+        Ok(BodyFormat::Utf8) => serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
+        _ => {
+            return Ok(Err(create_error_response_like(
+                req,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
 }
 
 struct JsonHandler<F>(F)
@@ -88,21 +163,41 @@ where
     F: Fn(Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
 {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
-        let param: Value = match BodyFormat::try_from(req.header.body_format) {
-            Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
-            Ok(BodyFormat::Utf8) => {
-                serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?
-            }
-            Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
-            _ => {
-                return Ok(create_error_response_like(
-                    req,
-                    ErrorCode::InvalidBody,
-                    "Expected JSON body",
-                ));
-            }
+        let param = match decode_json_param(req)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
         };
         match (self.0)(param) {
+            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+}
+
+struct JsonHandlerCtx<F>(F)
+where
+    F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static;
+
+impl<F> HandlerErased for JsonHandlerCtx<F>
+where
+    F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
+{
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let path = req.query_str().unwrap_or("");
+        let ctx = CallContext::detached(path);
+        self.handle_with_ctx(req, &ctx)
+    }
+
+    fn handle_with_ctx(
+        &self,
+        req: &Message,
+        ctx: &CallContext,
+    ) -> Result<Message, RepeError> {
+        let param = match decode_json_param(req)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match (self.0)(ctx, param) {
             Ok(value) => create_response(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
@@ -177,6 +272,25 @@ where
     }
 }
 
+fn decode_typed_param<T>(req: &Message) -> Result<Result<T, Message>, RepeError>
+where
+    T: DeserializeOwned,
+{
+    let value: T = match BodyFormat::try_from(req.header.body_format) {
+        Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
+        Ok(BodyFormat::Utf8) => serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
+        _ => {
+            return Ok(Err(create_error_response_like(
+                req,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
+}
+
 struct TypedHandler<T, R, F>(F, std::marker::PhantomData<(T, R)>)
 where
     T: DeserializeOwned + Send + Sync + 'static,
@@ -190,21 +304,74 @@ where
     F: TypedHandlerFn<T, R>,
 {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
-        let t: T = match BodyFormat::try_from(req.header.body_format) {
-            Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
-            Ok(BodyFormat::Utf8) => {
-                serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?
-            }
-            Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
-            _ => {
-                return Ok(create_error_response_like(
-                    req,
-                    ErrorCode::InvalidBody,
-                    "Expected JSON body",
-                ));
-            }
+        let t: T = match decode_typed_param(req)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
         };
         match self.0.call(t) {
+            Ok(r) => {
+                let (value, format) = r.into_typed_response();
+                create_response(req, value, format)
+            }
+            Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+}
+
+/// Trait shape mirroring [`TypedHandlerFn`] for context-aware typed
+/// handlers. Implemented by closures of the form
+/// `Fn(&CallContext, T) -> Result<R, (ErrorCode, String)>`.
+pub trait TypedHandlerFnCtx<T, R>: Send + Sync + 'static
+where
+    T: DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+{
+    type Response: IntoTypedResponse<R>;
+    fn call(&self, ctx: &CallContext, input: T) -> Result<Self::Response, (ErrorCode, String)>;
+}
+
+impl<T, R, S, F> TypedHandlerFnCtx<T, R> for F
+where
+    T: DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+    S: IntoTypedResponse<R>,
+    F: Fn(&CallContext, T) -> Result<S, (ErrorCode, String)> + Send + Sync + 'static,
+{
+    type Response = S;
+
+    fn call(&self, ctx: &CallContext, input: T) -> Result<Self::Response, (ErrorCode, String)> {
+        (self)(ctx, input)
+    }
+}
+
+struct TypedHandlerCtx<T, R, F>(F, std::marker::PhantomData<(T, R)>)
+where
+    T: DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+    F: TypedHandlerFnCtx<T, R>;
+
+impl<T, R, F> HandlerErased for TypedHandlerCtx<T, R, F>
+where
+    T: DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+    F: TypedHandlerFnCtx<T, R>,
+{
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let path = req.query_str().unwrap_or("");
+        let ctx = CallContext::detached(path);
+        self.handle_with_ctx(req, &ctx)
+    }
+
+    fn handle_with_ctx(
+        &self,
+        req: &Message,
+        ctx: &CallContext,
+    ) -> Result<Message, RepeError> {
+        let t: T = match decode_typed_param(req)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match self.0.call(ctx, t) {
             Ok(r) => {
                 let (value, format) = r.into_typed_response();
                 create_response(req, value, format)
@@ -405,6 +572,71 @@ impl Router {
         map.insert(
             path.to_string(),
             Arc::new(TypedHandler::<T, R, F>(f, std::marker::PhantomData))
+                as Arc<dyn HandlerErased>,
+        );
+        self.inner = Arc::new(map);
+        self
+    }
+
+    /// Context-aware JSON handler. Same shape as [`with_json`] but the
+    /// closure also receives a [`CallContext`] carrying the calling
+    /// peer (when one is available) and the dispatched method.
+    ///
+    /// Typical use: push a notify back to the calling peer during
+    /// request handling, e.g. progress updates while a long-running
+    /// call is in flight.
+    ///
+    /// ```ignore
+    /// use repe::server::Router;
+    /// use repe::NotifyBody;
+    ///
+    /// let router = Router::new().with_json_ctx("/start", |ctx, params| {
+    ///     if let Some(peer) = ctx.peer() {
+    ///         let _ = peer.send_notify(
+    ///             "/progress",
+    ///             NotifyBody::Json(serde_json::to_vec(&serde_json::json!({
+    ///                 "stage": "begin"
+    ///             })).unwrap()),
+    ///         );
+    ///     }
+    ///     Ok(serde_json::json!({ "started": true }))
+    /// });
+    /// ```
+    ///
+    /// When dispatched without a peer (TCP transports, direct
+    /// in-process calls), `ctx.peer()` returns `None`.
+    ///
+    /// [`with_json`]: Self::with_json
+    pub fn with_json_ctx<F>(mut self, path: &str, handler: F) -> Self
+    where
+        F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let mut map = self.inner.as_ref().clone();
+        map.insert(
+            path.to_string(),
+            Arc::new(JsonHandlerCtx(handler)) as Arc<dyn HandlerErased>,
+        );
+        self.inner = Arc::new(map);
+        self
+    }
+
+    /// Context-aware typed handler. Same shape as [`with_typed`] but
+    /// the closure also receives a [`CallContext`].
+    ///
+    /// [`with_typed`]: Self::with_typed
+    pub fn with_typed_ctx<T, R, F>(mut self, path: &str, f: F) -> Self
+    where
+        T: DeserializeOwned + Send + Sync + 'static,
+        R: Serialize + Send + Sync + 'static,
+        F: TypedHandlerFnCtx<T, R>,
+    {
+        let mut map = self.inner.as_ref().clone();
+        map.insert(
+            path.to_string(),
+            Arc::new(TypedHandlerCtx::<T, R, F>(f, std::marker::PhantomData))
                 as Arc<dyn HandlerErased>,
         );
         self.inner = Arc::new(map);
@@ -613,6 +845,22 @@ impl HandlerErased for RegistryRequestHandler {
         };
 
         match self.registry.dispatch(&self.pointer, body) {
+            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
+        }
+    }
+
+    fn handle_with_ctx(
+        &self,
+        req: &Message,
+        ctx: &CallContext,
+    ) -> Result<Message, RepeError> {
+        let body = match Registry::decode_body(req) {
+            Ok(value) => value,
+            Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
+        };
+
+        match self.registry.dispatch_with_ctx(&self.pointer, body, ctx) {
             Ok(value) => create_response(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -1,8 +1,19 @@
 use crate::constants::{ErrorCode, QueryFormat, REPE_VERSION};
 use crate::message::{Message, create_error_response_like};
+use crate::peer::CallContext;
 use crate::server::Router;
 
 pub(crate) fn route_request(router: &Router, req: &Message) -> Option<Message> {
+    let path = req.query_str().unwrap_or("");
+    let ctx = CallContext::detached(path);
+    route_request_with_ctx(router, req, &ctx)
+}
+
+pub(crate) fn route_request_with_ctx(
+    router: &Router,
+    req: &Message,
+    ctx: &CallContext,
+) -> Option<Message> {
     let notify = req.header.notify == 1;
 
     if req.header.version != REPE_VERSION {
@@ -42,13 +53,13 @@ pub(crate) fn route_request(router: &Router, req: &Message) -> Option<Message> {
 
     if notify {
         if let Some(handler) = router.get(path) {
-            let _ = handler.handle(req);
+            let _ = handler.handle_with_ctx(req, ctx);
         }
         return None;
     }
 
     Some(match router.get(path) {
-        Some(handler) => match handler.handle(req) {
+        Some(handler) => match handler.handle_with_ctx(req, ctx) {
             Ok(message) => message,
             Err(err) => create_error_response_like(req, err.to_error_code(), err.to_string()),
         },

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -2,7 +2,9 @@ use crate::async_client::AsyncClient;
 use crate::constants::QueryFormat;
 use crate::error::RepeError;
 use crate::message::Message;
-use crate::peer::{CallContext, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink};
+use crate::peer::{
+    CallContext, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink,
+};
 use crate::server::Router;
 use crate::server_request::route_request_with_ctx;
 use futures_util::stream::{SplitSink, SplitStream};
@@ -627,10 +629,7 @@ mod tests {
 
         // Round-trip a request so we know the peer is registered by
         // the time the broadcast runs.
-        let _ = client
-            .call_json("/ping", &json!({}))
-            .await
-            .unwrap();
+        let _ = client.call_json("/ping", &json!({})).await.unwrap();
 
         assert_eq!(peers.len(), 1);
         let results = peers
@@ -988,9 +987,7 @@ mod tests {
             if let Some(peer) = ctx.peer() {
                 let _ = peer.send_notify(
                     "/progress",
-                    NotifyBody::Json(
-                        serde_json::to_vec(&json!({ "stage": "running" })).unwrap(),
-                    ),
+                    NotifyBody::Json(serde_json::to_vec(&json!({ "stage": "running" })).unwrap()),
                 );
             }
             Ok(json!({ "done": true }))
@@ -1154,8 +1151,7 @@ mod tests {
         // Both peers must be present with distinct ids.
         assert_eq!(peers.len(), 2);
         let snapshot = peers.peers();
-        let ids: std::collections::HashSet<_> =
-            snapshot.iter().map(|p| p.peer_id().0).collect();
+        let ids: std::collections::HashSet<_> = snapshot.iter().map(|p| p.peer_id().0).collect();
         assert_eq!(ids.len(), 2, "shared registry minted colliding PeerIds");
 
         drop(c1);

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -2,9 +2,9 @@ use crate::async_client::AsyncClient;
 use crate::constants::QueryFormat;
 use crate::error::RepeError;
 use crate::message::Message;
-use crate::peer::{NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink};
+use crate::peer::{CallContext, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink};
 use crate::server::Router;
-use crate::server_request::route_request;
+use crate::server_request::route_request_with_ctx;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use std::io::ErrorKind;
@@ -263,9 +263,12 @@ async fn handle_connection_with_config(
         for hook in config.on_connect.iter() {
             hook(peer.clone());
         }
-        drop(peer); // Local clone no longer needed; hooks own theirs.
 
-        reader_task(ws_reader, &config.router, outbound_tx).await
+        // Keep `peer` in the reader scope; it is threaded into each
+        // request's `CallContext` so handlers can push notifies back
+        // to the originator (via `Router::with_json_ctx` /
+        // `with_typed_ctx` or a registry-backed `RegistryCallable`).
+        reader_task(ws_reader, &config.router, outbound_tx, peer).await
         // _guard drops here (on every exit path, including unwind),
         // firing disconnect hooks. Any registry entry holding a
         // PeerHandle clone (and thus a sender clone) is released,
@@ -290,6 +293,7 @@ async fn reader_task(
     mut ws_reader: SplitStream<WebSocketStream<TcpStream>>,
     router: &Router,
     outbound_tx: mpsc::Sender<Message>,
+    peer: PeerHandle,
 ) -> Result<(), RepeError> {
     loop {
         let frame = match ws_reader.next().await {
@@ -304,7 +308,15 @@ async fn reader_task(
             FrameAction::Close => break,
         };
 
-        if let Some(response) = route_request(router, &request) {
+        // Build a CallContext threading the calling peer to handlers.
+        // Handlers registered via `Router::with_json_ctx` /
+        // `with_typed_ctx` (or registry-backed callables that take a
+        // `CallContext`) can reach `ctx.peer()` and push notifies back
+        // through this connection's outbound channel during request
+        // handling.
+        let path = request.query_str().unwrap_or("");
+        let ctx = CallContext::new(path, &peer);
+        if let Some(response) = route_request_with_ctx(router, &request, &ctx) {
             if outbound_tx.send(response).await.is_err() {
                 // Writer task exited (likely wire error); abandon
                 // reader. The disconnect guard will still fire when
@@ -313,6 +325,9 @@ async fn reader_task(
             }
         }
     }
+    // `peer` drops here, releasing this connection's sender clone of
+    // the outbound channel and helping the writer drain.
+    drop(peer);
     Ok(())
 }
 
@@ -961,6 +976,152 @@ mod tests {
             peers.is_empty(),
             "panicking connect hook leaked peer in registry"
         );
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handler_pushes_notify_to_calling_peer_via_with_json_ctx() {
+        // A handler registered via with_json_ctx pushes a progress
+        // notify back to the calling peer mid-request. Both the
+        // notify and the response must arrive on the same connection.
+        let router = Router::new().with_json_ctx("/work", |ctx, _params| {
+            if let Some(peer) = ctx.peer() {
+                let _ = peer.send_notify(
+                    "/progress",
+                    NotifyBody::Json(
+                        serde_json::to_vec(&json!({ "stage": "running" })).unwrap(),
+                    ),
+                );
+            }
+            Ok(json!({ "done": true }))
+        });
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router);
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+
+        let resp = client.call_json("/work", &json!({})).await.unwrap();
+        assert_eq!(resp, json!({ "done": true }));
+
+        let pushed = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("progress notify did not arrive")
+            .expect("channel closed");
+        assert!(pushed.header.notify != 0);
+        assert_eq!(pushed.query_str().unwrap(), "/progress");
+        let body: serde_json::Value = pushed.json_body().unwrap();
+        assert_eq!(body, json!({ "stage": "running" }));
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ctx_handler_sees_no_peer_under_legacy_handle() {
+        // When a context-aware handler is invoked via the legacy
+        // HandlerErased::handle path (no peer threaded), ctx.peer()
+        // is None. This guards the TCP-transport / direct-dispatch
+        // fallback shape so a ctx-aware handler does not panic when
+        // there is no peer.
+        let router = Router::new().with_json_ctx("/probe", |ctx, _params| {
+            Ok(json!({ "has_peer": ctx.peer().is_some() }))
+        });
+        let handler = router.get("/probe").expect("handler exists");
+
+        let req = Message::builder()
+            .id(1)
+            .query_str("/probe")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({}))
+            .unwrap()
+            .build();
+        let resp = handler.handle(&req).unwrap();
+        let body: serde_json::Value = resp.json_body().unwrap();
+        assert_eq!(body, json!({ "has_peer": false }));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn registry_callable_receives_peer_via_with_context() {
+        // A Registry-backed handler wrapped in `WithContext` must see
+        // the calling peer when the request comes in over the
+        // WebSocket transport.
+        use crate::Registry;
+        use crate::registry::WithContext;
+
+        let registry = Arc::new(Registry::new());
+        registry
+            .register_function(
+                "/work",
+                WithContext(|ctx: &CallContext, _params| {
+                    if let Some(peer) = ctx.peer() {
+                        let _ = peer.send_notify(
+                            "/progress",
+                            NotifyBody::Json(
+                                serde_json::to_vec(&json!({ "stage": "registry" })).unwrap(),
+                            ),
+                        );
+                    }
+                    Ok(json!({ "done": true }))
+                }),
+            )
+            .unwrap();
+
+        let router = Router::new().with_registry("", Arc::clone(&registry));
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router);
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+
+        let resp = client.call_json("/work", &json!({})).await.unwrap();
+        assert_eq!(resp, json!({ "done": true }));
+
+        let pushed = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("registry handler did not push a notify")
+            .expect("channel closed");
+        assert_eq!(pushed.query_str().unwrap(), "/progress");
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn middleware_preserves_ctx_across_pipeline() {
+        // Middleware that calls next.run(req) without knowing about
+        // CallContext must still thread ctx to the leaf handler.
+        // This is what lets existing middleware compose with new
+        // context-aware handlers.
+        use crate::server::Next;
+        let router = Router::new()
+            .with_middleware(|req: &Message, next: Next<'_>| next.run(req))
+            .with_json_ctx("/work", |ctx, _params| {
+                Ok(json!({ "has_peer": ctx.peer().is_some() }))
+            });
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router);
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let resp = client.call_json("/work", &json!({})).await.unwrap();
+        assert_eq!(resp, json!({ "has_peer": true }));
+
+        drop(client);
         server_task.abort();
     }
 

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1,28 +1,134 @@
 use crate::async_client::AsyncClient;
+use crate::constants::QueryFormat;
 use crate::error::RepeError;
 use crate::message::Message;
+use crate::peer::{NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError, PeerSink};
 use crate::server::Router;
 use crate::server_request::route_request;
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use std::io::ErrorKind;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::oneshot;
+use tokio::time::Duration;
 use tokio_tungstenite::tungstenite::handshake::server::{
     Callback, ErrorResponse, Request, Response,
 };
 use tokio_tungstenite::tungstenite::{self, Message as WsMessage, http::StatusCode};
 use tokio_tungstenite::{WebSocketStream, accept_hdr_async};
 
+type ConnectHook = Arc<dyn Fn(PeerHandle) + Send + Sync>;
+type DisconnectHook = Arc<dyn Fn(PeerId) + Send + Sync>;
+
+/// Default per-connection outbound channel capacity.
+///
+/// Each accepted connection allocates a bounded `tokio::sync::mpsc`
+/// channel of this size for outbound messages (responses + pushed
+/// notifies). A full channel surfaces back as
+/// [`PeerSendError::Full`](crate::PeerSendError) on the next
+/// [`PeerHandle::send_notify`] attempt. Override per server with
+/// [`WebSocketServer::with_outbound_capacity`].
+pub const DEFAULT_OUTBOUND_CAPACITY: usize = 256;
+
+/// Upper bound on how long the writer task spends draining queued
+/// messages after the connection's reader has exited. A slow or
+/// unresponsive peer (where TCP has not yet errored) cannot pin the
+/// connection task open past this deadline.
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub struct WebSocketServer {
     router: Router,
+    outbound_capacity: usize,
+    peer_id_counter: Arc<AtomicU64>,
+    on_connect: Vec<ConnectHook>,
+    on_disconnect: Vec<DisconnectHook>,
 }
 
 impl WebSocketServer {
     pub fn new(router: Router) -> Self {
-        Self { router }
+        Self {
+            router,
+            outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
+            peer_id_counter: Arc::new(AtomicU64::new(0)),
+            on_connect: Vec::new(),
+            on_disconnect: Vec::new(),
+        }
     }
 
     pub async fn listen<A: ToSocketAddrs>(addr: A) -> std::io::Result<TcpListener> {
         TcpListener::bind(addr).await
+    }
+
+    /// Per-connection outbound channel capacity. Defaults to
+    /// [`DEFAULT_OUTBOUND_CAPACITY`]. A full channel returns
+    /// [`PeerSendError::Full`](crate::PeerSendError) from
+    /// [`PeerHandle::send_notify`]; the embedder decides whether to
+    /// retry, drop, or prune.
+    ///
+    /// Panics if `capacity == 0` (bounded mpsc with zero capacity has
+    /// surprising semantics; this is programmer error).
+    pub fn with_outbound_capacity(mut self, capacity: usize) -> Self {
+        assert!(
+            capacity >= 1,
+            "WebSocketServer outbound capacity must be >= 1"
+        );
+        self.outbound_capacity = capacity;
+        self
+    }
+
+    /// Attach a [`PeerRegistry`] so this server's accepted peers are
+    /// inserted on connect and removed on disconnect. The registry is
+    /// `Arc`-shared so background tasks can clone it and broadcast.
+    ///
+    /// Sugar over [`on_peer_connect`](Self::on_peer_connect) +
+    /// [`on_peer_disconnect`](Self::on_peer_disconnect). Calling this
+    /// does not exclude additional connect/disconnect callbacks; hooks
+    /// fire in registration order.
+    ///
+    /// The server's `PeerId` allocator is swapped for the registry's,
+    /// so two `WebSocketServer`s sharing one registry mint
+    /// non-colliding ids. If you call `with_peer_registry` more than
+    /// once on the same server, the most recent registry's counter
+    /// wins.
+    pub fn with_peer_registry(mut self, registry: PeerRegistry) -> Self {
+        self.peer_id_counter = registry.id_counter();
+        let insert_registry = registry.clone();
+        let remove_registry = registry;
+        self.on_peer_connect(move |peer| insert_registry.insert(peer))
+            .on_peer_disconnect(move |id| {
+                remove_registry.remove(id);
+            })
+    }
+
+    /// Run `f` from the per-connection task on accept, just after the
+    /// `PeerHandle` is built and *before* the reader/writer tasks
+    /// start processing traffic. Notifies queued from `f` via
+    /// `peer.send_notify(...)` are guaranteed to land on the wire
+    /// before any response.
+    ///
+    /// The callback runs synchronously on the accept task and must not
+    /// block; offload work to a channel or `tokio::spawn` if needed.
+    pub fn on_peer_connect<F>(mut self, f: F) -> Self
+    where
+        F: Fn(PeerHandle) + Send + Sync + 'static,
+    {
+        self.on_connect.push(Arc::new(f));
+        self
+    }
+
+    /// Run `f` when the connection closes (any exit path: clean Close
+    /// frame, transport error, handler panic). Fires exactly once per
+    /// accepted connection.
+    pub fn on_peer_disconnect<F>(mut self, f: F) -> Self
+    where
+        F: Fn(PeerId) + Send + Sync + 'static,
+    {
+        self.on_disconnect.push(Arc::new(f));
+        self
     }
 
     pub async fn serve<A: ToSocketAddrs>(self, addr: A, path: &str) -> std::io::Result<()> {
@@ -32,15 +138,22 @@ impl WebSocketServer {
 
     pub async fn serve_listener(self, listener: TcpListener, path: &str) -> std::io::Result<()> {
         let expected_path = normalize_path(path);
+        let config = Arc::new(ConnectionConfig {
+            router: self.router,
+            outbound_capacity: self.outbound_capacity,
+            peer_id_counter: self.peer_id_counter,
+            on_connect: Arc::new(self.on_connect),
+            on_disconnect: Arc::new(self.on_disconnect),
+        });
 
         loop {
             let (stream, _addr) = listener.accept().await?;
-            let router = self.router.clone();
             let expected_path = expected_path.clone();
+            let config = Arc::clone(&config);
             tokio::spawn(async move {
                 match accept_repe_websocket(stream, &expected_path).await {
                     Ok(ws_stream) => {
-                        if let Err(err) = handle_connection(ws_stream, router).await {
+                        if let Err(err) = handle_connection_with_config(ws_stream, config).await {
                             eprintln!("[repe] websocket connection error: {err}");
                         }
                     }
@@ -51,6 +164,14 @@ impl WebSocketServer {
             });
         }
     }
+}
+
+struct ConnectionConfig {
+    router: Router,
+    outbound_capacity: usize,
+    peer_id_counter: Arc<AtomicU64>,
+    on_connect: Arc<Vec<ConnectHook>>,
+    on_disconnect: Arc<Vec<DisconnectHook>>,
 }
 
 pub async fn proxy_connection<S>(
@@ -101,14 +222,77 @@ async fn accept_repe_websocket(
     .map_err(websocket_transport_error)
 }
 
-async fn handle_connection(
+async fn handle_connection_with_config(
     ws_stream: WebSocketStream<TcpStream>,
-    router: Router,
+    config: Arc<ConnectionConfig>,
 ) -> Result<(), RepeError> {
-    let (mut writer, mut reader) = ws_stream.split();
+    let (outbound_tx, outbound_rx) = mpsc::channel::<Message>(config.outbound_capacity);
 
+    let peer_id_value = config.peer_id_counter.fetch_add(1, Ordering::Relaxed);
+    debug_assert!(
+        peer_id_value != PeerId::DETACHED.0,
+        "peer id counter collided with PeerId::DETACHED sentinel"
+    );
+    let peer_id = PeerId(peer_id_value);
+
+    let sink = Arc::new(WsPeerSink {
+        tx: outbound_tx.clone(),
+    });
+    let peer = PeerHandle::new(peer_id, sink);
+
+    // Build the disconnect guard *before* invoking connect hooks. If a
+    // later connect hook panics after an earlier one (e.g. the
+    // registry-insert hook) has already side-effected, unwinding still
+    // runs the guard's Drop and the disconnect hook tears the
+    // partial state back down. Without this ordering, a panicking
+    // connect hook leaves the peer wedged in the registry forever.
+    let (ws_writer, ws_reader) = ws_stream.split();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let writer_handle = tokio::spawn(writer_task(ws_writer, outbound_rx, shutdown_rx));
+
+    let reader_result = {
+        let _guard = DisconnectGuard {
+            peer_id,
+            hooks: Arc::clone(&config.on_disconnect),
+        };
+
+        // Fire connect hooks *before* the reader/writer tasks process
+        // traffic, so any notifies queued here are already in the
+        // outbound channel when the writer task begins draining.
+        for hook in config.on_connect.iter() {
+            hook(peer.clone());
+        }
+        drop(peer); // Local clone no longer needed; hooks own theirs.
+
+        reader_task(ws_reader, &config.router, outbound_tx).await
+        // _guard drops here (on every exit path, including unwind),
+        // firing disconnect hooks. Any registry entry holding a
+        // PeerHandle clone (and thus a sender clone) is released,
+        // helping the writer task drain.
+    };
+
+    // Tell the writer to drain any queued messages and exit, regardless
+    // of whether sender clones still linger in user-held PeerHandles.
+    let _ = shutdown_tx.send(());
+
+    let writer_result = match writer_handle.await {
+        Ok(r) => r,
+        Err(join_err) => Err(RepeError::Io(std::io::Error::other(format!(
+            "websocket writer task panicked: {join_err}"
+        )))),
+    };
+
+    reader_result.and(writer_result)
+}
+
+async fn reader_task(
+    mut ws_reader: SplitStream<WebSocketStream<TcpStream>>,
+    router: &Router,
+    outbound_tx: mpsc::Sender<Message>,
+) -> Result<(), RepeError> {
     loop {
-        let frame = match reader.next().await {
+        let frame = match ws_reader.next().await {
             Some(Ok(frame)) => frame,
             Some(Err(err)) => return Err(websocket_transport_error(err)),
             None => break,
@@ -120,16 +304,110 @@ async fn handle_connection(
             FrameAction::Close => break,
         };
 
-        if let Some(response) = route_request(&router, &request) {
-            writer
-                .send(WsMessage::Binary(response.to_vec()))
-                .await
-                .map_err(websocket_transport_error)?;
+        if let Some(response) = route_request(router, &request) {
+            if outbound_tx.send(response).await.is_err() {
+                // Writer task exited (likely wire error); abandon
+                // reader. The disconnect guard will still fire when
+                // we return.
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn writer_task(
+    mut ws_writer: SplitSink<WebSocketStream<TcpStream>, WsMessage>,
+    mut outbound_rx: mpsc::Receiver<Message>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) -> Result<(), RepeError> {
+    let mut result: Result<(), RepeError> = Ok(());
+    loop {
+        tokio::select! {
+            biased;
+            // Drain queued messages preferentially so already-enqueued
+            // notifies make the wire before shutdown.
+            msg = outbound_rx.recv() => match msg {
+                Some(m) => {
+                    if let Err(err) = ws_writer
+                        .send(WsMessage::Binary(m.to_vec()))
+                        .await
+                    {
+                        result = Err(websocket_transport_error(err));
+                        break;
+                    }
+                }
+                None => break,
+            },
+            _ = &mut shutdown_rx => {
+                // Shutdown requested: flush whatever is immediately
+                // available, then exit. Bounded by SHUTDOWN_DRAIN_TIMEOUT
+                // so a slow peer (TCP still responsive but throttled)
+                // cannot pin the connection task open. Sends that
+                // arrive after we break are discarded when outbound_rx
+                // drops.
+                let deadline = tokio::time::Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
+                while let Ok(m) = outbound_rx.try_recv() {
+                    let send_fut = ws_writer.send(WsMessage::Binary(m.to_vec()));
+                    match tokio::time::timeout_at(deadline, send_fut).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(err)) => {
+                            result = Err(websocket_transport_error(err));
+                            break;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                break;
+            }
+        }
+    }
+    let deadline = tokio::time::Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
+    let _ = tokio::time::timeout_at(deadline, ws_writer.send(WsMessage::Close(None))).await;
+    let _ = tokio::time::timeout_at(deadline, ws_writer.close()).await;
+    result
+}
+
+pub(crate) struct WsPeerSink {
+    tx: mpsc::Sender<Message>,
+}
+
+impl PeerSink for WsPeerSink {
+    fn send_notify(&self, method: &str, body: NotifyBody) -> Result<(), PeerSendError> {
+        let body_format = body.body_format();
+        let body_bytes = body.into_bytes();
+        let msg = Message::builder()
+            .id(0)
+            .notify(true)
+            .query_str(method)
+            .query_format(QueryFormat::JsonPointer)
+            .body_format_code(u16::from(body_format))
+            .body_bytes(body_bytes)
+            .build();
+
+        match self.tx.try_send(msg) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(PeerSendError::Full),
+            Err(TrySendError::Closed(_)) => Err(PeerSendError::Disconnected),
         }
     }
 
-    let _ = writer.send(WsMessage::Close(None)).await;
-    writer.close().await.map_err(websocket_transport_error)
+    fn is_connected(&self) -> bool {
+        !self.tx.is_closed()
+    }
+}
+
+struct DisconnectGuard {
+    peer_id: PeerId,
+    hooks: Arc<Vec<DisconnectHook>>,
+}
+
+impl Drop for DisconnectGuard {
+    fn drop(&mut self) {
+        for hook in self.hooks.iter() {
+            hook(self.peer_id);
+        }
+    }
 }
 
 enum FrameAction {
@@ -201,8 +479,25 @@ impl Callback for WebSocketPathValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::BodyFormat;
     use crate::websocket_client::WebSocketClient;
     use serde_json::json;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    async fn run_default_connection(
+        ws_stream: WebSocketStream<TcpStream>,
+        router: Router,
+    ) -> Result<(), RepeError> {
+        let config = Arc::new(ConnectionConfig {
+            router,
+            outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
+            peer_id_counter: Arc::new(AtomicU64::new(0)),
+            on_connect: Arc::new(Vec::new()),
+            on_disconnect: Arc::new(Vec::new()),
+        });
+        handle_connection_with_config(ws_stream, config).await
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn websocket_server_roundtrip() {
@@ -218,7 +513,7 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let ws_stream = accept_repe_websocket(stream, "/repe").await.unwrap();
-            handle_connection(ws_stream, router).await.unwrap();
+            run_default_connection(ws_stream, router).await.unwrap();
         });
 
         let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
@@ -269,5 +564,442 @@ mod tests {
         drop(client);
         proxy_task.await.unwrap();
         upstream_task.abort();
+    }
+
+    async fn serve_one(
+        listener: TcpListener,
+        path: &str,
+        server: WebSocketServer,
+    ) -> tokio::task::JoinHandle<()> {
+        let path = path.to_string();
+        let config = Arc::new(ConnectionConfig {
+            router: server.router,
+            outbound_capacity: server.outbound_capacity,
+            peer_id_counter: server.peer_id_counter,
+            on_connect: Arc::new(server.on_connect),
+            on_disconnect: Arc::new(server.on_disconnect),
+        });
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let path = path.clone();
+                let config = Arc::clone(&config);
+                tokio::spawn(async move {
+                    if let Ok(ws_stream) = accept_repe_websocket(stream, &path).await {
+                        let _ = handle_connection_with_config(ws_stream, config).await;
+                    }
+                });
+            }
+        })
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn registry_receives_broadcast() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+
+        // Round-trip a request so we know the peer is registered by
+        // the time the broadcast runs.
+        let _ = client
+            .call_json("/ping", &json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(peers.len(), 1);
+        let results = peers
+            .broadcast_notify_json("/announce", &json!({ "hello": "world" }))
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        for r in results.values() {
+            r.as_ref().expect("broadcast send");
+        }
+
+        let pushed = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("notify did not arrive")
+            .expect("subscriber channel closed");
+        assert!(pushed.header.notify != 0);
+        assert_eq!(pushed.query_str().unwrap(), "/announce");
+        let body: serde_json::Value = pushed.json_body().unwrap();
+        assert_eq!(body, json!({ "hello": "world" }));
+
+        drop(client);
+        // Wait for disconnect to propagate.
+        for _ in 0..50 {
+            if peers.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(peers.is_empty(), "peer not removed after disconnect");
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_reaches_multiple_peers() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let mut clients = Vec::new();
+        let mut receivers = Vec::new();
+        for _ in 0..3 {
+            let c = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+                .await
+                .unwrap();
+            let rx = c.subscribe_notifies().expect("subscribe");
+            // Synchronize so the peer is registered.
+            c.call_json("/ping", &json!({})).await.unwrap();
+            clients.push(c);
+            receivers.push(rx);
+        }
+
+        assert_eq!(peers.len(), 3);
+        let results = peers
+            .broadcast_notify_json("/event", &json!({ "n": 1 }))
+            .unwrap();
+        assert_eq!(results.len(), 3);
+        for r in results.values() {
+            r.as_ref().expect("broadcast send");
+        }
+
+        for mut rx in receivers {
+            let pushed = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .expect("notify did not arrive")
+                .expect("channel closed");
+            assert_eq!(pushed.query_str().unwrap(), "/event");
+        }
+
+        for c in clients {
+            drop(c);
+        }
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn connect_hook_queued_notify_arrives_before_response() {
+        let router = Router::new().with_json("/sync", |_| Ok(json!({ "ok": true })));
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router).on_peer_connect(|peer| {
+            // Hook queues a notify before any traffic. The writer task
+            // drains this before any response can be produced.
+            let _ = peer.send_notify(
+                "/welcome",
+                NotifyBody::Json(serde_json::to_vec(&json!({ "id": peer.peer_id().0 })).unwrap()),
+            );
+        });
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+
+        // The welcome notify must arrive before the /sync response.
+        let pushed = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("welcome notify did not arrive")
+            .expect("channel closed");
+        assert_eq!(pushed.query_str().unwrap(), "/welcome");
+
+        let resp = client.call_json("/sync", &json!({})).await.unwrap();
+        assert_eq!(resp, json!({ "ok": true }));
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disconnect_hook_fires_on_drop() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let disconnected = Arc::new(Mutex::new(Vec::<PeerId>::new()));
+        let disconnected_clone = Arc::clone(&disconnected);
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router)
+            .on_peer_disconnect(move |id| disconnected_clone.lock().unwrap().push(id));
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        // Synchronize so the connection is fully accepted.
+        client.call_json("/ping", &json!({})).await.unwrap();
+        drop(client);
+
+        for _ in 0..50 {
+            if !disconnected.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let observed = disconnected.lock().unwrap();
+        assert_eq!(observed.len(), 1, "expected exactly one disconnect");
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn slow_consumer_surfaces_backpressure() {
+        // Capacity 1: the second outbound send saturates the channel.
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router)
+            .with_outbound_capacity(1)
+            .with_peer_registry(peers.clone());
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        // Subscribe but never drain, so notifies accumulate in the
+        // *server's* outbound channel as well (after the writer fills
+        // its own buffer). The exact mechanism doesn't matter; we
+        // just need to push enough that try_send eventually returns
+        // Full.
+        let _notifies = client.subscribe_notifies().expect("subscribe");
+        client.call_json("/ping", &json!({})).await.unwrap();
+
+        assert_eq!(peers.len(), 1);
+
+        // Push notifies until we see Full. The bound is small so this
+        // happens quickly; cap at a generous limit.
+        let mut saw_full = false;
+        for i in 0..1024 {
+            let results = peers
+                .broadcast_notify_json("/burst", &json!({ "i": i }))
+                .unwrap();
+            for (_, r) in results {
+                match r {
+                    Err(PeerSendError::Full) => {
+                        saw_full = true;
+                        break;
+                    }
+                    Err(PeerSendError::Disconnected) => break,
+                    _ => {}
+                }
+            }
+            if saw_full {
+                break;
+            }
+        }
+        assert!(saw_full, "expected PeerSendError::Full under backpressure");
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_after_disconnect_surfaces_disconnected() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        client.call_json("/ping", &json!({})).await.unwrap();
+        assert_eq!(peers.len(), 1);
+
+        // Snapshot the peer handles so we can keep them after the
+        // registry removes them on disconnect.
+        let captured = peers.peers();
+        assert_eq!(captured.len(), 1);
+
+        drop(client);
+        for _ in 0..50 {
+            if peers.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(peers.is_empty());
+
+        // The captured handle's outbound channel is now closed.
+        let err = captured[0]
+            .send_notify("/after", NotifyBody::Json(b"{}".to_vec()))
+            .unwrap_err();
+        assert!(matches!(err, PeerSendError::Disconnected));
+
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hooks_compose_in_registration_order() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let order = Arc::new(Mutex::new(Vec::<u32>::new()));
+        let order_a = Arc::clone(&order);
+        let order_b = Arc::clone(&order);
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router)
+            .on_peer_connect(move |_| order_a.lock().unwrap().push(1))
+            .on_peer_connect(move |_| order_b.lock().unwrap().push(2));
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        client.call_json("/ping", &json!({})).await.unwrap();
+
+        let snapshot = order.lock().unwrap().clone();
+        assert_eq!(snapshot, vec![1, 2]);
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_utf8_and_raw() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = WebSocketServer::new(router).with_peer_registry(peers.clone());
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+        client.call_json("/ping", &json!({})).await.unwrap();
+
+        let utf_results = peers.broadcast_notify_utf8("/msg", "hello");
+        for (_, r) in utf_results {
+            r.expect("utf8 broadcast send");
+        }
+
+        let raw_results =
+            peers.broadcast_notify_raw("/bytes", BodyFormat::RawBinary, &[1u8, 2, 3, 4]);
+        for (_, r) in raw_results {
+            r.expect("raw broadcast send");
+        }
+
+        let m1 = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m1.query_str().unwrap(), "/msg");
+        assert_eq!(m1.body, b"hello".to_vec());
+        assert_eq!(m1.header.body_format, BodyFormat::Utf8 as u16);
+
+        let m2 = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(m2.query_str().unwrap(), "/bytes");
+        assert_eq!(m2.body, vec![1u8, 2, 3, 4]);
+        assert_eq!(m2.header.body_format, BodyFormat::RawBinary as u16);
+
+        drop(client);
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[should_panic(expected = "WebSocketServer outbound capacity must be >= 1")]
+    async fn outbound_capacity_zero_panics() {
+        let router = Router::new();
+        let _ = WebSocketServer::new(router).with_outbound_capacity(0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn panicking_connect_hook_still_runs_disconnect_cleanup() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // with_peer_registry's insert hook runs first; the second hook
+        // panics, simulating a faulty embedder callback. The disconnect
+        // guard must still fire on unwind and remove the peer.
+        let server = WebSocketServer::new(router)
+            .with_peer_registry(peers.clone())
+            .on_peer_connect(|_| panic!("boom"));
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        // The client's handshake will likely succeed (the panic happens
+        // post-handshake during hook execution), but the connection
+        // will be torn down. We just need the registry to be empty
+        // after the dust settles.
+        let _ = WebSocketClient::connect(&format!("ws://{addr}/repe")).await;
+
+        for _ in 0..100 {
+            if peers.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            peers.is_empty(),
+            "panicking connect hook leaked peer in registry"
+        );
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shared_registry_across_two_servers_mints_unique_ids() {
+        let router_a = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let router_b = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        let la = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let aa = la.local_addr().unwrap();
+        let lb = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let ab = lb.local_addr().unwrap();
+
+        let sa = WebSocketServer::new(router_a).with_peer_registry(peers.clone());
+        let sb = WebSocketServer::new(router_b).with_peer_registry(peers.clone());
+        let ta = serve_one(la, "/repe", sa).await;
+        let tb = serve_one(lb, "/repe", sb).await;
+
+        let c1 = WebSocketClient::connect(&format!("ws://{aa}/repe"))
+            .await
+            .unwrap();
+        let c2 = WebSocketClient::connect(&format!("ws://{ab}/repe"))
+            .await
+            .unwrap();
+        // Round-trips so both peers are registered.
+        c1.call_json("/ping", &json!({})).await.unwrap();
+        c2.call_json("/ping", &json!({})).await.unwrap();
+
+        // Both peers must be present with distinct ids.
+        assert_eq!(peers.len(), 2);
+        let snapshot = peers.peers();
+        let ids: std::collections::HashSet<_> =
+            snapshot.iter().map(|p| p.peer_id().0).collect();
+        assert_eq!(ids.len(), 2, "shared registry minted colliding PeerIds");
+
+        drop(c1);
+        drop(c2);
+        ta.abort();
+        tb.abort();
     }
 }


### PR DESCRIPTION
## Summary

`WebSocketServer` is now push-capable, both for **external broadcast** (background tasks fanning notifies to live peers) and for **in-handler push** (a handler reaches the calling peer and emits progress / streaming notifies mid-request). The single-task `handle_connection` becomes a reader/writer pair coordinated by a bounded `tokio::sync::mpsc`, so pushed notifies share the wire with in-flight responses.

All additions are gated on the existing `websocket` feature and opt-in. Source-compatible: `WebSocketServer::new(router).serve(...)` callers compile and run unchanged. Wire-compatible: notify frames are the same shape they have always been.

## What's new

### External broadcast

- **`PeerRegistry`** (`src/peer.rs`): transport-agnostic cloneable live peer set. Owns its own `PeerId` allocator (`next_peer_id`), so two `WebSocketServer`s sharing one registry never mint colliding ids.
  - Broadcast helpers: `broadcast_notify_json`, `broadcast_notify_beve`, `broadcast_notify_utf8`, `broadcast_notify_raw`. Encode (or copy, for the pre-encoded variants) once; return `HashMap<PeerId, Result<(), PeerSendError>>`.
- **`WebSocketServer` builder methods**:
  - `with_peer_registry(registry)` attaches a registry and adopts its id counter.
  - `on_peer_connect(f)` / `on_peer_disconnect(f)` lifecycle hooks. Multiple hooks compose in registration order.
  - `with_outbound_capacity(n)` overrides `DEFAULT_OUTBOUND_CAPACITY` (256).
- **Reader/writer split**: bounded outbound channel, writer task drains, shutdown bounded by `SHUTDOWN_DRAIN_TIMEOUT` (5s) so a slow-but-not-errored peer cannot pin the connection task.
- **Lifecycle ordering guarantees** (now documented):
  - Connect hook runs synchronously *before* reader/writer tasks process traffic. A notify queued from inside the hook is guaranteed to land on the wire before any response on that connection.
  - Disconnect guard is built *before* the connect-hook loop, so it fires on every exit path, including a panic in a later connect hook.
  - After the connect hook returns, notifies and responses are strict FIFO on the same connection.

### In-handler push

- **`Router::with_json_ctx` / `with_typed_ctx`**: register handlers that take a `&CallContext` alongside the body. Inside the handler, `ctx.peer()` is the calling `PeerHandle` (when the request came in over a transport that produces peers; `WebSocketServer` does). Handlers can push notifies back to the originator mid-request.
- **`HandlerErased::handle_with_ctx`**: new trait method threading the context. Defaults to ignoring the context and calling `handle`, so existing implementors compile unchanged.
- **`Next` carries the context internally**: existing middleware that calls `next.run(req)` preserves whatever the upstream attached. The leaf handler reaches `handle_with_ctx` automatically when context is present, falls back to `handle` otherwise. No changes required to the `Middleware` trait.
- **Registry path**: `RegistryRequestHandler` overrides `handle_with_ctx` to call `Registry::dispatch_with_ctx`, so registry-backed functions wrapped in `WithContext` see the peer too.
- TCP transports (`Client`, `AsyncClient`, `Server`, `AsyncServer`) continue to dispatch through the existing context-free path; `ctx.peer()` returns `None` for context-aware handlers invoked under those.

## Files touched

- `src/peer.rs` — `PeerRegistry`, broadcast helpers, `next_peer_id`.
- `src/server.rs` — `HandlerErased::handle_with_ctx`, `Next::with_ctx`, `JsonHandlerCtx`, `TypedHandlerCtx`, `TypedHandlerFnCtx`, `Router::with_json_ctx` / `with_typed_ctx`, registry path threading.
- `src/server_request.rs` — `route_request_with_ctx`.
- `src/websocket_server.rs` — reader/writer rewrite, `WsPeerSink`, `DisconnectGuard`, builders, peer threaded into the reader's `CallContext`.
- `src/lib.rs` — re-export `PeerRegistry`.
- `docs/websocket.md` — new "Server-Initiated Notifies" section plus an "In-Handler Notifies" subsection.
- `CHANGELOG.md` — `[Unreleased]` entry.
- `.gitignore` — exclude the local planning doc.

## Out of scope (future work)

- **`PeerSink::send_notify` query format**: the trait currently fixes the wire query format at `JsonPointer`. Threading a `QueryFormat` is breaking; deliberately deferred and documented on the trait.
- **Zero-clone broadcast**: an `Arc<[u8]>`-based `NotifyBody` variant would let one broadcast share one allocation across N peers. Not needed for bring-up; noted in the CHANGELOG.
- **TCP-transport peer surface**: `Server` and `AsyncServer` don't currently produce `PeerHandle`s. Extending the same model to them is mechanical once a real use case asks for it.

## Test plan

17 new unit tests in `src/websocket_server.rs::tests` cover the design matrix:

External broadcast / lifecycle:
- [x] `registry_receives_broadcast`, `broadcast_reaches_multiple_peers`
- [x] `connect_hook_queued_notify_arrives_before_response` (structural ordering)
- [x] `disconnect_hook_fires_on_drop`, `broadcast_after_disconnect_surfaces_disconnected`
- [x] `slow_consumer_surfaces_backpressure` (`PeerSendError::Full`)
- [x] `hooks_compose_in_registration_order`
- [x] `broadcast_utf8_and_raw` (covers `BodyFormat::Utf8` and `BodyFormat::RawBinary`)
- [x] `outbound_capacity_zero_panics`
- [x] `panicking_connect_hook_still_runs_disconnect_cleanup`
- [x] `shared_registry_across_two_servers_mints_unique_ids`

In-handler push / context plumbing:
- [x] `handler_pushes_notify_to_calling_peer_via_with_json_ctx`
- [x] `registry_callable_receives_peer_via_with_context`
- [x] `middleware_preserves_ctx_across_pipeline`
- [x] `ctx_handler_sees_no_peer_under_legacy_handle`

Pre-existing tests (`websocket_server_roundtrip`, `websocket_proxy_forwards_raw_messages`) continue to pass unchanged.

- [x] `cargo test --features websocket` green across all suites (162 tests).
- [x] `cargo test --lib` (no features) green (69 tests).
- [x] `cargo clippy --features websocket --lib --tests` clean.