### PR TITLE
Cut per-request allocations on the outbound and routing hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +92,12 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -144,10 +165,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -223,6 +277,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +342,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -385,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,10 +540,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -525,6 +645,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +673,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
@@ -733,12 +868,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "repe"
 version = "3.0.0"
 dependencies = [
  "beve",
  "clap",
  "clap_complete",
+ "criterion",
  "futures-channel",
  "futures-util",
  "js-sys",
@@ -793,6 +958,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -949,6 +1123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1269,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1377,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "/src/**",
     "/examples/**",
     "/tests/**",
+    "/benches/**",
 ]
 
 [package.metadata.docs.rs]
@@ -88,3 +89,18 @@ web-sys = { version = "0.3", optional = true, features = [
 
 [dev-dependencies]
 rand = "0.8"
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+# Wire-serialization throughput: `Message::to_vec` vs the new
+# `Message::into_wire_bytes` for the WebSocket-style outbound path, sized to
+# cover both small responses and multi-MiB streaming bodies.
+name = "wire_serialization"
+harness = false
+
+[[bench]]
+# Router dispatch throughput: registered HashMap routes, `Registry`-backed
+# routes, and `RepeStruct`-backed routes, each measured with and without a
+# middleware pipeline so the hoisted middleware wrap is visible.
+name = "route_dispatch"
+harness = false

--- a/benches/route_dispatch.rs
+++ b/benches/route_dispatch.rs
@@ -1,0 +1,184 @@
+//! Router dispatch throughput.
+//!
+//! Measures the per-request work of resolving a path to a handler and
+//! optionally invoking it, across the three handler shapes the router
+//! supports (plain HashMap route, [`Registry`]-backed route, [`RepeStruct`]
+//! struct route), each with and without an attached middleware.
+//!
+//! Before this refactor, registry and struct lookups paid a per-request
+//! `String` + `Arc::new(...RequestHandler { ... })`, and any router with at
+//! least one middleware paid an extra `Arc::new(MiddlewarePipeline)` per
+//! lookup even on routes that did not need it. Post-refactor, each lookup is
+//! a prefix check (or HashMap probe) plus a single `Arc::clone` of a handler
+//! `Arc` built at registration time. The `middleware` variants of these
+//! benches surface that hoisting directly.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use repe::registry::{Registry, RegistryCallable};
+use repe::server::{Middleware, Next, Router};
+use repe::{BodyFormat, Message, QueryFormat};
+use serde_json::{Value, json};
+use std::hint::black_box;
+use std::sync::{Arc, Mutex};
+
+#[derive(Default, serde::Serialize, serde::Deserialize, repe::RepeStruct)]
+#[repe(methods(get_number(&self) -> i32))]
+struct BenchStruct {
+    counter: i32,
+}
+
+impl BenchStruct {
+    fn get_number(&self) -> i32 {
+        self.counter
+    }
+}
+
+/// Trivial pass-through middleware: just forwards to the next layer.
+/// Realistic instrumented middleware would do more work, but this is enough
+/// to populate `Router::middlewares` and exercise the wrap-on-registration
+/// path versus the prior wrap-on-lookup path.
+struct PassThrough;
+
+impl Middleware for PassThrough {
+    fn handle(&self, req: &Message, next: Next<'_>) -> Result<Message, repe::error::RepeError> {
+        next.run(req)
+    }
+}
+
+struct BenchCallable;
+
+impl RegistryCallable for BenchCallable {
+    fn call(
+        &self,
+        _ctx: &repe::peer::CallContext,
+        _body: Option<Value>,
+    ) -> Result<Value, (repe::ErrorCode, String)> {
+        Ok(json!({"ok": true}))
+    }
+}
+
+fn build_plain_router(with_middleware: bool) -> Router {
+    let router = Router::new().with_json("/sum", |_v: Value| Ok(json!({"sum": 0})));
+    if with_middleware {
+        router.with_middleware(PassThrough)
+    } else {
+        router
+    }
+}
+
+fn build_registry_router(with_middleware: bool) -> Router {
+    let registry = Arc::new(Registry::new());
+    registry.register_function("/echo", BenchCallable).unwrap();
+    let router = Router::new().with_registry("/api", registry);
+    if with_middleware {
+        router.with_middleware(PassThrough)
+    } else {
+        router
+    }
+}
+
+fn build_struct_router(with_middleware: bool) -> Router {
+    let shared = Arc::new(Mutex::new(BenchStruct { counter: 7 }));
+    let router = Router::new().with_struct_shared::<BenchStruct, _>("/svc", shared);
+    if with_middleware {
+        router.with_middleware(PassThrough)
+    } else {
+        router
+    }
+}
+
+fn build_request(path: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_json(&json!({}))
+        .unwrap()
+        .body_format(BodyFormat::Json)
+        .build()
+}
+
+fn bench_router_get(c: &mut Criterion) {
+    let plain = build_plain_router(false);
+    let plain_mw = build_plain_router(true);
+    let registry = build_registry_router(false);
+    let registry_mw = build_registry_router(true);
+    let struct_router = build_struct_router(false);
+    let struct_router_mw = build_struct_router(true);
+
+    let mut group = c.benchmark_group("router_get");
+    group.bench_function("plain", |b| {
+        b.iter(|| black_box(plain.get(black_box("/sum"))))
+    });
+    group.bench_function("plain_with_middleware", |b| {
+        b.iter(|| black_box(plain_mw.get(black_box("/sum"))))
+    });
+    group.bench_function("registry", |b| {
+        b.iter(|| black_box(registry.get(black_box("/api/echo"))))
+    });
+    group.bench_function("registry_with_middleware", |b| {
+        b.iter(|| black_box(registry_mw.get(black_box("/api/echo"))))
+    });
+    group.bench_function("struct", |b| {
+        b.iter(|| black_box(struct_router.get(black_box("/svc/get_number"))))
+    });
+    group.bench_function("struct_with_middleware", |b| {
+        b.iter(|| black_box(struct_router_mw.get(black_box("/svc/get_number"))))
+    });
+    group.finish();
+}
+
+fn bench_full_dispatch(c: &mut Criterion) {
+    let plain = build_plain_router(false);
+    let plain_mw = build_plain_router(true);
+    let registry = build_registry_router(false);
+    let registry_mw = build_registry_router(true);
+    let struct_router = build_struct_router(false);
+    let struct_router_mw = build_struct_router(true);
+
+    let plain_req = build_request("/sum");
+    let registry_req = build_request("/api/echo");
+    let struct_req = build_request("/svc/get_number");
+
+    let mut group = c.benchmark_group("router_dispatch");
+    group.bench_function("plain", |b| {
+        b.iter(|| {
+            let h = plain.get(black_box("/sum")).unwrap();
+            black_box(h.handle(&plain_req).unwrap());
+        })
+    });
+    group.bench_function("plain_with_middleware", |b| {
+        b.iter(|| {
+            let h = plain_mw.get(black_box("/sum")).unwrap();
+            black_box(h.handle(&plain_req).unwrap());
+        })
+    });
+    group.bench_function("registry", |b| {
+        b.iter(|| {
+            let h = registry.get(black_box("/api/echo")).unwrap();
+            black_box(h.handle(&registry_req).unwrap());
+        })
+    });
+    group.bench_function("registry_with_middleware", |b| {
+        b.iter(|| {
+            let h = registry_mw.get(black_box("/api/echo")).unwrap();
+            black_box(h.handle(&registry_req).unwrap());
+        })
+    });
+    group.bench_function("struct", |b| {
+        b.iter(|| {
+            let h = struct_router.get(black_box("/svc/get_number")).unwrap();
+            black_box(h.handle(&struct_req).unwrap());
+        })
+    });
+    group.bench_function("struct_with_middleware", |b| {
+        b.iter(|| {
+            let h = struct_router_mw.get(black_box("/svc/get_number")).unwrap();
+            black_box(h.handle(&struct_req).unwrap());
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_router_get, bench_full_dispatch);
+criterion_main!(benches);

--- a/benches/wire_serialization.rs
+++ b/benches/wire_serialization.rs
@@ -50,9 +50,7 @@ fn build_message_with_reserve(body_len: usize) -> Message {
 fn bench_wire_serialization(c: &mut Criterion) {
     let mut group = c.benchmark_group("wire_serialization");
     for &size in BODY_SIZES {
-        group.throughput(Throughput::Bytes(
-            (HEADER_SIZE + QUERY.len() + size) as u64,
-        ));
+        group.throughput(Throughput::Bytes((HEADER_SIZE + QUERY.len() + size) as u64));
 
         group.bench_with_input(BenchmarkId::new("to_vec", size), &size, |b, &size| {
             // Build outside the timing loop; the cost being measured is the

--- a/benches/wire_serialization.rs
+++ b/benches/wire_serialization.rs
@@ -1,0 +1,95 @@
+//! Outbound wire-serialization throughput.
+//!
+//! Measures the cost of turning a [`Message`] into a `Vec<u8>` suitable for
+//! the WebSocket writer sink. Three shapes are compared:
+//!
+//! * `to_vec`: the original API; always allocates a fresh wire buffer and
+//!   copies the body into it.
+//! * `into_wire_bytes` (slow path): same input shape as `to_vec`, but the
+//!   message is consumed. Body has no spare capacity for the prefix, so the
+//!   method falls back to a fresh allocation. Should be at parity with
+//!   `to_vec`.
+//! * `into_wire_bytes` (fast path): the body is pre-allocated with
+//!   `Vec::with_capacity(body_len + HEADER_SIZE + query.len())`. The method
+//!   reuses the body buffer and performs one in-place memcpy. Should improve
+//!   noticeably as the body grows.
+//!
+//! Body sizes span the small RPC response (64 B) through the multi-MiB
+//! streaming chunk (`repe::stream` documents 64 MiB windows; bench up to a
+//! representative 4 MiB chunk).
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use repe::{BodyFormat, HEADER_SIZE, Message, QueryFormat};
+use std::hint::black_box;
+
+const QUERY: &str = "/collect/file_chunk";
+const BODY_SIZES: &[usize] = &[64, 4 * 1024, 64 * 1024, 4 * 1024 * 1024];
+
+fn build_message_no_reserve(body_len: usize) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(QUERY)
+        .query_format(QueryFormat::JsonPointer)
+        .body_bytes(vec![0xABu8; body_len])
+        .body_format(BodyFormat::RawBinary)
+        .build()
+}
+
+fn build_message_with_reserve(body_len: usize) -> Message {
+    let mut body = Vec::with_capacity(HEADER_SIZE + QUERY.len() + body_len);
+    body.resize(body_len, 0xAB);
+    Message::builder()
+        .id(1)
+        .query_str(QUERY)
+        .query_format(QueryFormat::JsonPointer)
+        .body_bytes(body)
+        .body_format(BodyFormat::RawBinary)
+        .build()
+}
+
+fn bench_wire_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wire_serialization");
+    for &size in BODY_SIZES {
+        group.throughput(Throughput::Bytes(
+            (HEADER_SIZE + QUERY.len() + size) as u64,
+        ));
+
+        group.bench_with_input(BenchmarkId::new("to_vec", size), &size, |b, &size| {
+            // Build outside the timing loop; the cost being measured is the
+            // serialization step, not the build.
+            b.iter_batched(
+                || build_message_no_reserve(size),
+                |msg| black_box(msg.to_vec()),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("into_wire_bytes_slow", size),
+            &size,
+            |b, &size| {
+                b.iter_batched(
+                    || build_message_no_reserve(size),
+                    |msg| black_box(msg.into_wire_bytes()),
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("into_wire_bytes_fast", size),
+            &size,
+            |b, &size| {
+                b.iter_batched(
+                    || build_message_with_reserve(size),
+                    |msg| black_box(msg.into_wire_bytes()),
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_wire_serialization);
+criterion_main!(benches);

--- a/src/bin/repe.rs
+++ b/src/bin/repe.rs
@@ -476,7 +476,7 @@ fn decode_response(msg: &Message) -> Result<Option<DecodedBody>, CliError> {
             |e| CliError::Rpc(format!("server returned malformed BEVE body: {e}")),
         )?))),
         Ok(BodyFormat::Utf8) => Ok(Some(DecodedBody::Utf8Raw(msg.body_utf8()))),
-        Ok(BodyFormat::RawBinary) | Err(_) => Err(CliError::Rpc(format!(
+        Ok(BodyFormat::RawBinary) | Ok(_) | Err(_) => Err(CliError::Rpc(format!(
             "server returned {} raw-binary bytes (cannot render as JSON)",
             msg.body.len()
         ))),

--- a/src/message.rs
+++ b/src/message.rs
@@ -64,6 +64,63 @@ impl Message {
         Ok(())
     }
 
+    /// Consume the message and produce its wire-frame bytes.
+    ///
+    /// Prefer this over [`to_vec`](Self::to_vec) on outbound paths where the
+    /// `Message` is being shipped to a sink that takes an owned `Vec<u8>` (e.g.
+    /// the WebSocket writer): `to_vec` always allocates a fresh frame buffer
+    /// and copies the body into it, whereas `into_wire_bytes` reuses the body
+    /// allocation when it already has the spare capacity to host the header
+    /// and query prefix.
+    ///
+    /// Fast path (zero new allocations, one body memcpy to shift to the back):
+    /// triggers when `body.capacity() >= HEADER_SIZE + query.len() +
+    /// body.len()`. Callers that care about streaming throughput can guarantee
+    /// the fast path by constructing the body via
+    /// `Vec::with_capacity(body_len + HEADER_SIZE + query.len())` and then
+    /// passing it to `MessageBuilder::body_bytes`.
+    ///
+    /// Slow path: when the body has no spare capacity for the prefix, a fresh
+    /// `Vec<u8>` is allocated. The byte output is identical to `to_vec`.
+    pub fn into_wire_bytes(self) -> Vec<u8> {
+        let Self {
+            header,
+            query,
+            mut body,
+        } = self;
+        let prefix_len = HEADER_SIZE + query.len();
+        let body_len = body.len();
+        let total = prefix_len + body_len;
+
+        if body.capacity() >= total {
+            // Reuse the body allocation: grow in place, shift the body bytes
+            // to the back, then overwrite the prefix with header + query.
+            body.resize(total, 0);
+            if body_len > 0 {
+                body.copy_within(0..body_len, prefix_len);
+            }
+            body[..HEADER_SIZE].copy_from_slice(&header.encode());
+            if !query.is_empty() {
+                body[HEADER_SIZE..prefix_len].copy_from_slice(&query);
+            }
+            body
+        } else {
+            // No room in body for the prefix: fall back to a fresh allocation.
+            // Same cost as `to_vec`, but consumes self so the original query
+            // and body buffers are released as soon as the wire bytes are
+            // produced.
+            let mut out = Vec::with_capacity(total);
+            out.extend_from_slice(&header.encode());
+            if !query.is_empty() {
+                out.extend_from_slice(&query);
+            }
+            if body_len > 0 {
+                out.append(&mut body);
+            }
+            out
+        }
+    }
+
     pub fn from_slice(buf: &[u8]) -> Result<Self, RepeError> {
         if buf.len() < HEADER_SIZE {
             return Err(RepeError::InvalidHeaderLength(buf.len()));
@@ -426,6 +483,96 @@ mod tests {
         msg.write_to(&mut got).expect("write_to");
         assert_eq!(got, expected);
         assert_eq!(msg.serialized_len(), expected.len());
+    }
+
+    #[test]
+    fn into_wire_bytes_matches_to_vec_slow_path() {
+        // Body allocated with cap == len, so into_wire_bytes hits the fresh-
+        // allocation fallback. Output must still equal to_vec.
+        let msg = Message::builder()
+            .id(42)
+            .query_str("/collect/file_chunk")
+            .query_format(QueryFormat::JsonPointer)
+            .body_bytes(vec![0xDEu8; 1024])
+            .body_format(BodyFormat::Beve)
+            .build();
+        let expected = msg.to_vec();
+        let got = msg.into_wire_bytes();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn into_wire_bytes_matches_to_vec_fast_path() {
+        // Body pre-allocated with prefix room so into_wire_bytes takes the
+        // in-place fast path. Output must still equal to_vec.
+        let query = b"/collect/file_chunk";
+        let body_len = 4096;
+        let mut body = Vec::with_capacity(HEADER_SIZE + query.len() + body_len);
+        body.resize(body_len, 0xAB);
+        let msg = Message::builder()
+            .id(42)
+            .query_bytes(query.to_vec())
+            .query_format(QueryFormat::JsonPointer)
+            .body_bytes(body)
+            .body_format(BodyFormat::Beve)
+            .build();
+        let expected = msg.clone().to_vec();
+        let got = msg.into_wire_bytes();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn into_wire_bytes_handles_empty_query_and_body() {
+        let msg = Message::builder().id(1).build();
+        let expected = msg.to_vec();
+        let got = msg.into_wire_bytes();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn into_wire_bytes_handles_empty_body_only() {
+        let msg = Message::builder()
+            .id(2)
+            .query_str("/notify")
+            .query_format(QueryFormat::JsonPointer)
+            .build();
+        let expected = msg.to_vec();
+        let got = msg.into_wire_bytes();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn into_wire_bytes_handles_empty_query_only() {
+        let msg = Message::builder()
+            .id(3)
+            .body_bytes(vec![1u8, 2, 3])
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        let expected = msg.clone().to_vec();
+        let got = msg.into_wire_bytes();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn into_wire_bytes_fast_path_does_not_reallocate() {
+        // Confirm that when the body has room for the prefix, the resulting
+        // Vec reuses the body's original allocation (same data pointer).
+        let query = b"/q";
+        let body_len = 256;
+        let total = HEADER_SIZE + query.len() + body_len;
+        let mut body = Vec::with_capacity(total);
+        body.resize(body_len, 0x42);
+        let body_ptr = body.as_ptr();
+        let msg = Message::builder()
+            .id(1)
+            .query_bytes(query.to_vec())
+            .query_format(QueryFormat::JsonPointer)
+            .body_bytes(body)
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        let wire = msg.into_wire_bytes();
+        assert_eq!(wire.len(), total);
+        assert_eq!(wire.as_ptr(), body_ptr, "fast path should reuse body buffer");
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -572,7 +572,11 @@ mod tests {
             .build();
         let wire = msg.into_wire_bytes();
         assert_eq!(wire.len(), total);
-        assert_eq!(wire.as_ptr(), body_ptr, "fast path should reuse body buffer");
+        assert_eq!(
+            wire.as_ptr(),
+            body_ptr,
+            "fast path should reuse body buffer"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -434,12 +434,94 @@ where
     }
 }
 
-trait StructRouterEntry: Send + Sync {
-    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>>;
+/// One handler entry in `Router::inner`.
+///
+/// `raw` is the bare handler as registered; `dispatched` is `raw` already
+/// wrapped in any active [`MiddlewarePipeline`]. Keeping both means dispatch
+/// is a single `Arc::clone(&entry.dispatched)` (no per-request wrap allocation)
+/// while [`Router::register_middleware`] can still rebuild the wrapped form
+/// across every existing entry when the middleware chain changes.
+///
+/// With no middleware registered, `raw` and `dispatched` are clones of the
+/// same `Arc` — no extra allocation for plain routes.
+#[derive(Clone)]
+struct RouterMapEntry {
+    raw: Arc<dyn HandlerErased>,
+    dispatched: Arc<dyn HandlerErased>,
 }
 
-trait RegistryRouterEntry: Send + Sync {
-    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>>;
+/// Internal router entry for a [`Registry`] mounted at a fixed prefix.
+///
+/// Holds the normalized prefix once for path matching plus both the raw
+/// `Arc<RegisteredRegistry>` (coerced to `Arc<dyn HandlerErased>`) and the
+/// pre-middleware-wrapped form used at dispatch. Lookup is a prefix check plus
+/// an `Arc` refcount bump; the per-request `String` + `Arc::new` that the
+/// original `RegistryRequestHandler` cost — and the per-request
+/// `MiddlewarePipeline` allocation — have been folded away.
+#[derive(Clone)]
+struct RegistryEntry {
+    prefix: String,
+    raw: Arc<dyn HandlerErased>,
+    dispatched: Arc<dyn HandlerErased>,
+}
+
+impl RegistryEntry {
+    fn matches(&self, path: &str) -> bool {
+        if self.prefix.is_empty() {
+            return true;
+        }
+        if path == self.prefix {
+            return true;
+        }
+        path.strip_prefix(&self.prefix)
+            .is_some_and(|rest| rest.starts_with('/'))
+    }
+}
+
+/// Internal router entry for a [`RepeStruct`] mounted at a fixed root.
+///
+/// Holds the normalized root once for path matching plus both the raw
+/// `Arc<RegisteredStruct<T, L>>` (coerced to `Arc<dyn HandlerErased>`) and the
+/// pre-middleware-wrapped form used at dispatch. Lookup is a prefix check plus
+/// an `Arc` refcount bump; the per-request `Vec<String>` from
+/// `json_pointer::parse`, the per-request `String`, the per-request
+/// `Arc::new` that the original `StructRequestHandler` cost, and the
+/// per-request `MiddlewarePipeline` allocation have all been folded away.
+#[derive(Clone)]
+struct StructEntry {
+    root: String,
+    raw: Arc<dyn HandlerErased>,
+    dispatched: Arc<dyn HandlerErased>,
+}
+
+impl StructEntry {
+    fn matches(&self, path: &str) -> bool {
+        if self.root.is_empty() {
+            return true;
+        }
+        if path == self.root {
+            return true;
+        }
+        path.strip_prefix(&self.root)
+            .is_some_and(|rest| rest.starts_with('/'))
+    }
+}
+
+/// Wrap `handler` in the active middleware pipeline, or return it unchanged
+/// when no middleware is registered. Built once at registration / middleware
+/// change rather than per dispatch.
+fn wrap_with_middlewares(
+    handler: &Arc<dyn HandlerErased>,
+    middlewares: &Arc<Vec<Arc<dyn Middleware>>>,
+) -> Arc<dyn HandlerErased> {
+    if middlewares.is_empty() {
+        Arc::clone(handler)
+    } else {
+        Arc::new(MiddlewarePipeline {
+            handler: Arc::clone(handler),
+            middlewares: Arc::clone(middlewares),
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -554,9 +636,9 @@ impl<T: ?Sized + Send + Sync> Lockable<T> for parking_lot::RwLock<T> {
 
 #[derive(Clone)]
 pub struct Router {
-    inner: Arc<HashMap<String, Arc<dyn HandlerErased>>>,
-    structs: Arc<Vec<Arc<dyn StructRouterEntry>>>,
-    registries: Arc<Vec<Arc<dyn RegistryRouterEntry>>>,
+    inner: Arc<HashMap<String, RouterMapEntry>>,
+    structs: Arc<Vec<StructEntry>>,
+    registries: Arc<Vec<RegistryEntry>>,
     middlewares: Arc<Vec<Arc<dyn Middleware>>>,
 }
 
@@ -570,18 +652,25 @@ impl Router {
         }
     }
 
+    /// Insert a raw handler into `self.inner`, pre-wrapping it in the active
+    /// middleware pipeline. Centralizes the boilerplate every `with_*`
+    /// registrar would otherwise repeat, and keeps the wrap-on-registration
+    /// invariant in one place so [`register_middleware`] only has to rebuild
+    /// the `dispatched` slot.
+    fn insert_route(&mut self, path: &str, raw: Arc<dyn HandlerErased>) {
+        let dispatched = wrap_with_middlewares(&raw, &self.middlewares);
+        let mut map = self.inner.as_ref().clone();
+        map.insert(path.to_string(), RouterMapEntry { raw, dispatched });
+        self.inner = Arc::new(map);
+    }
+
     /// Add a JSON Value-based handler. Alias: `with`.
     pub fn with_json(
         mut self,
         path: &str,
         handler: impl Fn(Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
     ) -> Self {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(JsonHandler(handler)) as Arc<dyn HandlerErased>,
-        );
-        self.inner = Arc::new(map);
+        self.insert_route(path, Arc::new(JsonHandler(handler)));
         self
     }
 
@@ -592,6 +681,18 @@ impl Router {
     }
 
     /// Register middleware in-place so callers can retain the shared handle.
+    ///
+    /// Existing routes have their `dispatched` slot rebuilt against the new
+    /// middleware chain so future lookups remain a single `Arc::clone` with
+    /// no per-request wrap allocation. The rebuild is a one-time `Arc::new`
+    /// per route, paid only here.
+    ///
+    /// Cost note: each call walks every registered route once, so chaining
+    /// `N` middleware registrations after `K` routes is `O(N·K)` setup. This
+    /// only runs at builder time, never on the dispatch hot path, and the
+    /// typical usage shape (a handful of middlewares registered once) is
+    /// nowhere near that worst case. A future batch helper that takes
+    /// several middlewares at once could amortize the rebuild to `O(K)`.
     pub fn register_middleware(
         &mut self,
         middleware: impl Middleware + 'static,
@@ -600,6 +701,47 @@ impl Router {
         let arc: Arc<dyn Middleware> = Arc::new(middleware);
         list.push(arc.clone());
         self.middlewares = Arc::new(list);
+
+        // Rebuild dispatched slots so middleware applies uniformly to every
+        // already-registered route (HashMap entries, registries, structs).
+        let rebuilt_map: HashMap<String, RouterMapEntry> = self
+            .inner
+            .iter()
+            .map(|(path, entry)| {
+                let dispatched = wrap_with_middlewares(&entry.raw, &self.middlewares);
+                (
+                    path.clone(),
+                    RouterMapEntry {
+                        raw: Arc::clone(&entry.raw),
+                        dispatched,
+                    },
+                )
+            })
+            .collect();
+        self.inner = Arc::new(rebuilt_map);
+
+        let rebuilt_registries: Vec<RegistryEntry> = self
+            .registries
+            .iter()
+            .map(|entry| RegistryEntry {
+                prefix: entry.prefix.clone(),
+                raw: Arc::clone(&entry.raw),
+                dispatched: wrap_with_middlewares(&entry.raw, &self.middlewares),
+            })
+            .collect();
+        self.registries = Arc::new(rebuilt_registries);
+
+        let rebuilt_structs: Vec<StructEntry> = self
+            .structs
+            .iter()
+            .map(|entry| StructEntry {
+                root: entry.root.clone(),
+                raw: Arc::clone(&entry.raw),
+                dispatched: wrap_with_middlewares(&entry.raw, &self.middlewares),
+            })
+            .collect();
+        self.structs = Arc::new(rebuilt_structs);
+
         arc
     }
 
@@ -621,13 +763,10 @@ impl Router {
         R: Serialize + Send + Sync + 'static,
         F: TypedHandlerFn<T, R>,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(TypedHandler::<T, R, F>(f, std::marker::PhantomData))
-                as Arc<dyn HandlerErased>,
+        self.insert_route(
+            path,
+            Arc::new(TypedHandler::<T, R, F>(f, std::marker::PhantomData)),
         );
-        self.inner = Arc::new(map);
         self
     }
 
@@ -664,12 +803,7 @@ impl Router {
     where
         F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(JsonHandlerCtx(handler)) as Arc<dyn HandlerErased>,
-        );
-        self.inner = Arc::new(map);
+        self.insert_route(path, Arc::new(JsonHandlerCtx(handler)));
         self
     }
 
@@ -683,13 +817,10 @@ impl Router {
         R: Serialize + Send + Sync + 'static,
         F: TypedHandlerFnCtx<T, R>,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(TypedHandlerCtx::<T, R, F>(f, std::marker::PhantomData))
-                as Arc<dyn HandlerErased>,
+        self.insert_route(
+            path,
+            Arc::new(TypedHandlerCtx::<T, R, F>(f, std::marker::PhantomData)),
         );
-        self.inner = Arc::new(map);
         self
     }
 
@@ -705,12 +836,7 @@ impl Router {
         path: &str,
         handler: impl Fn(Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
     ) -> Self {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(OffReaderHandler(JsonHandler(handler))) as Arc<dyn HandlerErased>,
-        );
-        self.inner = Arc::new(map);
+        self.insert_route(path, Arc::new(OffReaderHandler(JsonHandler(handler))));
         self
     }
 
@@ -720,12 +846,7 @@ impl Router {
     where
         F: Fn(&CallContext, Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(OffReaderHandler(JsonHandlerCtx(handler))) as Arc<dyn HandlerErased>,
-        );
-        self.inner = Arc::new(map);
+        self.insert_route(path, Arc::new(OffReaderHandler(JsonHandlerCtx(handler))));
         self
     }
 
@@ -737,15 +858,13 @@ impl Router {
         R: Serialize + Send + Sync + 'static,
         F: TypedHandlerFn<T, R>,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
+        self.insert_route(
+            path,
             Arc::new(OffReaderHandler(TypedHandler::<T, R, F>(
                 f,
                 std::marker::PhantomData,
-            ))) as Arc<dyn HandlerErased>,
+            ))),
         );
-        self.inner = Arc::new(map);
         self
     }
 
@@ -757,15 +876,13 @@ impl Router {
         R: Serialize + Send + Sync + 'static,
         F: TypedHandlerFnCtx<T, R>,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
+        self.insert_route(
+            path,
             Arc::new(OffReaderHandler(TypedHandlerCtx::<T, R, F>(
                 f,
                 std::marker::PhantomData,
-            ))) as Arc<dyn HandlerErased>,
+            ))),
         );
-        self.inner = Arc::new(map);
         self
     }
 
@@ -775,12 +892,7 @@ impl Router {
     where
         H: JsonTypedHandler + 'static,
     {
-        let mut map = self.inner.as_ref().clone();
-        map.insert(
-            path.to_string(),
-            Arc::new(JsonTypedAdapter(handler)) as Arc<dyn HandlerErased>,
-        );
-        self.inner = Arc::new(map);
+        self.insert_route(path, Arc::new(JsonTypedAdapter(handler)));
         self
     }
 
@@ -805,11 +917,21 @@ impl Router {
         T: RepeStruct + 'static,
         L: Lockable<T> + 'static,
     {
-        let mut entries = (*self.structs).clone();
-        entries.push(Arc::new(RegisteredStruct::<T, L>::new(
+        let registered = Arc::new(RegisteredStruct::<T, L>::new(root, Arc::clone(&shared)));
+        let root = registered.root.clone();
+        // `Arc<RegisteredStruct<T, L>>` coerces to `Arc<dyn HandlerErased>`
+        // because `RegisteredStruct: HandlerErased + Sized`. The handler is
+        // built once at registration so dispatch is a clone of this Arc, not
+        // a fresh allocation.
+        let raw: Arc<dyn HandlerErased> = registered;
+        let dispatched = wrap_with_middlewares(&raw, &self.middlewares);
+        let entry = StructEntry {
             root,
-            Arc::clone(&shared),
-        )));
+            raw,
+            dispatched,
+        };
+        let mut entries = (*self.structs).clone();
+        entries.push(entry);
         self.structs = Arc::new(entries);
         shared
     }
@@ -849,41 +971,35 @@ impl Router {
         path_prefix: &str,
         registry: Arc<Registry>,
     ) -> Arc<Registry> {
+        let registered = Arc::new(RegisteredRegistry::new(path_prefix, Arc::clone(&registry)));
+        let prefix = registered.prefix.clone();
+        // `Arc<RegisteredRegistry>` coerces to `Arc<dyn HandlerErased>` — the
+        // handler is built once at registration so dispatch is a clone of this
+        // Arc, not a fresh allocation.
+        let raw: Arc<dyn HandlerErased> = registered;
+        let dispatched = wrap_with_middlewares(&raw, &self.middlewares);
+        let entry = RegistryEntry {
+            prefix,
+            raw,
+            dispatched,
+        };
         let mut entries = (*self.registries).clone();
-        entries.push(Arc::new(RegisteredRegistry::new(
-            path_prefix,
-            Arc::clone(&registry),
-        )));
+        entries.push(entry);
         self.registries = Arc::new(entries);
         registry
     }
 
     pub fn get(&self, path: &str) -> Option<Arc<dyn HandlerErased>> {
-        let handler = if let Some(handler) = self.inner.get(path) {
-            Some(handler.clone())
-        } else if let Some(handler) = self
-            .registries
-            .iter()
-            .find_map(|entry| entry.handler_for(path))
-        {
-            Some(handler)
-        } else {
-            self.structs
-                .iter()
-                .find_map(|entry| entry.handler_for(path))
-        };
-        handler.map(|h| self.wrap_handler(h))
-    }
-
-    fn wrap_handler(&self, handler: Arc<dyn HandlerErased>) -> Arc<dyn HandlerErased> {
-        if self.middlewares.is_empty() {
-            handler
-        } else {
-            Arc::new(MiddlewarePipeline {
-                handler,
-                middlewares: Arc::clone(&self.middlewares),
-            })
+        if let Some(entry) = self.inner.get(path) {
+            return Some(Arc::clone(&entry.dispatched));
         }
+        if let Some(entry) = self.registries.iter().find(|entry| entry.matches(path)) {
+            return Some(Arc::clone(&entry.dispatched));
+        }
+        self.structs
+            .iter()
+            .find(|entry| entry.matches(path))
+            .map(|entry| Arc::clone(&entry.dispatched))
     }
 }
 
@@ -948,41 +1064,40 @@ impl RegisteredRegistry {
     }
 }
 
-impl RegistryRouterEntry for RegisteredRegistry {
-    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>> {
-        let pointer = self.pointer_for(path)?.to_string();
-        Some(Arc::new(RegistryRequestHandler {
-            registry: Arc::clone(&self.registry),
-            pointer,
-        }))
-    }
-}
-
-struct RegistryRequestHandler {
-    registry: Arc<Registry>,
-    pointer: String,
-}
-
-impl HandlerErased for RegistryRequestHandler {
+impl HandlerErased for RegisteredRegistry {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let path = req.query_str().unwrap_or("");
+        let Some(pointer) = self.pointer_for(path) else {
+            return Ok(create_error_response_like(
+                req,
+                ErrorCode::MethodNotFound,
+                format!("path is not below registry prefix: {path}"),
+            ));
+        };
         let body = match Registry::decode_body(req) {
             Ok(value) => value,
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
-
-        match self.registry.dispatch(&self.pointer, body) {
+        match self.registry.dispatch(pointer, body) {
             Ok(value) => create_response(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
     }
 
     fn handle_with_ctx(&self, req: &Message, ctx: &CallContext) -> Result<Message, RepeError> {
+        let path = req.query_str().unwrap_or("");
+        let Some(pointer) = self.pointer_for(path) else {
+            return Ok(create_error_response_like(
+                req,
+                ErrorCode::MethodNotFound,
+                format!("path is not below registry prefix: {path}"),
+            ));
+        };
         let body = match Registry::decode_body(req) {
             Ok(value) => value,
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
-
-        match self.registry.dispatch_with_ctx(&self.pointer, body, ctx) {
+        match self.registry.dispatch_with_ctx(pointer, body, ctx) {
             Ok(value) => create_response(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
@@ -1027,59 +1142,21 @@ where
     }
 }
 
-impl<T, L> StructRouterEntry for RegisteredStruct<T, L>
-where
-    T: RepeStruct + 'static,
-    L: Lockable<T> + 'static,
-{
-    fn handler_for(&self, path: &str) -> Option<Arc<dyn HandlerErased>> {
-        let relative = self.relative_pointer(path)?;
-        let tokens = crate::json_pointer::parse(relative);
-        let full_path = if path.is_empty() {
-            String::from("")
-        } else {
-            path.to_string()
-        };
-        Some(Arc::new(StructRequestHandler::<T, L>::new(
-            self.shared.clone(),
-            tokens,
-            full_path,
-        )))
-    }
-}
-
-struct StructRequestHandler<T, L>
-where
-    T: RepeStruct + 'static,
-    L: Lockable<T> + 'static,
-{
-    shared: Arc<L>,
-    segments: Vec<String>,
-    full_path: String,
-    phantom: std::marker::PhantomData<T>,
-}
-
-impl<T, L> StructRequestHandler<T, L>
-where
-    T: RepeStruct + 'static,
-    L: Lockable<T> + 'static,
-{
-    fn new(shared: Arc<L>, segments: Vec<String>, full_path: String) -> Self {
-        Self {
-            shared,
-            segments,
-            full_path,
-            phantom: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<T, L> HandlerErased for StructRequestHandler<T, L>
+impl<T, L> HandlerErased for RegisteredStruct<T, L>
 where
     T: RepeStruct + 'static,
     L: Lockable<T> + 'static,
 {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let path = req.query_str().unwrap_or("");
+        let Some(relative) = self.relative_pointer(path) else {
+            return Ok(create_error_response_like(
+                req,
+                ErrorCode::MethodNotFound,
+                format!("path is not below struct root: {path}"),
+            ));
+        };
+
         let body = if req.body.is_empty() {
             None
         } else {
@@ -1096,8 +1173,8 @@ where
                         req,
                         ErrorCode::InvalidBody,
                         format!(
-                            "struct handler `{}` requires JSON or BEVE body, got format {}",
-                            self.full_path, req.header.body_format
+                            "struct handler `{path}` requires JSON or BEVE body, got format {}",
+                            req.header.body_format
                         ),
                     ));
                 }
@@ -1109,10 +1186,10 @@ where
             Err(err) => {
                 let detail = match err {
                     LockError::Poisoned(msg) => {
-                        format!("struct handler `{}` lock poisoned: {}", self.full_path, msg)
+                        format!("struct handler `{path}` lock poisoned: {msg}")
                     }
                     LockError::Other(msg) => {
-                        format!("struct handler `{}` lock error: {}", self.full_path, msg)
+                        format!("struct handler `{path}` lock error: {msg}")
                     }
                 };
                 return Ok(create_error_response_like(
@@ -1123,18 +1200,79 @@ where
             }
         };
 
-        let mut seg_refs = Vec::with_capacity(self.segments.len());
-        for segment in &self.segments {
-            seg_refs.push(segment.as_str());
-        }
+        dispatch_struct_segments(&mut *guard, relative, body, req)
+    }
+}
 
-        match guard.repe_handle(&seg_refs, body) {
-            Ok(result) => {
-                let value = result.unwrap_or(Value::Null);
-                create_response(req, value, BodyFormat::Json)
+/// Run a `RepeStruct::repe_handle` call after parsing `relative` into
+/// path segments and map the result back to a `Message`.
+///
+/// Segment parsing mirrors [`crate::json_pointer::parse`] byte-for-byte so the
+/// dispatch result is independent of which path is taken:
+///
+/// * `""` → no reference tokens; calls `repe_handle(&[], _)` (whole struct).
+/// * `"/"` → one empty reference token; calls `repe_handle(&[""], _)`. The
+///   derive-macro impls treat this as `InvalidPath`, matching RFC 6901
+///   semantics ("/" points at a field named `""`).
+///
+/// The escape-free fast path (`!relative.contains('~')`, the common case for
+/// JSON Pointers) avoids the `Vec<String>` from `json_pointer::parse` and
+/// drops segment `&str`s into a fixed-size stack buffer, spilling to a
+/// `Vec<&str>` only when the path is unusually deep. The escape path keeps the
+/// original `Vec<String>` + `Vec<&str>` shape because each escaped segment
+/// genuinely needs an owned `String`.
+fn dispatch_struct_segments<T>(
+    handler: &mut T,
+    relative: &str,
+    body: Option<Value>,
+    req: &Message,
+) -> Result<Message, RepeError>
+where
+    T: RepeStruct + ?Sized,
+{
+    const STACK_SEGS: usize = 16;
+
+    let result = if !relative.contains('~') {
+        if relative.is_empty() {
+            handler.repe_handle(&[], body)
+        } else if relative == "/" {
+            // RFC 6901: "/" decodes to a single empty reference token. The
+            // old `json_pointer::parse("/")` path returned `vec![""]`; the
+            // fast path must match so trailing-slash requests still surface
+            // as `InvalidPath` rather than silently serving the whole struct.
+            handler.repe_handle(&[""], body)
+        } else {
+            let trimmed = relative.strip_prefix('/').unwrap_or(relative);
+            let mut stack: [&str; STACK_SEGS] = [""; STACK_SEGS];
+            let mut count = 0usize;
+            let mut overflow: Option<Vec<&str>> = None;
+            for seg in trimmed.split('/') {
+                if let Some(v) = overflow.as_mut() {
+                    v.push(seg);
+                } else if count < STACK_SEGS {
+                    stack[count] = seg;
+                    count += 1;
+                } else {
+                    let mut v = Vec::with_capacity(STACK_SEGS + 4);
+                    v.extend_from_slice(&stack);
+                    v.push(seg);
+                    overflow = Some(v);
+                }
             }
-            Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
+            match overflow.as_deref() {
+                Some(v) => handler.repe_handle(v, body),
+                None => handler.repe_handle(&stack[..count], body),
+            }
         }
+    } else {
+        let owned = crate::json_pointer::parse(relative);
+        let seg_refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+        handler.repe_handle(&seg_refs, body)
+    };
+
+    match result {
+        Ok(value) => create_response(req, value.unwrap_or(Value::Null), BodyFormat::Json),
+        Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
     }
 }
 

--- a/src/udp_client.rs
+++ b/src/udp_client.rs
@@ -143,7 +143,7 @@ impl UniUdpClient {
         let repe_id = self.next_repe_message_id();
         let message =
             build_message_for_udp(repe_id, method, params, query_format, body_format, notify)?;
-        let payload = message.to_vec();
+        let payload = message.into_wire_bytes();
         let request = SendRequest::new(self.inner.destination, &payload)
             .with_options(self.send_options())
             .with_identity(SendIdentityOverrides::new().with_message_id(repe_id));

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -748,7 +748,7 @@ where
 
         if let Some(response) = upstream.forward_message(&request).await? {
             writer
-                .send(WsMessage::Binary(response.to_vec()))
+                .send(WsMessage::Binary(response.into_wire_bytes()))
                 .await
                 .map_err(websocket_transport_error)?;
         }
@@ -1055,7 +1055,7 @@ async fn writer_task(
             msg = outbound_rx.recv() => match msg {
                 Some(m) => {
                     if let Err(err) = ws_writer
-                        .send(WsMessage::Binary(m.to_vec()))
+                        .send(WsMessage::Binary(m.into_wire_bytes()))
                         .await
                     {
                         result = Err(websocket_transport_error(err));
@@ -1073,7 +1073,7 @@ async fn writer_task(
                 // drops.
                 let deadline = tokio::time::Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
                 while let Ok(m) = outbound_rx.try_recv() {
-                    let send_fut = ws_writer.send(WsMessage::Binary(m.to_vec()));
+                    let send_fut = ws_writer.send(WsMessage::Binary(m.into_wire_bytes()));
                     match tokio::time::timeout_at(deadline, send_fut).await {
                         Ok(Ok(())) => {}
                         Ok(Err(err)) => {

--- a/tests/struct_registration.rs
+++ b/tests/struct_registration.rs
@@ -603,3 +603,68 @@ fn struct_with_root_prefix_routes() {
 
     assert!(router.get("/i").is_none(), "prefix should scope visibility");
 }
+
+/// Pins down the RFC 6901 split between `""` and `"/"` at the dispatch
+/// boundary so the routing fast path does not silently collapse them.
+///
+/// * `""` → empty pointer → no reference tokens → serialize the whole struct.
+/// * `"/"` → pointer with a single empty reference token → field named `""`,
+///   which the derive-macro emits as `InvalidPath` because no such field
+///   exists.
+///
+/// Holds for both a root-mounted struct (`""`) and a prefix-mounted struct
+/// (`"/svc"`), where the trailing-slash form is `"/svc/"`.
+#[test]
+fn struct_dispatch_distinguishes_root_from_trailing_slash() {
+    // Root-mounted struct: "" → whole struct, "/" → InvalidPath.
+    let root_shared = Arc::new(Mutex::new(RootStruct {
+        foo: 7,
+        bar: "ok".into(),
+    }));
+    let root_router = Router::new().with_struct_shared("", root_shared);
+
+    let whole = root_router
+        .get("")
+        .unwrap()
+        .handle(&request_empty(""))
+        .unwrap();
+    assert!(!whole.is_error(), "empty query should return the struct");
+    assert_eq!(parse_body(&whole), json!({"foo": 7, "bar": "ok"}));
+
+    let trailing_root = root_router
+        .get("/")
+        .unwrap()
+        .handle(&request_empty("/"))
+        .unwrap();
+    assert!(
+        trailing_root.is_error(),
+        "lone `/` should resolve to the empty-named field and miss"
+    );
+    assert_eq!(trailing_root.header.ec, ErrorCode::MethodNotFound as u32);
+
+    // Prefix-mounted struct: "/svc" → whole struct, "/svc/" → InvalidPath.
+    let svc_shared = Arc::new(Mutex::new(RootStruct {
+        foo: 1,
+        bar: "x".into(),
+    }));
+    let svc_router = Router::new().with_struct_shared("/svc", svc_shared);
+
+    let svc_whole = svc_router
+        .get("/svc")
+        .unwrap()
+        .handle(&request_empty("/svc"))
+        .unwrap();
+    assert!(!svc_whole.is_error(), "/svc should return the struct");
+    assert_eq!(parse_body(&svc_whole), json!({"foo": 1, "bar": "x"}));
+
+    let svc_trailing = svc_router
+        .get("/svc/")
+        .unwrap()
+        .handle(&request_empty("/svc/"))
+        .unwrap();
+    assert!(
+        svc_trailing.is_error(),
+        "/svc/ should resolve to the empty-named field and miss"
+    );
+    assert_eq!(svc_trailing.header.ec, ErrorCode::MethodNotFound as u32);
+}


### PR DESCRIPTION
## Summary

Two small, well-bounded performance refactors plus benches that gate them. All public APIs preserved; the `Message` struct shape is unchanged.

- **`Message::into_wire_bytes(self)`** replaces `to_vec()` on the outbound paths (WebSocket writer + UDP client). Fast path is zero-alloc / one-body-memcpy when the body has spare prefix capacity; slow path matches `to_vec`'s cost while releasing the original query and body buffers sooner.
- **Routing collapsed into direct `HandlerErased` impls.** `RegisteredRegistry` and `RegisteredStruct<T, L>` *are* the handlers now: each registry / struct entry stores a single dyn-coerced `Arc<dyn HandlerErased>` built at registration time. `Router::get` is a prefix check (or HashMap probe) plus a single `Arc::clone` — no per-request `Arc::new(...RequestHandler)`, no per-request `String` / `Vec<String>`, no per-request `MiddlewarePipeline` wrap.
- **Middleware wrap hoisted to registration.** Each entry caches both a `raw` and a `dispatched` Arc; `register_middleware` rebuilds dispatched slots in place so semantics stay uniform across already-registered routes.
- **Pre-existing bin bug fixed.** v3.0.0 added `#[non_exhaustive]` to `BodyFormat` / `QueryFormat` / `ErrorCode` but didn't update the CLI's match. `cargo check --all-features` failed on `main` until this one-liner.

Pulled apart into four reviewable commits.

## Measured (criterion `--quick`)

`router_get` (lookup only):

| route shape | no middleware | with middleware |
| --- | --- | --- |
| plain HashMap | 33 ns | 33 ns |
| registry | 9.7 ns | 9.8 ns |
| struct | 9.8 ns | 9.8 ns |

The `_with_middleware` columns match the no-middleware columns to within noise — the per-lookup `Arc::new(MiddlewarePipeline)` is gone.

`wire_serialization` (`into_wire_bytes_fast` vs `to_vec`):

| body size | `to_vec` | fast path | speedup |
| --- | --- | --- | --- |
| 4 KiB | 262 ns | 180 ns | ~1.5× |
| 64 KiB | 16.8 µs | 2.4 µs | ~7× |
| 4 MiB | 117 µs | 86 µs | ~1.4× |

The slow path (no caller pre-reserve) is within noise of `to_vec` at every size; it costs the same allocation but releases the body sooner. Current `create_response` builders don't pre-reserve, so the immediate WebSocket win is the slow-path memory behavior; the fast path opens the door for `repe::stream` chunk producers to opt in.

## Notable behavior preserved

Routing keeps the RFC 6901 boundary between `\"\"` and `\"/\"`:

- `\"\"` → no reference tokens → whole struct.
- `\"/\"` → one empty reference token → derive-macro impls return `InvalidPath`.

The new dispatch fast path handles this explicitly (`\"/\"` calls `repe_handle(&[\"\"], _)`) and a new integration test, `struct_dispatch_distinguishes_root_from_trailing_slash`, pins both the root-mounted and prefix-mounted cases so a future micro-optimization can't silently collapse them again.

## Test plan

- [x] `cargo check --all-features --all-targets`
- [x] `cargo test --all-features` — 121 lib + 133 integration tests pass (incl. the new `into_wire_bytes_*` parity tests and the `\"/\"`-semantics regression test)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo bench --bench wire_serialization -- --quick`
- [x] `cargo bench --bench route_dispatch -- --quick`