### PR TITLE
Add one-port HTTP co-hosting helper and embedder-keyed peer lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ PR_DESCRIPTION.md
 dev/pr-description.md
 dev/feature-expansion-plan.md
 dev/push-capable-websocket-server.md
+dev/http-cohosting-and-keyed-peer-registry.md
 PR.md
 
 # MkDocs build output and local virtualenv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ required-features = ["cli"]
 name = "websocket_graceful_server"
 required-features = ["websocket"]
 
+[[example]]
+name = "websocket_cohosting"
+required-features = ["websocket"]
+
 [dependencies]
 beve = "0.1"
 serde = { version = "1", features = ["derive" ] }

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -100,6 +100,40 @@ Per-peer broadcast helpers all encode the body once on the caller's task and clo
 
 Each helper returns a `HashMap<PeerId, Result<(), PeerSendError>>` so callers can prune dead peers (`PeerSendError::Disconnected`) or surface backpressure (`PeerSendError::Full`).
 
+### Addressing peers by an embedder key
+
+`PeerId` is the registry's canonical, server-minted key: it is what `with_peer_registry` auto-inserts and what the `broadcast_notify_*` result maps are keyed by. When your own client identity is something else — a UUID/token from the handshake, a domain id — attach it as a secondary **alias** instead of maintaining a parallel `key -> PeerId` map by hand:
+
+- `alias<K: Into<String>>(peer_id, key)` associates an embedder key with an already-inserted peer. Returns `false` if the peer is gone (no dangling alias is created). A peer may carry several aliases; a given key addresses at most one peer (re-aliasing moves it).
+- `get_by<Q>(&key)` resolves an alias to its `PeerHandle` for a **targeted push** by your own identity (`peers.get_by("session-abc").map(|h| h.send_notify(...))`). The lookup is generic over the borrowed key form, like `HashMap::get`, so string aliases are queried with a `&str`.
+- `key_for(peer_id)` / `aliases_for(peer_id)` map a `PeerId` **back** to your key(s). Use these to read a `broadcast_notify_*` result map by your own identity — e.g. to answer "which of *my* clients hit `PeerSendError::Full`?". `key_for` returns the first alias (the common single-alias case); `aliases_for` returns all of them.
+
+`PeerId` stays canonical, so the auto-insert path is untouched and the whole feature is additive. Aliases are cleaned up automatically: `remove` (which `with_peer_registry` routes disconnect through) drops the peer's primary entry and every alias pointing at it, so a disconnect needs no extra bookkeeping. Aliases are owned `String`s; convert a non-string key with `to_string()`.
+
+When the key rides in the upgrade request itself, derive it at connect time with [`on_peer_connect_with_handshake`](#lifecycle-hooks):
+
+```rust
+use repe::{PeerRegistry, NotifyBody, WebSocketServer};
+
+let peers = PeerRegistry::new();
+let server = WebSocketServer::new(router)
+    .with_peer_registry(peers.clone())
+    .on_peer_connect_with_handshake({
+        let peers = peers.clone();
+        move |peer, hs| {
+            // e.g. a bearer token in the Authorization header
+            if let Some(token) = hs.header("authorization") {
+                peers.alias(peer.peer_id(), token);
+            }
+        }
+    });
+
+// Later, anywhere holding a registry clone — a targeted push by your key:
+if let Some(handle) = peers.get_by("Bearer abc123") {
+    let _ = handle.send_notify("/nudge", NotifyBody::Json(b"{}".to_vec()));
+}
+```
+
 ### Lifecycle hooks
 
 `with_peer_registry` is sugar over two lower-level hooks:
@@ -117,6 +151,8 @@ The connect hook runs synchronously on the accept task **before** the reader/wri
 After the hook returns, the outbound channel is strict FIFO across both notifies and responses on the same connection: a notify pushed by a background broadcaster at time T arrives on the wire in the order it was enqueued relative to any handler response also enqueued at time T. Clients de-multiplex by the `notify` header flag (`WebSocketClient::subscribe_notifies()`); notifies do not "cut the line" past in-flight responses.
 
 The disconnect hook fires from a `Drop` guard, so it runs on every exit path: clean Close frame, transport error, handler panic, or a panic in a *later* connect hook (the guard is built before the connect-hook loop). Exactly once per accepted connection.
+
+`on_peer_connect_with_handshake(|peer, hs|)` is a sibling connect hook that additionally receives a `HandshakeContext` — the upgrade request's `path()`, `query()`, and `header(name)` (case-insensitive). Use it when your client identity rides in the handshake: derive your key from the request and `alias` the just-inserted peer (see [Addressing peers by an embedder key](#addressing-peers-by-an-embedder-key)). These hooks fire **after** the plain `on_peer_connect` hooks — so a `with_peer_registry` insert has already landed and the peer is present for `alias` — and still before any traffic is processed. The context is available wherever the handshake is: the built-in `serve*` loops, and the co-hosting `accept_with_handshake` + `serve_connection_with_handshake` (or `serve_connection_with_cancel_and_handshake`) path. A connection served through plain `serve_connection`, which carries no captured handshake, does not fire these hooks. If your key instead arrives in a request *body*, this hook is unnecessary — the handler already has both the key and the peer via `CallContext::peer`.
 
 `PeerHandle::send_notify` returning `Ok(())` means the message was queued onto the outbound channel, not that it was written to the wire. During concurrent disconnect, a late-arriving send may queue successfully but be dropped when the writer task exits and the bounded receiver is released. This is intrinsic to async shutdown; treat `Ok` as best-effort delivery, not as confirmation.
 
@@ -302,10 +338,10 @@ The server tracks every connection it accepts in a `JoinSet`, so you do not have
 
 ## One-Port Co-Hosting
 
-To share a single TCP port between the REPE WebSocket endpoint and your own HTTP routes, drive connections yourself instead of using the built-in accept loop. `WebSocketServer::into_shared()` consumes the builder into a cheap, cloneable `SharedWebSocketServer` — the per-connection configuration is built once, each clone is an `Arc` clone, and the handle is `Send + Sync + 'static`. Then, for each accepted stream, peek the upgrade request and route it: `WebSocketServer::accept(stream, path)` performs the REPE handshake (validating `path`), and `SharedWebSocketServer::serve_connection(ws)` runs that connection's reader/writer loop. Connect/disconnect hooks and any attached `PeerRegistry` fire exactly as under `serve`.
+To share a single TCP port between the REPE WebSocket endpoint and your own HTTP routes, drive connections yourself instead of using the built-in accept loop. `WebSocketServer::into_shared()` consumes the builder into a cheap, cloneable `SharedWebSocketServer` — the per-connection configuration is built once, each clone is an `Arc` clone, and the handle is `Send + Sync + 'static`. Then, for each accepted stream, classify it and route it: `is_websocket_upgrade(&stream)` reports whether the client is opening a WebSocket upgrade, `WebSocketServer::accept(stream, path)` performs the REPE handshake (validating `path`), and `SharedWebSocketServer::serve_connection(ws)` runs that connection's reader/writer loop. Connect/disconnect hooks and any attached `PeerRegistry` fire exactly as under `serve`.
 
 ```rust
-use repe::websocket_server::WebSocketServer;
+use repe::{is_websocket_upgrade, WebSocketServer};
 
 let shared = WebSocketServer::new(router).into_shared();
 let listener = tokio::net::TcpListener::bind("0.0.0.0:8081").await?;
@@ -313,16 +349,22 @@ loop {
     let (stream, _addr) = listener.accept().await?;
     let shared = shared.clone();
     tokio::spawn(async move {
-        if looks_like_websocket_upgrade(&stream) {     // your own header peek
-            if let Ok(ws) = WebSocketServer::accept(stream, "/repe").await {
-                let _ = shared.serve_connection(ws).await;
+        match is_websocket_upgrade(&stream).await {
+            Ok(true) => {
+                if let Ok(ws) = WebSocketServer::accept(stream, "/repe").await {
+                    let _ = shared.serve_connection(ws).await;
+                }
             }
-        } else {
-            serve_http(stream).await;                  // your own HTTP handler
+            Ok(false) => { let _ = serve_http(stream).await; }  // your own HTTP handler
+            Err(err) => eprintln!("peek failed: {err}"),
         }
     });
 }
 ```
+
+`is_websocket_upgrade` is **non-destructive**: it peeks (`TcpStream::peek`) and leaves the request bytes in the socket buffer, because `WebSocketServer::accept` replays the handshake from the start of the stream. It is a sniff — it looks for an `Upgrade: websocket` header — and `accept` still does the authoritative RFC 6455 validation on the `true` branch, so a false positive fails the handshake rather than corrupting anything. A helper that *parsed* the request would consume the bytes and break `accept`; the peek-and-sniff keeps repe out of the business of serving HTTP while removing the trickiest part of the fork.
+
+`examples/websocket_cohosting.rs` is a runnable end-to-end demo: it fills in both pieces the sketch above leaves open — the `is_websocket_upgrade` classifier and a minimal, dependency-free `serve_http` (a `/healthz` probe plus a small JSON `GET`) — and drives both forks against one port. Run it with `cargo run --example websocket_cohosting --features websocket`.
 
 The built-in `serve` / `serve_listener` loop is itself implemented on top of `into_shared` + `accept` + `serve_connection`, so a co-hosted connection behaves identically to one accepted by the built-in loop.
 

--- a/examples/websocket_cohosting.rs
+++ b/examples/websocket_cohosting.rs
@@ -1,0 +1,209 @@
+//! One-port co-hosting: REPE-over-WebSocket and plain HTTP on one port.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example websocket_cohosting --features websocket
+//! ```
+//!
+//! A service often wants a REPE WebSocket endpoint *and* a few sibling
+//! plain-HTTP routes (a `/healthz` liveness probe, a small JSON config
+//! read) on the **same** TCP port, without pulling in a second HTTP
+//! framework. repe makes that a peek-then-fork: own the accept loop,
+//! classify each accepted stream, send WebSocket upgrades to REPE and
+//! everything else to a tiny HTTP handler.
+//!
+//! This fills in the two pieces the `docs/websocket.md` co-hosting
+//! sketch leaves as placeholders:
+//!
+//! * [`repe::is_websocket_upgrade`] — the non-destructive WS-vs-HTTP
+//!   classifier (it peeks, leaving the request bytes intact for the
+//!   subsequent [`WebSocketServer::accept`]), and
+//! * `serve_http` below — a minimal, dependency-free HTTP/1.1 handler for
+//!   the sibling routes.
+//!
+//! The program runs the co-hosting server and then drives both forks
+//! against it in one process: a [`WebSocketClient`] round-trips a REPE
+//! call, and a raw `GET /healthz` (written over a plain TCP socket) gets
+//! an HTTP `200`.
+
+use repe::server::Router;
+use repe::{WebSocketClient, WebSocketServer, is_websocket_upgrade};
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+const REPE_PATH: &str = "/repe";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let router = Router::new().with_json("/ping", |_| Ok(json!({ "pong": true })));
+    let shared = WebSocketServer::new(router).into_shared();
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await?;
+    let addr = listener.local_addr()?;
+
+    // The co-hosting accept loop: one TCP port, two protocols.
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _peer_addr)) = listener.accept().await else {
+                break;
+            };
+            let shared = shared.clone();
+            tokio::spawn(async move {
+                // Peek the request head without consuming it, then fork.
+                match is_websocket_upgrade(&stream).await {
+                    Ok(true) => {
+                        // A WebSocket upgrade: hand the *original* stream to
+                        // `accept`, which replays the handshake from the
+                        // bytes the peek left in place.
+                        if let Ok(ws) = WebSocketServer::accept(stream, REPE_PATH).await {
+                            let _ = shared.serve_connection(ws).await;
+                        }
+                    }
+                    Ok(false) => {
+                        // Anything else is a plain HTTP request.
+                        if let Err(err) = serve_http(stream).await {
+                            eprintln!("[http] {err}");
+                        }
+                    }
+                    Err(err) => eprintln!("[accept] peek failed: {err}"),
+                }
+            });
+        }
+    });
+
+    // --- Fork 1: the REPE WebSocket endpoint. ---
+    let client = WebSocketClient::connect(&format!("ws://{addr}{REPE_PATH}")).await?;
+    let pong = client.call_json("/ping", &json!({})).await?;
+    println!("[ws] /ping -> {pong}");
+    assert_eq!(pong["pong"], true);
+    drop(client);
+
+    // --- Fork 2: a plain HTTP route on the same port. ---
+    let status = http_get(addr, "/healthz").await?;
+    println!("[http] GET /healthz -> {status}");
+    assert!(status.starts_with("HTTP/1.1 200"));
+
+    let body = http_get(addr, "/config").await?;
+    println!("[http] GET /config -> {} bytes", body.len());
+    assert!(body.contains("\"version\""));
+
+    let missing = http_get(addr, "/nope").await?;
+    assert!(missing.starts_with("HTTP/1.1 404"));
+
+    println!("[main] both forks answered on one TCP port");
+    server.abort();
+    Ok(())
+}
+
+/// A minimal, dependency-free HTTP/1.1 handler for the sibling routes a
+/// co-hosting embedder wants beside its WebSocket endpoint. It reads one
+/// request, routes on the method + path, writes one response, and closes
+/// the connection (`Connection: close` — no keep-alive).
+///
+/// This is deliberately small: just enough to answer a liveness probe and
+/// a couple of JSON `GET`s. A production embedder would expand the routing
+/// table (or reach for a real HTTP server) but would keep this exact
+/// peek-then-fork shape on the accept loop.
+async fn serve_http(mut stream: TcpStream) -> std::io::Result<()> {
+    let Some(head) = read_request_head(&mut stream).await? else {
+        // No request head (peer closed before sending one); nothing to do.
+        return Ok(());
+    };
+
+    // The request line is the first line of the head:
+    // "METHOD <target> HTTP/1.1" -> (method, path-without-query).
+    let request_line = head.lines().next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("/");
+    let path = target.split(['?', '#']).next().unwrap_or(target);
+
+    match (method, path) {
+        ("GET", "/healthz") => write_response(&mut stream, 200, "OK", "text/plain", b"ok").await,
+        ("GET", "/config") => {
+            let body = json!({ "version": env!("CARGO_PKG_VERSION"), "transport": "repe" });
+            let bytes = serde_json::to_vec(&body).expect("serialize config");
+            write_response(&mut stream, 200, "OK", "application/json", &bytes).await
+        }
+        ("GET", _) => {
+            write_response(&mut stream, 404, "Not Found", "text/plain", b"not found").await
+        }
+        _ => {
+            write_response(
+                &mut stream,
+                405,
+                "Method Not Allowed",
+                "text/plain",
+                b"method not allowed",
+            )
+            .await
+        }
+    }
+}
+
+/// Read the full HTTP request head (up to and including the `\r\n\r\n`
+/// header terminator), bounded so a misbehaving client cannot make us
+/// buffer without limit. Returns `None` if the connection closed before a
+/// head arrived.
+///
+/// Draining the whole head (not just the request line) matters: closing
+/// the socket while bytes the peer already sent sit unread in our receive
+/// buffer makes the OS send a TCP `RST` instead of a clean `FIN`, which
+/// the client sees as "connection reset" mid-read. The example serves only
+/// `GET`s (no request body), so end-of-headers is the end of the request.
+async fn read_request_head(stream: &mut TcpStream) -> std::io::Result<Option<String>> {
+    let mut buf = Vec::with_capacity(512);
+    let mut chunk = [0u8; 512];
+    loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            // EOF: return whatever we have (empty -> None).
+            return Ok((!buf.is_empty()).then(|| String::from_utf8_lossy(&buf).into_owned()));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            return Ok(Some(String::from_utf8_lossy(&buf).into_owned()));
+        }
+        if buf.len() >= 8192 {
+            // Header block too long; stop reading and treat as bad input
+            // rather than buffering unbounded.
+            return Ok(Some(String::from_utf8_lossy(&buf).into_owned()));
+        }
+    }
+}
+
+/// Write a complete HTTP/1.1 response with a fixed `Content-Length` and
+/// `Connection: close`.
+async fn write_response(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    content_type: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\r\n",
+        len = body.len(),
+    );
+    stream.write_all(head.as_bytes()).await?;
+    stream.write_all(body).await?;
+    stream.flush().await
+}
+
+/// Tiny raw-socket HTTP client used only to exercise the plain-HTTP fork
+/// in this example (so it needs no extra dependency). Returns the full
+/// response (status line, headers, body) as a string.
+async fn http_get(addr: std::net::SocketAddr, path: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).await?;
+    stream.flush().await?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await?;
+    Ok(response)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,5 +96,6 @@ pub use wasm_client::WasmClient;
 pub use websocket_client::{AlreadySubscribed, WebSocketClient};
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_server::{
-    ConnectionError, SharedWebSocketServer, ShutdownToken, WebSocketServer, proxy_connection,
+    ConnectionError, HandshakeContext, SharedWebSocketServer, ShutdownToken, WebSocketServer,
+    is_websocket_upgrade, proxy_connection,
 };

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -582,9 +582,13 @@ impl PeerRegistry {
         // Purge this peer's aliases via the reverse index (no full scan).
         if let Some(keys) = inner.alias_index.remove(&id) {
             for key in keys {
-                // Guard against a key that was re-pointed to another peer
-                // after this one acquired it; that peer now owns the
-                // forward mapping and must keep it.
+                // Defensive: `alias` retains a re-pointed key out of its
+                // previous owner's `alias_index`, so under that invariant
+                // every key reached here still maps to `id` and this check
+                // always passes. It is kept so a future change that broke
+                // the invariant could not turn a stale reverse-index entry
+                // into the wrongful removal of another peer's live forward
+                // mapping.
                 if inner.aliases.get(&key) == Some(&id) {
                     inner.aliases.remove(&key);
                 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -28,8 +28,10 @@
 use crate::constants::BodyFormat;
 use crate::error::RepeError;
 use serde::Serialize;
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::future::Future;
+use std::hash::Hash;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -346,10 +348,55 @@ impl std::fmt::Debug for CallContext<'_> {
 ///     publisher.broadcast_notify_json("/state/changed", &snapshot);
 /// });
 /// ```
+///
+/// # Addressing peers by an embedder key
+///
+/// [`PeerId`] is the registry's canonical, server-minted key — it is what
+/// [`with_peer_registry`](crate::websocket_server::WebSocketServer::with_peer_registry)
+/// auto-inserts and what the `broadcast_notify_*` result maps are keyed
+/// by. An embedder whose own client identity is something else (a
+/// UUID/token from the handshake, a domain id) can attach a secondary
+/// **alias** to an already-inserted peer with [`alias`](Self::alias) and
+/// then address it by that key with [`get_by`](Self::get_by), without
+/// maintaining a parallel `key -> PeerId` map by hand. Aliases are owned
+/// strings; a non-string key is converted with `to_string()`.
+///
+/// ```ignore
+/// // In an on_peer_connect_with_handshake hook the embedder derives its
+/// // key from the upgrade request and aliases the freshly-inserted peer:
+/// peers.alias(peer.peer_id(), token_from_handshake);
+///
+/// // Later, a targeted push addressed by the embedder's own identity:
+/// if let Some(handle) = peers.get_by("session-abc123") {
+///     let _ = handle.send_notify("/nudge", NotifyBody::Json(payload));
+/// }
+/// ```
+///
+/// Aliases are cleaned up automatically: [`remove`](Self::remove) (which
+/// `with_peer_registry` routes disconnect through) drops the peer's
+/// primary entry and every alias pointing at it. To interpret a
+/// `broadcast_notify_*` result map by the embedder's own identity, map
+/// each [`PeerId`] back with [`key_for`](Self::key_for) /
+/// [`aliases_for`](Self::aliases_for).
 #[derive(Clone)]
 pub struct PeerRegistry {
-    inner: Arc<Mutex<HashMap<PeerId, PeerHandle>>>,
+    inner: Arc<Mutex<RegistryInner>>,
     next_id: Arc<AtomicU64>,
+}
+
+/// Backing storage for a [`PeerRegistry`], guarded by one mutex so the
+/// primary map and the alias indices never drift out of sync.
+#[derive(Default)]
+struct RegistryInner {
+    /// Canonical map: the server-minted [`PeerId`] to its handle.
+    peers: HashMap<PeerId, PeerHandle>,
+    /// Forward alias lookup: an embedder-supplied key to the peer it
+    /// addresses. Many keys may point at one peer.
+    aliases: HashMap<String, PeerId>,
+    /// Reverse index: a peer to the aliases pointing at it, so a close can
+    /// purge those aliases without scanning the whole forward map.
+    /// Preserves alias insertion order so [`key_for`] is well-defined.
+    alias_index: HashMap<PeerId, Vec<String>>,
 }
 
 impl Default for PeerRegistry {
@@ -362,7 +409,7 @@ impl PeerRegistry {
     /// Build an empty registry.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
+            inner: Arc::new(Mutex::new(RegistryInner::default())),
             next_id: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -395,12 +442,12 @@ impl PeerRegistry {
 
     /// Current number of connected peers.
     pub fn len(&self) -> usize {
-        self.lock().len()
+        self.lock().peers.len()
     }
 
     /// `true` if no peers are connected.
     pub fn is_empty(&self) -> bool {
-        self.lock().is_empty()
+        self.lock().peers.is_empty()
     }
 
     /// Snapshot of currently-connected peer handles.
@@ -409,13 +456,96 @@ impl PeerRegistry {
     /// into the returned `Vec`; callers can iterate freely without
     /// blocking inserts or removals.
     pub fn peers(&self) -> Vec<PeerHandle> {
-        self.lock().values().cloned().collect()
+        self.lock().peers.values().cloned().collect()
     }
 
     /// Look up a peer by id. Returns `None` if the peer has
     /// disconnected.
     pub fn get(&self, id: PeerId) -> Option<PeerHandle> {
-        self.lock().get(&id).cloned()
+        self.lock().peers.get(&id).cloned()
+    }
+
+    /// Associate an embedder-supplied `key` with an already-inserted
+    /// peer, so the peer can later be addressed by that key through
+    /// [`get_by`](Self::get_by) without the embedder maintaining a
+    /// parallel `key -> PeerId` map.
+    ///
+    /// Returns `true` if the alias was attached, `false` if `peer_id`
+    /// is not currently in the registry (e.g. the peer already
+    /// disconnected) — in which case no dangling alias is created.
+    ///
+    /// A peer may carry several aliases (e.g. a user id and a session
+    /// id); calling `alias` again with a fresh key adds another. If
+    /// `key` was already pointing at a *different* peer, it is moved to
+    /// `peer_id` (a key addresses at most one peer). Re-attaching a key
+    /// the peer already has is a no-op.
+    ///
+    /// The alias is dropped automatically when the peer is
+    /// [`remove`](Self::remove)d, so an embedder using
+    /// [`with_peer_registry`](crate::websocket_server::WebSocketServer::with_peer_registry)
+    /// never has to clean it up on disconnect.
+    pub fn alias<K: Into<String>>(&self, peer_id: PeerId, key: K) -> bool {
+        let key = key.into();
+        let mut guard = self.lock();
+        let inner: &mut RegistryInner = &mut guard;
+        if !inner.peers.contains_key(&peer_id) {
+            return false;
+        }
+        match inner.aliases.insert(key.clone(), peer_id) {
+            // The key already addressed this same peer: the reverse index
+            // already lists it, so there is nothing to add.
+            Some(prev) if prev == peer_id => return true,
+            // The key addressed a different peer: detach it there before
+            // recording it under the new owner.
+            Some(prev) => {
+                if let Some(keys) = inner.alias_index.get_mut(&prev) {
+                    keys.retain(|k| k != &key);
+                }
+            }
+            None => {}
+        }
+        inner.alias_index.entry(peer_id).or_default().push(key);
+        true
+    }
+
+    /// Look up a peer by an embedder [`alias`](Self::alias). Returns
+    /// `None` if no peer is aliased by `key` or the aliased peer has
+    /// since disconnected.
+    ///
+    /// The lookup is generic over the borrowed key form, mirroring
+    /// [`HashMap::get`](std::collections::HashMap::get): a registry whose
+    /// aliases are owned `String`s can be queried with a `&str`.
+    pub fn get_by<Q>(&self, key: &Q) -> Option<PeerHandle>
+    where
+        String: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let guard = self.lock();
+        let id = *guard.aliases.get(key)?;
+        guard.peers.get(&id).cloned()
+    }
+
+    /// The first alias (in registration order) attached to `peer_id`, if
+    /// any. When each peer carries a single alias — the common case —
+    /// this is that alias, letting an embedder map a [`PeerId`] from a
+    /// `broadcast_notify_*` result back to its own client identity. Use
+    /// [`aliases_for`](Self::aliases_for) when a peer may carry several.
+    pub fn key_for(&self, peer_id: PeerId) -> Option<String> {
+        self.lock()
+            .alias_index
+            .get(&peer_id)
+            .and_then(|keys| keys.first().cloned())
+    }
+
+    /// Every alias attached to `peer_id`, in registration order (empty if
+    /// the peer has none or is gone). The owned `Vec` is a snapshot; the
+    /// registry lock is released before it is returned.
+    pub fn aliases_for(&self, peer_id: PeerId) -> Vec<String> {
+        self.lock()
+            .alias_index
+            .get(&peer_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Insert a peer.
@@ -429,7 +559,7 @@ impl PeerRegistry {
     /// (two servers minting `PeerId(0)` against a shared registry)
     /// fires loudly in tests.
     pub fn insert(&self, peer: PeerHandle) {
-        let prev = self.lock().insert(peer.peer_id(), peer);
+        let prev = self.lock().peers.insert(peer.peer_id(), peer);
         debug_assert!(
             prev.is_none(),
             "PeerRegistry::insert overwrote an existing peer; \
@@ -439,9 +569,28 @@ impl PeerRegistry {
         );
     }
 
-    /// Remove a peer. Returns the removed handle if it was present.
+    /// Remove a peer, dropping its primary entry and every
+    /// [`alias`](Self::alias) pointing at it. Returns the removed handle
+    /// if it was present.
+    ///
+    /// `with_peer_registry` routes disconnect through this method, so an
+    /// embedder's aliases are cleaned up on close with no extra wiring.
     pub fn remove(&self, id: PeerId) -> Option<PeerHandle> {
-        self.lock().remove(&id)
+        let mut guard = self.lock();
+        let inner: &mut RegistryInner = &mut guard;
+        let removed = inner.peers.remove(&id);
+        // Purge this peer's aliases via the reverse index (no full scan).
+        if let Some(keys) = inner.alias_index.remove(&id) {
+            for key in keys {
+                // Guard against a key that was re-pointed to another peer
+                // after this one acquired it; that peer now owns the
+                // forward mapping and must keep it.
+                if inner.aliases.get(&key) == Some(&id) {
+                    inner.aliases.remove(&key);
+                }
+            }
+        }
+        removed
     }
 
     /// Broadcast a JSON-bodied notify to every connected peer.
@@ -534,12 +683,13 @@ impl PeerRegistry {
         out
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<PeerId, PeerHandle>> {
-        // Recover from poison: the map's invariants (an `Arc`-keyed
-        // `HashMap<PeerId, PeerHandle>` with no cross-entry coupling)
-        // cannot be left inconsistent by any single insert/remove, so
-        // honoring the poison would block the registry forever on the
-        // strength of an unrelated panic in some other code path.
+    fn lock(&self) -> std::sync::MutexGuard<'_, RegistryInner> {
+        // Recover from poison: every public mutation takes this one lock
+        // and leaves the peer map and its alias indices mutually
+        // consistent before releasing it, so a panic in unrelated code
+        // cannot have torn that invariant. Honoring the poison would
+        // instead block the registry forever on the strength of that
+        // unrelated panic.
         match self.inner.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -676,5 +826,130 @@ mod tests {
         let peer = PeerHandle::new(PeerId(4), sink);
         assert!(!CallContext::detached("/m").is_cancelled());
         assert!(!CallContext::new("/m", &peer).is_cancelled());
+    }
+
+    // ---- Alias index (embedder-keyed peer lookup) ------------------
+
+    fn connected_peer(id: u64) -> PeerHandle {
+        PeerHandle::new(
+            PeerId(id),
+            Arc::new(CapturingSink {
+                connected: true,
+                ..Default::default()
+            }),
+        )
+    }
+
+    #[test]
+    fn alias_then_get_by_resolves_to_the_peer() {
+        let registry = PeerRegistry::new();
+        let peer = connected_peer(1);
+        registry.insert(peer.clone());
+
+        assert!(registry.alias(peer.peer_id(), "session-abc"));
+        // Generic lookup: aliases are owned Strings, queryable by &str.
+        let found = registry.get_by("session-abc").expect("alias resolves");
+        assert_eq!(found.peer_id(), PeerId(1));
+        // Reverse lookup recovers the embedder key from a PeerId.
+        assert_eq!(registry.key_for(PeerId(1)).as_deref(), Some("session-abc"));
+        assert_eq!(registry.aliases_for(PeerId(1)), vec!["session-abc"]);
+    }
+
+    #[test]
+    fn alias_on_absent_peer_is_rejected() {
+        let registry = PeerRegistry::new();
+        // No peer with this id is registered, so no dangling alias forms.
+        assert!(!registry.alias(PeerId(7), "ghost"));
+        assert!(registry.get_by("ghost").is_none());
+        assert!(registry.key_for(PeerId(7)).is_none());
+    }
+
+    #[test]
+    fn get_by_missing_key_is_none() {
+        let registry = PeerRegistry::new();
+        registry.insert(connected_peer(1));
+        assert!(registry.get_by("nope").is_none());
+    }
+
+    #[test]
+    fn remove_purges_all_aliases() {
+        let registry = PeerRegistry::new();
+        let peer = connected_peer(1);
+        registry.insert(peer.clone());
+        registry.alias(peer.peer_id(), "user-1");
+        registry.alias(peer.peer_id(), "session-1");
+        assert_eq!(registry.aliases_for(PeerId(1)).len(), 2);
+
+        let removed = registry.remove(PeerId(1)).expect("peer was present");
+        assert_eq!(removed.peer_id(), PeerId(1));
+        // Both the primary entry and every alias are gone.
+        assert!(registry.get_by("user-1").is_none());
+        assert!(registry.get_by("session-1").is_none());
+        assert!(registry.aliases_for(PeerId(1)).is_empty());
+        assert!(registry.key_for(PeerId(1)).is_none());
+    }
+
+    #[test]
+    fn multiple_aliases_address_one_peer() {
+        let registry = PeerRegistry::new();
+        let peer = connected_peer(5);
+        registry.insert(peer.clone());
+        registry.alias(peer.peer_id(), "u-5");
+        registry.alias(peer.peer_id(), "s-5");
+
+        assert_eq!(registry.get_by("u-5").unwrap().peer_id(), PeerId(5));
+        assert_eq!(registry.get_by("s-5").unwrap().peer_id(), PeerId(5));
+        // Registration order is preserved.
+        assert_eq!(registry.aliases_for(PeerId(5)), vec!["u-5", "s-5"]);
+    }
+
+    #[test]
+    fn re_aliasing_a_key_moves_it_to_the_new_peer() {
+        let registry = PeerRegistry::new();
+        registry.insert(connected_peer(1));
+        registry.insert(connected_peer(2));
+
+        registry.alias(PeerId(1), "shared");
+        assert_eq!(registry.get_by("shared").unwrap().peer_id(), PeerId(1));
+
+        // Re-point the same key at peer 2: a key addresses at most one peer.
+        registry.alias(PeerId(2), "shared");
+        assert_eq!(registry.get_by("shared").unwrap().peer_id(), PeerId(2));
+        // The old owner no longer lists it in its reverse index.
+        assert!(registry.aliases_for(PeerId(1)).is_empty());
+        assert_eq!(registry.aliases_for(PeerId(2)), vec!["shared"]);
+
+        // Removing the old owner must not disturb the re-pointed alias.
+        registry.remove(PeerId(1));
+        assert_eq!(registry.get_by("shared").unwrap().peer_id(), PeerId(2));
+    }
+
+    #[test]
+    fn re_aliasing_same_peer_is_idempotent() {
+        let registry = PeerRegistry::new();
+        registry.insert(connected_peer(1));
+        assert!(registry.alias(PeerId(1), "k"));
+        assert!(registry.alias(PeerId(1), "k"));
+        // The key is not duplicated in the reverse index.
+        assert_eq!(registry.aliases_for(PeerId(1)), vec!["k"]);
+    }
+
+    #[test]
+    fn aliases_let_broadcast_results_map_back_to_keys() {
+        // The motivating case: a broadcast returns HashMap<PeerId, _>, and
+        // the embedder reads it by its own identity via key_for.
+        let registry = PeerRegistry::new();
+        registry.insert(connected_peer(1));
+        registry.insert(connected_peer(2));
+        registry.alias(PeerId(1), "alice");
+        registry.alias(PeerId(2), "bob");
+
+        let results = registry.broadcast_notify_utf8("/ping", "hi");
+        let keyed: std::collections::HashMap<String, _> = results
+            .into_iter()
+            .filter_map(|(id, r)| registry.key_for(id).map(|k| (k, r)))
+            .collect();
+        assert!(keyed.contains_key("alice"));
+        assert!(keyed.contains_key("bob"));
     }
 }

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -165,7 +165,7 @@ impl std::error::Error for ConnectionError {
 /// If the embedder's key instead arrives in a request *body*, this hook
 /// is unnecessary — the handler already has both the key and the peer via
 /// [`CallContext::peer`](crate::CallContext::peer).
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct HandshakeContext {
     path: String,
     query: Option<String>,
@@ -179,11 +179,18 @@ impl HandshakeContext {
         let headers = request
             .headers()
             .iter()
-            .map(|(name, value)| {
-                (
-                    name.as_str().to_owned(),
-                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
-                )
+            .filter_map(|(name, value)| {
+                // Keep only values that round-trip to clean text. The
+                // documented use is keying off a token / auth header, so a
+                // value that is not valid (visible ASCII) text is better
+                // surfaced as an absent header (fail-closed: the embedder
+                // sees `None` and can reject the connection) than captured
+                // as a lossily-mangled string that no `get_by` lookup would
+                // ever match.
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_owned(), v.to_owned()))
             })
             .collect();
         Self {
@@ -209,7 +216,10 @@ impl HandshakeContext {
 
     /// The first value of the named header, matched case-insensitively
     /// (HTTP header names are case-insensitive). Returns `None` if the
-    /// header was absent or its value was not valid UTF-8.
+    /// header was absent, or if its value was not valid (visible ASCII)
+    /// text — such values are dropped at capture rather than mangled, so a
+    /// token or auth header that cannot round-trip to a clean string reads
+    /// as absent rather than as a corrupted key.
     pub fn header(&self, name: &str) -> Option<&str> {
         self.headers
             .iter()
@@ -220,10 +230,37 @@ impl HandshakeContext {
     /// Iterate over every captured header as `(name, value)` pairs, in
     /// the order they arrived. Header names retain the case the client
     /// sent; use [`header`](Self::header) for a case-insensitive lookup.
+    /// Headers whose value was not valid (visible ASCII) text are dropped
+    /// at capture (see [`header`](Self::header)), so they do not appear
+    /// here either.
     pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
         self.headers
             .iter()
             .map(|(name, value)| (name.as_str(), value.as_str()))
+    }
+}
+
+impl std::fmt::Debug for HandshakeContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Hand-written rather than derived (mirroring `PeerHandle` and
+        // `CallContext` in the peer module): the query string and header
+        // values can carry credentials — the documented use keys off an
+        // auth header or a token in the query — so a routine
+        // `tracing::debug!(?ctx)` must not spill them into logs. The path
+        // and header names are safe to show; values and the query are
+        // redacted.
+        f.debug_struct("HandshakeContext")
+            .field("path", &self.path)
+            .field("query", &self.query.as_ref().map(|_| "<redacted>"))
+            .field(
+                "headers",
+                &self
+                    .headers
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
     }
 }
 
@@ -1429,21 +1466,44 @@ fn decode_request_frame(frame: WsMessage) -> Result<FrameAction, RepeError> {
 /// per RFC 6455 §4.2.1) within the request head, and matches the
 /// `websocket` token only inside that header's value, so a plain
 /// `GET /websocket-status` request is not misclassified.
-/// [`WebSocketServer::accept`] still performs the authoritative RFC 6455
-/// validation on the `true` branch, so a false positive there fails the
-/// handshake rather than corrupting anything.
+///
+/// The two misclassification directions are **not** symmetric:
+///
+/// - A false positive (plain HTTP sniffed as an upgrade) is harmless. The
+///   `true` branch hands off to [`WebSocketServer::accept`], whose
+///   authoritative RFC 6455 validation rejects the request and fails the
+///   handshake rather than corrupting anything.
+/// - A false negative is **not** recoverable here. If a real upgrade's
+///   `Upgrade` header has not arrived in the connection's first readable
+///   chunk (TCP may split the request head across segments) or falls
+///   beyond the 1 KiB peek window, the request is routed to the HTTP
+///   handler with no second look.
 ///
 /// The peek reads the request head that arrives in the connection's first
-/// readable chunk (bounded to 1 KiB). A WebSocket upgrade request — a
-/// short `GET` line plus its `Upgrade`/`Connection` headers — fits well
-/// within that, and those headers lead the block.
+/// readable chunk (bounded to 1 KiB). A real WebSocket upgrade — a short
+/// `GET` line plus its `Upgrade`/`Connection` headers — sends a compact
+/// head with those headers up front, so a false negative is unlikely on a
+/// sane network; but it depends on client and network framing, not on the
+/// heuristic alone. An embedder that must be exact can read and buffer the
+/// request head itself (up to the terminating `\r\n\r\n`) before
+/// classifying.
 ///
 /// # Errors
 ///
 /// Returns the underlying [`std::io::Error`] if peeking the stream fails.
-/// A peer that connects and sends nothing yet is reported as `false`
-/// (`peek` resolves once at least one byte is readable; an immediate EOF
-/// yields an empty, non-upgrade head).
+///
+/// # Blocking and timeouts
+///
+/// `peek` resolves only once at least one byte is readable. A peer that
+/// connects and immediately closes (EOF) yields an empty, non-upgrade head
+/// and is reported as `false`; but a peer that connects and holds the
+/// socket open *without sending* leaves this future pending indefinitely,
+/// pinning the spawned task (a slowloris). This mirrors
+/// [`WebSocketServer::accept`], which likewise awaits the client's bytes,
+/// so it is not specific to co-hosting — but because this helper is the
+/// recommended one-port entry point, production embedders should wrap the
+/// peek in a [`tokio::time::timeout`] and drop the connection if the
+/// request head does not arrive promptly.
 pub async fn is_websocket_upgrade(stream: &TcpStream) -> std::io::Result<bool> {
     let mut buf = [0u8; 1024];
     let n = stream.peek(&mut buf).await?;
@@ -3337,5 +3397,60 @@ mod tests {
 
         drop(client);
         server_task.abort();
+    }
+
+    #[test]
+    fn handshake_capture_drops_non_ascii_header_values_and_keeps_ascii() {
+        // The capture path keeps only header values that round-trip to
+        // clean text, so an embedder keying off a token / auth header sees
+        // a non-ASCII value as absent (fail-closed) rather than as a
+        // U+FFFD-mangled key that no `get_by` lookup would ever match.
+        use tungstenite::http;
+        let garbled = http::HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap();
+        let request = http::Request::builder()
+            .uri("/repe?token=abc123")
+            .header("authorization", "Bearer good-token")
+            .header("x-garbled", garbled)
+            .body(())
+            .unwrap();
+
+        let ctx = HandshakeContext::from_request(&request);
+
+        // The ASCII header survives and stays case-insensitively addressable.
+        assert_eq!(ctx.header("authorization"), Some("Bearer good-token"));
+        assert_eq!(ctx.header("Authorization"), Some("Bearer good-token"));
+        // The non-ASCII value is dropped at capture: absent, not mangled.
+        assert_eq!(ctx.header("x-garbled"), None);
+        // ...and it is absent from the full iterator too.
+        assert!(ctx.headers().all(|(name, _)| name != "x-garbled"));
+        // Path and query are still captured verbatim.
+        assert_eq!(ctx.path(), "/repe");
+        assert_eq!(ctx.query(), Some("token=abc123"));
+    }
+
+    #[test]
+    fn handshake_debug_redacts_credentials() {
+        // The hand-written Debug must not spill the query string or header
+        // values (the documented key / token carriers) into logs.
+        use tungstenite::http;
+        let request = http::Request::builder()
+            .uri("/repe?token=super-secret")
+            .header("authorization", "Bearer super-secret")
+            .body(())
+            .unwrap();
+
+        let ctx = HandshakeContext::from_request(&request);
+        let rendered = format!("{ctx:?}");
+
+        // Neither secret value appears anywhere in the rendering.
+        assert!(
+            !rendered.contains("super-secret"),
+            "Debug leaked a credential: {rendered}"
+        );
+        // The safe-to-show shape does: the path and the header *name*.
+        assert!(rendered.contains("/repe"), "rendered = {rendered}");
+        assert!(rendered.contains("authorization"), "rendered = {rendered}");
+        // Query presence is signalled without exposing its value.
+        assert!(rendered.contains("<redacted>"), "rendered = {rendered}");
     }
 }

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -30,6 +30,7 @@ use tokio_tungstenite::{WebSocketStream, accept_hdr_async};
 use tokio_util::sync::CancellationToken;
 
 type ConnectHook = Arc<dyn Fn(PeerHandle) + Send + Sync>;
+type ConnectCtxHook = Arc<dyn Fn(&PeerHandle, &HandshakeContext) + Send + Sync>;
 type DisconnectHook = Arc<dyn Fn(PeerId) + Send + Sync>;
 type ErrorHook = Arc<dyn Fn(&ConnectionError) + Send + Sync>;
 
@@ -144,6 +145,85 @@ impl std::error::Error for ConnectionError {
             ConnectionError::Handshake(err) | ConnectionError::Connection(err) => Some(err),
             ConnectionError::HandlerPanic { .. } | ConnectionError::Saturation { .. } => None,
         }
+    }
+}
+
+/// Read-only snapshot of the WebSocket upgrade request, captured during
+/// the handshake and handed to an
+/// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
+/// hook.
+///
+/// An embedder whose canonical client identity rides in the upgrade
+/// request — a token in the query string, an auth header — derives its
+/// key from this context at connect time and attaches it to the
+/// freshly-inserted peer with
+/// [`PeerRegistry::alias`](crate::PeerRegistry::alias), so later targeted
+/// pushes can address the peer by that key. The path, query, and headers
+/// are captured as owned values, so the context outlives the handshake
+/// and is cheap to clone.
+///
+/// If the embedder's key instead arrives in a request *body*, this hook
+/// is unnecessary — the handler already has both the key and the peer via
+/// [`CallContext::peer`](crate::CallContext::peer).
+#[derive(Clone, Debug)]
+pub struct HandshakeContext {
+    path: String,
+    query: Option<String>,
+    headers: Vec<(String, String)>,
+}
+
+impl HandshakeContext {
+    /// Capture the parts of an upgrade [`Request`] an embedder may key on.
+    fn from_request(request: &Request) -> Self {
+        let uri = request.uri();
+        let headers = request
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str().to_owned(),
+                    String::from_utf8_lossy(value.as_bytes()).into_owned(),
+                )
+            })
+            .collect();
+        Self {
+            path: uri.path().to_owned(),
+            query: uri.query().map(str::to_owned),
+            headers,
+        }
+    }
+
+    /// The request-target path of the upgrade (e.g. `/repe`). This is the
+    /// same path [`WebSocketServer::accept`] validated against, normalized
+    /// by the client; the query string is not included.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// The raw query string of the upgrade request (the part after `?`),
+    /// if present. Percent-decoding and key/value splitting are left to
+    /// the embedder so repe pulls in no URL-parsing dependency.
+    pub fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+
+    /// The first value of the named header, matched case-insensitively
+    /// (HTTP header names are case-insensitive). Returns `None` if the
+    /// header was absent or its value was not valid UTF-8.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// Iterate over every captured header as `(name, value)` pairs, in
+    /// the order they arrived. Header names retain the case the client
+    /// sent; use [`header`](Self::header) for a case-insensitive lookup.
+    pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.headers
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
     }
 }
 
@@ -275,6 +355,7 @@ pub struct WebSocketServer {
     offreader_limit: Option<usize>,
     peer_id_counter: Arc<AtomicU64>,
     on_connect: Vec<ConnectHook>,
+    on_connect_ctx: Vec<ConnectCtxHook>,
     on_disconnect: Vec<DisconnectHook>,
     on_error: Vec<ErrorHook>,
 }
@@ -287,6 +368,7 @@ impl WebSocketServer {
             offreader_limit: Some(DEFAULT_OFFREADER_LIMIT),
             peer_id_counter: Arc::new(AtomicU64::new(0)),
             on_connect: Vec::new(),
+            on_connect_ctx: Vec::new(),
             on_disconnect: Vec::new(),
             on_error: Vec::new(),
         }
@@ -367,6 +449,51 @@ impl WebSocketServer {
         F: Fn(PeerHandle) + Send + Sync + 'static,
     {
         self.on_connect.push(Arc::new(f));
+        self
+    }
+
+    /// Like [`on_peer_connect`](Self::on_peer_connect), but the callback
+    /// also receives the [`HandshakeContext`] of the upgrade request
+    /// (path, query, headers). Use it when the embedder's client identity
+    /// rides in the handshake: derive a key from the request and attach it
+    /// to the just-inserted peer with
+    /// [`PeerRegistry::alias`](crate::PeerRegistry::alias), so later
+    /// targeted pushes can address the peer by that key.
+    ///
+    /// ```ignore
+    /// let peers = PeerRegistry::new();
+    /// let server = WebSocketServer::new(router)
+    ///     .with_peer_registry(peers.clone())
+    ///     .on_peer_connect_with_handshake({
+    ///         let peers = peers.clone();
+    ///         move |peer, hs| {
+    ///             if let Some(token) = hs.header("authorization") {
+    ///                 peers.alias(peer.peer_id(), token);
+    ///             }
+    ///         }
+    ///     });
+    /// ```
+    ///
+    /// These hooks fire **after** the plain
+    /// [`on_peer_connect`](Self::on_peer_connect) hooks (so a
+    /// [`with_peer_registry`](Self::with_peer_registry) insert has already
+    /// run and the peer is present for `alias`), in registration order,
+    /// and still before the connection processes any traffic. Like the
+    /// plain hook the callback runs synchronously on the accept task and
+    /// must not block.
+    ///
+    /// The context is available wherever the handshake is: the built-in
+    /// `serve*` loops, and the co-hosting
+    /// [`accept_with_handshake`](Self::accept_with_handshake) +
+    /// [`serve_connection_with_handshake`](SharedWebSocketServer::serve_connection_with_handshake)
+    /// path. A connection served through plain
+    /// [`serve_connection`](SharedWebSocketServer::serve_connection)
+    /// (which carries no captured handshake) does not fire these hooks.
+    pub fn on_peer_connect_with_handshake<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&PeerHandle, &HandshakeContext) + Send + Sync + 'static,
+    {
+        self.on_connect_ctx.push(Arc::new(f));
         self
     }
 
@@ -460,7 +587,7 @@ impl WebSocketServer {
         path: &str,
         shutdown: impl Future<Output = ()>,
     ) -> std::io::Result<()> {
-        let path = path.to_string();
+        let path = normalize_path(path);
         let shared = self.into_shared();
 
         tokio::pin!(shutdown);
@@ -473,16 +600,7 @@ impl WebSocketServer {
                     let path = path.clone();
                     let shared = shared.clone();
                     tokio::spawn(async move {
-                        match WebSocketServer::accept(stream, &path).await {
-                            Ok(ws_stream) => {
-                                if let Err(err) = shared.serve_connection(ws_stream).await {
-                                    shared.report_error(ConnectionError::Connection(err));
-                                }
-                            }
-                            Err(err) => {
-                                shared.report_error(ConnectionError::Handshake(err));
-                            }
-                        }
+                        shared.accept_and_serve(stream, &path, None).await;
                     });
                 }
                 _ = &mut shutdown => break,
@@ -550,7 +668,7 @@ impl WebSocketServer {
         shutdown: impl Future<Output = ()>,
         drain_timeout: Duration,
     ) -> std::io::Result<()> {
-        let path = path.to_string();
+        let path = normalize_path(path);
         let shared = self.into_shared();
         // Parent of every connection's cancellation token. Cancelled once
         // on shutdown to wake all in-flight handlers at once.
@@ -566,18 +684,7 @@ impl WebSocketServer {
                     let shared = shared.clone();
                     let parent = parent.clone();
                     conns.spawn(async move {
-                        match WebSocketServer::accept(stream, &path).await {
-                            Ok(ws_stream) => {
-                                if let Err(err) =
-                                    shared.serve_connection_with_cancel(ws_stream, &parent).await
-                                {
-                                    shared.report_error(ConnectionError::Connection(err));
-                                }
-                            }
-                            Err(err) => {
-                                shared.report_error(ConnectionError::Handshake(err));
-                            }
-                        }
+                        shared.accept_and_serve(stream, &path, Some(&parent)).await;
                     });
                     // Reap finished connections so the JoinSet tracks only
                     // live ones rather than growing with every accept.
@@ -625,6 +732,7 @@ impl WebSocketServer {
                 offreader_limit: self.offreader_limit,
                 peer_id_counter: self.peer_id_counter,
                 on_connect: Arc::new(self.on_connect),
+                on_connect_ctx: Arc::new(self.on_connect_ctx),
                 on_disconnect: Arc::new(self.on_disconnect),
                 on_error: Arc::new(self.on_error),
             }),
@@ -644,7 +752,35 @@ impl WebSocketServer {
         stream: TcpStream,
         path: &str,
     ) -> Result<WebSocketStream<TcpStream>, RepeError> {
-        accept_repe_websocket(stream, &normalize_path(path)).await
+        // No handshake capture: this path feeds `serve_connection`, which
+        // does not fire handshake-aware hooks.
+        accept_repe_websocket(stream, &normalize_path(path), false)
+            .await
+            .map(|(ws, _handshake)| ws)
+    }
+
+    /// Like [`accept`](Self::accept), but also returns the
+    /// [`HandshakeContext`] of the upgrade request so a co-hosting
+    /// embedder can fire
+    /// [`on_peer_connect_with_handshake`](Self::on_peer_connect_with_handshake)
+    /// hooks. Pair the returned context with
+    /// [`SharedWebSocketServer::serve_connection_with_handshake`] (or
+    /// [`serve_connection_with_cancel_and_handshake`](SharedWebSocketServer::serve_connection_with_cancel_and_handshake)).
+    ///
+    /// The built-in `serve*` loops capture this context for you, so this
+    /// pairing is only needed when the embedder owns its own accept loop
+    /// (one-port co-hosting) *and* keys peers off the handshake.
+    pub async fn accept_with_handshake(
+        stream: TcpStream,
+        path: &str,
+    ) -> Result<(WebSocketStream<TcpStream>, HandshakeContext), RepeError> {
+        let (ws, handshake) = accept_repe_websocket(stream, &normalize_path(path), true).await?;
+        // `capture_handshake = true` always yields `Some` on the accept
+        // path (the validator populates it before returning `Ok`).
+        Ok((
+            ws,
+            handshake.expect("handshake captured when capture_handshake is set"),
+        ))
     }
 }
 
@@ -654,6 +790,7 @@ struct ConnectionConfig {
     offreader_limit: Option<usize>,
     peer_id_counter: Arc<AtomicU64>,
     on_connect: Arc<Vec<ConnectHook>>,
+    on_connect_ctx: Arc<Vec<ConnectCtxHook>>,
     on_disconnect: Arc<Vec<DisconnectHook>>,
     on_error: Arc<Vec<ErrorHook>>,
 }
@@ -690,8 +827,30 @@ impl SharedWebSocketServer {
     /// [`serve_connection_with_cancel`](Self::serve_connection_with_cancel).
     pub async fn serve_connection(&self, ws: WebSocketStream<TcpStream>) -> Result<(), RepeError> {
         // No parent: the connection token is cancelled only when this
-        // connection's reader exits (disconnect).
-        handle_connection_with_config(ws, Arc::clone(&self.config), CancellationToken::new()).await
+        // connection's reader exits (disconnect). No captured handshake,
+        // so on_peer_connect_with_handshake hooks do not fire.
+        handle_connection_with_config(ws, Arc::clone(&self.config), CancellationToken::new(), None)
+            .await
+    }
+
+    /// Like [`serve_connection`](Self::serve_connection), but threads the
+    /// [`HandshakeContext`] from [`WebSocketServer::accept_with_handshake`]
+    /// through so
+    /// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
+    /// hooks fire for this connection. For a one-port co-hosting embedder
+    /// that keys peers off the upgrade request.
+    pub async fn serve_connection_with_handshake(
+        &self,
+        ws: WebSocketStream<TcpStream>,
+        handshake: HandshakeContext,
+    ) -> Result<(), RepeError> {
+        handle_connection_with_config(
+            ws,
+            Arc::clone(&self.config),
+            CancellationToken::new(),
+            Some(handshake),
+        )
+        .await
     }
 
     /// Like [`serve_connection`](Self::serve_connection), but ties this
@@ -711,7 +870,30 @@ impl SharedWebSocketServer {
         ws: WebSocketStream<TcpStream>,
         shutdown: &ShutdownToken,
     ) -> Result<(), RepeError> {
-        handle_connection_with_config(ws, Arc::clone(&self.config), shutdown.child_token()).await
+        handle_connection_with_config(ws, Arc::clone(&self.config), shutdown.child_token(), None)
+            .await
+    }
+
+    /// [`serve_connection_with_cancel`](Self::serve_connection_with_cancel)
+    /// plus the captured [`HandshakeContext`] — the union of co-hosting,
+    /// embedder-driven drain, and handshake-keyed peers. Cancelling the
+    /// shared [`ShutdownToken`] winds the connection's in-flight off-reader
+    /// handlers down, and
+    /// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
+    /// hooks fire from the captured `handshake`.
+    pub async fn serve_connection_with_cancel_and_handshake(
+        &self,
+        ws: WebSocketStream<TcpStream>,
+        handshake: HandshakeContext,
+        shutdown: &ShutdownToken,
+    ) -> Result<(), RepeError> {
+        handle_connection_with_config(
+            ws,
+            Arc::clone(&self.config),
+            shutdown.child_token(),
+            Some(handshake),
+        )
+        .await
     }
 
     /// Report a transport-level error through this server's
@@ -721,6 +903,41 @@ impl SharedWebSocketServer {
     /// [`serve_connection`](Self::serve_connection) however it likes.
     pub(crate) fn report_error(&self, err: ConnectionError) {
         report_error(&self.config.on_error, err);
+    }
+
+    /// One connection's full lifecycle for the built-in accept loops:
+    /// handshake, serve, and report any handshake/connection error. The
+    /// [`HandshakeContext`] is captured only when a handshake-aware connect
+    /// hook is registered, so a server that uses none pays nothing extra on
+    /// the accept path. `expected_path` must already be normalized.
+    /// `shutdown` is `Some` for the graceful-drain loop (ties the
+    /// connection token to the shared trigger) and `None` otherwise.
+    async fn accept_and_serve(
+        &self,
+        stream: TcpStream,
+        expected_path: &str,
+        shutdown: Option<&ShutdownToken>,
+    ) {
+        let capture = !self.config.on_connect_ctx.is_empty();
+        match accept_repe_websocket(stream, expected_path, capture).await {
+            Ok((ws, handshake)) => {
+                let conn_token = match shutdown {
+                    Some(token) => token.child_token(),
+                    None => CancellationToken::new(),
+                };
+                if let Err(err) = handle_connection_with_config(
+                    ws,
+                    Arc::clone(&self.config),
+                    conn_token,
+                    handshake,
+                )
+                .await
+                {
+                    self.report_error(ConnectionError::Connection(err));
+                }
+            }
+            Err(err) => self.report_error(ConnectionError::Handshake(err)),
+        }
     }
 }
 
@@ -758,24 +975,49 @@ where
     writer.close().await.map_err(websocket_transport_error)
 }
 
+/// Perform the REPE upgrade handshake, optionally capturing the request
+/// context. `capture_handshake` is `false` for the plain accept paths so
+/// they pay no per-connection cost building a [`HandshakeContext`] no hook
+/// will read; it is `true` only when an
+/// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
+/// hook (or the explicit
+/// [`accept_with_handshake`](WebSocketServer::accept_with_handshake)) needs
+/// it. The returned `Option` is `Some` iff `capture_handshake` was `true`.
 async fn accept_repe_websocket(
     stream: TcpStream,
     expected_path: &str,
-) -> Result<WebSocketStream<TcpStream>, RepeError> {
-    accept_hdr_async(
+    capture_handshake: bool,
+) -> Result<(WebSocketStream<TcpStream>, Option<HandshakeContext>), RepeError> {
+    // The handshake `Callback` borrows the request only for the duration
+    // of `on_request`, so stash the captured context in a shared slot the
+    // validator fills and we read back once the upgrade completes. When no
+    // hook will read it, the slot is absent and the validator skips the
+    // capture entirely.
+    let captured = capture_handshake.then(|| Arc::new(std::sync::Mutex::new(None)));
+    let ws = accept_hdr_async(
         stream,
         WebSocketPathValidator {
             expected: expected_path.to_owned(),
+            captured: captured.clone(),
         },
     )
     .await
-    .map_err(websocket_transport_error)
+    .map_err(websocket_transport_error)?;
+    // The validator populates the slot on the accept path; a rejected path
+    // returns `Err` above before we get here.
+    let handshake = captured.and_then(|slot| {
+        slot.lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    });
+    Ok((ws, handshake))
 }
 
 async fn handle_connection_with_config(
     ws_stream: WebSocketStream<TcpStream>,
     config: Arc<ConnectionConfig>,
     conn_token: CancellationToken,
+    handshake: Option<HandshakeContext>,
 ) -> Result<(), RepeError> {
     let (outbound_tx, outbound_rx) = mpsc::channel::<Message>(config.outbound_capacity);
 
@@ -827,6 +1069,16 @@ async fn handle_connection_with_config(
         // outbound channel when the writer task begins draining.
         for hook in config.on_connect.iter() {
             hook(peer.clone());
+        }
+        // Handshake-aware hooks run after the plain ones (so a
+        // `with_peer_registry` insert has already landed and the peer is
+        // present for `alias`) and only when a handshake was captured
+        // (the built-in `serve*` loops and the `*_with_handshake`
+        // co-hosting path; not plain `serve_connection`).
+        if let Some(handshake) = &handshake {
+            for hook in config.on_connect_ctx.iter() {
+                hook(&peer, handshake);
+            }
         }
 
         // Bundle the per-connection dispatch state for the reader. `peer`
@@ -1158,6 +1410,92 @@ fn decode_request_frame(frame: WsMessage) -> Result<FrameAction, RepeError> {
     }
 }
 
+/// Peek at an accepted `stream` and report whether the client is opening
+/// a WebSocket upgrade (as opposed to issuing a plain HTTP request),
+/// **without consuming any bytes**.
+///
+/// This is the WS-vs-HTTP fork a one-port co-hosting embedder needs: route
+/// `true` to [`WebSocketServer::accept`] +
+/// [`serve_connection`](SharedWebSocketServer::serve_connection) and `false`
+/// to your own HTTP handler, all on one TCP port. Because
+/// [`WebSocketServer::accept`] replays the handshake from the start of the
+/// stream, this helper only *peeks* (`TcpStream::peek`) — it leaves the
+/// request bytes in the socket buffer so the subsequent `accept` (or your
+/// HTTP handler) sees the full request intact. See
+/// `examples/websocket_cohosting.rs` for the worked fork.
+///
+/// The classification is a sniff, not a full handshake validation: it
+/// looks for an `Upgrade: websocket` header (compared case-insensitively,
+/// per RFC 6455 §4.2.1) within the request head, and matches the
+/// `websocket` token only inside that header's value, so a plain
+/// `GET /websocket-status` request is not misclassified.
+/// [`WebSocketServer::accept`] still performs the authoritative RFC 6455
+/// validation on the `true` branch, so a false positive there fails the
+/// handshake rather than corrupting anything.
+///
+/// The peek reads the request head that arrives in the connection's first
+/// readable chunk (bounded to 1 KiB). A WebSocket upgrade request — a
+/// short `GET` line plus its `Upgrade`/`Connection` headers — fits well
+/// within that, and those headers lead the block.
+///
+/// # Errors
+///
+/// Returns the underlying [`std::io::Error`] if peeking the stream fails.
+/// A peer that connects and sends nothing yet is reported as `false`
+/// (`peek` resolves once at least one byte is readable; an immediate EOF
+/// yields an empty, non-upgrade head).
+pub async fn is_websocket_upgrade(stream: &TcpStream) -> std::io::Result<bool> {
+    let mut buf = [0u8; 1024];
+    let n = stream.peek(&mut buf).await?;
+    Ok(head_requests_websocket_upgrade(&buf[..n]))
+}
+
+/// Scan an HTTP request head for a WebSocket upgrade signal. Pure and
+/// byte-slice-based so it is unit-testable without a socket.
+fn head_requests_websocket_upgrade(head: &[u8]) -> bool {
+    // Restrict to the header block when its terminator is present, so a
+    // body can never contribute a spurious match.
+    let block = match find_subslice(head, b"\r\n\r\n") {
+        Some(end) => &head[..end],
+        None => head,
+    };
+    for line in block.split(|&b| b == b'\n') {
+        // `trim_ascii` strips the trailing CR (and any surrounding space).
+        let line = line.trim_ascii();
+        let Some(colon) = line.iter().position(|&b| b == b':') else {
+            continue;
+        };
+        let (name, rest) = line.split_at(colon);
+        // `rest` starts at the colon; skip it for the value.
+        if name.eq_ignore_ascii_case(b"upgrade")
+            && contains_ignore_ascii_case(&rest[1..], b"websocket")
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// First index of `needle` within `haystack`, or `None`. `needle` must be
+/// non-empty.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Whether `haystack` contains `needle` as a contiguous run, compared
+/// ASCII-case-insensitively.
+fn contains_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if haystack.len() < needle.len() {
+        return false;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|w| w.eq_ignore_ascii_case(needle))
+}
+
 fn normalize_path(path: &str) -> String {
     if path.is_empty() || path == "/" {
         "/".to_string()
@@ -1194,12 +1532,24 @@ fn websocket_invalid_data_error(message: &str) -> RepeError {
 
 struct WebSocketPathValidator {
     expected: String,
+    /// Where to stash the captured [`HandshakeContext`], or `None` when no
+    /// hook will read it (the plain accept paths) so the capture is
+    /// skipped entirely.
+    captured: Option<Arc<std::sync::Mutex<Option<HandshakeContext>>>>,
 }
 
 impl Callback for WebSocketPathValidator {
     #[allow(clippy::result_large_err)]
     fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
         if request.uri().path() == self.expected {
+            // Capture the request context for the connect hook before the
+            // borrow ends, but only when a slot was provided (a hook needs
+            // it) and only on the accept path (a rejected upgrade returns
+            // below without capturing).
+            if let Some(slot) = &self.captured {
+                *slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                    Some(HandshakeContext::from_request(request));
+            }
             Ok(response)
         } else {
             Err(path_not_found_response(request))
@@ -1226,10 +1576,11 @@ mod tests {
             offreader_limit: Some(DEFAULT_OFFREADER_LIMIT),
             peer_id_counter: Arc::new(AtomicU64::new(0)),
             on_connect: Arc::new(Vec::new()),
+            on_connect_ctx: Arc::new(Vec::new()),
             on_disconnect: Arc::new(Vec::new()),
             on_error: Arc::new(Vec::new()),
         });
-        handle_connection_with_config(ws_stream, config, CancellationToken::new()).await
+        handle_connection_with_config(ws_stream, config, CancellationToken::new(), None).await
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1245,7 +1596,8 @@ mod tests {
 
         let server_task = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
-            let ws_stream = accept_repe_websocket(stream, "/repe").await.unwrap();
+            let (ws_stream, _handshake) =
+                accept_repe_websocket(stream, "/repe", false).await.unwrap();
             run_default_connection(ws_stream, router).await.unwrap();
         });
 
@@ -1334,7 +1686,8 @@ mod tests {
         let proxy_task = tokio::spawn(async move {
             let upstream = AsyncClient::connect(upstream_addr).await.unwrap();
             let (stream, _) = proxy_listener.accept().await.unwrap();
-            let ws_stream = accept_repe_websocket(stream, "/repe").await.unwrap();
+            let (ws_stream, _handshake) =
+                accept_repe_websocket(stream, "/repe", false).await.unwrap();
             proxy_connection(ws_stream, upstream).await.unwrap();
         });
 
@@ -2750,5 +3103,239 @@ mod tests {
 
         shutdown_tx.send(()).unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(5), serve).await;
+    }
+
+    // ---- Friction 1: one-port co-hosting WS-vs-HTTP classifier ------
+
+    #[test]
+    fn classifier_detects_websocket_upgrade_head() {
+        let req = b"GET /repe HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\
+                    Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\n\
+                    Sec-WebSocket-Version: 13\r\n\r\n";
+        assert!(head_requests_websocket_upgrade(req));
+    }
+
+    #[test]
+    fn classifier_is_case_insensitive() {
+        let req = b"GET / HTTP/1.1\r\nupgrade: WebSocket\r\n\r\n";
+        assert!(head_requests_websocket_upgrade(req));
+    }
+
+    #[test]
+    fn classifier_rejects_plain_http() {
+        let req = b"GET /healthz HTTP/1.1\r\nHost: x\r\nAccept: */*\r\n\r\n";
+        assert!(!head_requests_websocket_upgrade(req));
+    }
+
+    #[test]
+    fn classifier_ignores_websocket_outside_the_upgrade_header() {
+        // "websocket" appears in the request target and a header value but
+        // never as an Upgrade header, so this is a plain HTTP request.
+        let req =
+            b"GET /websocket-status HTTP/1.1\r\nHost: x\r\nUser-Agent: websocket-probe/1.0\r\n\r\n";
+        assert!(!head_requests_websocket_upgrade(req));
+    }
+
+    #[test]
+    fn classifier_handles_head_without_terminator() {
+        // The first readable chunk ended mid-header, but the Upgrade line
+        // is already complete and present.
+        let req = b"GET /repe HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upg";
+        assert!(head_requests_websocket_upgrade(req));
+    }
+
+    #[test]
+    fn classifier_empty_head_is_not_upgrade() {
+        assert!(!head_requests_websocket_upgrade(b""));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_websocket_upgrade_peeks_without_consuming() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // The server classifies each accepted stream and confirms peek left
+        // the request head intact for a subsequent reader (`accept`).
+        let server = tokio::spawn(async move {
+            let mut verdicts = Vec::new();
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let is_ws = is_websocket_upgrade(&stream).await.unwrap();
+                // Peek again: the bytes must still be there (non-destructive).
+                let mut buf = [0u8; 32];
+                let n = stream.peek(&mut buf).await.unwrap();
+                verdicts.push((is_ws, buf[..n].starts_with(b"GET ")));
+            }
+            verdicts
+        });
+
+        let mut ws_like = TcpStream::connect(addr).await.unwrap();
+        ws_like
+            .write_all(b"GET /repe HTTP/1.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+            .await
+            .unwrap();
+        ws_like.flush().await.unwrap();
+
+        let mut http = TcpStream::connect(addr).await.unwrap();
+        http.write_all(b"GET /healthz HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        http.flush().await.unwrap();
+
+        let verdicts = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("classifier server hung")
+            .unwrap();
+        // Connection order is deterministic on loopback (first connect is
+        // accepted first), but assert on the set to stay robust: exactly one
+        // upgrade and one non-upgrade, both with their head still readable.
+        assert!(verdicts.iter().all(|(_, head_intact)| *head_intact));
+        let upgrades = verdicts.iter().filter(|(is_ws, _)| *is_ws).count();
+        assert_eq!(upgrades, 1, "exactly one stream should classify as WS");
+
+        drop(ws_like);
+        drop(http);
+    }
+
+    // ---- Friction 2: handshake-context connect hook + alias --------
+
+    /// Co-hosting accept loop that threads the captured [`HandshakeContext`]
+    /// so `on_peer_connect_with_handshake` hooks fire (mirrors the built-in
+    /// `serve*` loops, which also capture it).
+    async fn serve_one_with_handshake(
+        listener: TcpListener,
+        path: &str,
+        server: WebSocketServer,
+    ) -> tokio::task::JoinHandle<()> {
+        let path = path.to_string();
+        let shared = server.into_shared();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let path = path.clone();
+                let shared = shared.clone();
+                tokio::spawn(async move {
+                    if let Ok((ws, hs)) =
+                        WebSocketServer::accept_with_handshake(stream, &path).await
+                    {
+                        let _ = shared.serve_connection_with_handshake(ws, hs).await;
+                    }
+                });
+            }
+        })
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn handshake_query_param_drives_alias_for_targeted_push() {
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let peers = PeerRegistry::new();
+
+        // Capture the context fields the hook saw, to assert the handshake
+        // was threaded through with its path, query, and headers intact.
+        let captured = Arc::new(Mutex::new(None::<(String, Option<String>, Option<String>)>));
+        let captured_hook = Arc::clone(&captured);
+        let peers_hook = peers.clone();
+        let server = WebSocketServer::new(router)
+            .with_peer_registry(peers.clone())
+            .on_peer_connect_with_handshake(move |peer, hs| {
+                *captured_hook.lock().unwrap() = Some((
+                    hs.path().to_string(),
+                    hs.query().map(str::to_string),
+                    hs.header("upgrade").map(str::to_string),
+                ));
+                // The embedder's key rides in the query string: token=<id>.
+                if let Some(token) = hs.query().and_then(|q| q.strip_prefix("token=")) {
+                    peers_hook.alias(peer.peer_id(), token);
+                }
+            });
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = serve_one_with_handshake(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe?token=abc123"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+        // Round-trip so the connect hooks (registry insert, then alias) ran.
+        client.call_json("/ping", &json!({})).await.unwrap();
+
+        // The hook observed the upgrade request context.
+        let seen = captured.lock().unwrap().clone().expect("hook fired");
+        assert_eq!(seen.0, "/repe");
+        assert_eq!(seen.1.as_deref(), Some("token=abc123"));
+        assert_eq!(seen.2.as_deref(), Some("websocket"));
+
+        // Targeted push addressed by the embedder's own identity -- no
+        // parallel key -> PeerId map maintained by hand.
+        let handle = peers.get_by("abc123").expect("alias resolved to a peer");
+        handle
+            .send_notify("/nudge", NotifyBody::Json(b"{}".to_vec()))
+            .unwrap();
+
+        let pushed = tokio::time::timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("nudge did not arrive")
+            .expect("notify channel closed");
+        assert_eq!(pushed.query_str().unwrap(), "/nudge");
+
+        // Disconnect drops the peer and its alias in one step.
+        drop(client);
+        for _ in 0..50 {
+            if peers.get_by("abc123").is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            peers.get_by("abc123").is_none(),
+            "alias not cleaned up on disconnect"
+        );
+        server_task.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn plain_serve_connection_does_not_fire_handshake_hook() {
+        // A connection served through plain `serve_connection` carries no
+        // captured handshake, so `on_peer_connect_with_handshake` must not
+        // fire (while the plain `on_peer_connect` still does).
+        use std::sync::atomic::AtomicUsize;
+        let plain = Arc::new(AtomicUsize::new(0));
+        let ctx = Arc::new(AtomicUsize::new(0));
+        let plain_h = Arc::clone(&plain);
+        let ctx_h = Arc::clone(&ctx);
+
+        let router = Router::new().with_json("/ping", |_| Ok(json!({ "ok": true })));
+        let server = WebSocketServer::new(router)
+            .on_peer_connect(move |_| {
+                plain_h.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_peer_connect_with_handshake(move |_, _| {
+                ctx_h.fetch_add(1, Ordering::SeqCst);
+            });
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // serve_one uses plain accept + serve_connection (no handshake).
+        let server_task = serve_one(listener, "/repe", server).await;
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .unwrap();
+        client.call_json("/ping", &json!({})).await.unwrap();
+
+        assert_eq!(plain.load(Ordering::SeqCst), 1, "plain connect hook ran");
+        assert_eq!(
+            ctx.load(Ordering::SeqCst),
+            0,
+            "handshake hook must not fire without a captured handshake"
+        );
+
+        drop(client);
+        server_task.abort();
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,24 @@ pub struct TransportFlakyServer {
 }
 
 impl TransportFlakyServer {
+    /// A flaky TCP server: the first `failures_before_success` *request-bearing*
+    /// connections are dropped without a reply (simulating a transport-level
+    /// failure), and every request after that is answered normally.
+    ///
+    /// Two properties keep the simulation deterministic under load, where it
+    /// would otherwise flake:
+    ///
+    /// - Each connection is serviced on its own thread, so an idle probe (such
+    ///   as the connect-time TCP handshake, which carries no request) cannot
+    ///   block the accept loop while the client is retrying on a fresh
+    ///   connection. A single-threaded loop here serialized those, and under
+    ///   CPU contention the head-of-line stall blew past the client's
+    ///   per-attempt timeout.
+    /// - The attempt counter advances only once a request has actually been
+    ///   read, so the failure budget tracks real call attempts rather than raw
+    ///   TCP accepts. An idle connection that never sends a request is not
+    ///   counted, which is what made "fail the first N attempts" depend on
+    ///   exactly how the client opened its sockets.
     pub fn spawn(failures_before_success: usize) -> (Self, Arc<AtomicUsize>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
         listener
@@ -40,32 +58,47 @@ impl TransportFlakyServer {
             while !stop_thread.load(Ordering::SeqCst) {
                 match listener.accept() {
                     Ok((stream, _)) => {
-                        let current = attempts_thread.fetch_add(1, Ordering::SeqCst) + 1;
-                        let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
-                        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
-                        let req = match read_message(&mut reader) {
-                            Ok(req) => req,
-                            Err(_) => continue,
-                        };
+                        let attempts = Arc::clone(&attempts_thread);
+                        // Service each connection on its own (detached) thread
+                        // so a slow or idle peer never stalls the accept loop.
+                        thread::spawn(move || {
+                            // Only a safety net so an idle connection's thread
+                            // eventually exits; a request-bearing connection is
+                            // read in microseconds, far inside this window.
+                            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                            let mut reader =
+                                BufReader::new(stream.try_clone().expect("clone stream"));
+                            let Ok(req) = read_message(&mut reader) else {
+                                // No request arrived (idle probe or the peer
+                                // closed): not an attempt, nothing to fail.
+                                return;
+                            };
 
-                        if current <= failures_before_success {
-                            // Simulate a transport-level failure by closing without replying.
-                            continue;
-                        }
+                            // Count only once a real request has been read.
+                            let current = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                            if current <= failures_before_success {
+                                // Simulate a transport-level failure by closing
+                                // without replying.
+                                return;
+                            }
 
-                        let resp = if req.query_utf8() == "/flaky" {
-                            json_response_for(&req, &json!({"success": true, "attempt": current}))
-                        } else {
-                            error_response_for(&req, ErrorCode::MethodNotFound, "unknown route")
-                        };
+                            let resp = if req.query_utf8() == "/flaky" {
+                                json_response_for(
+                                    &req,
+                                    &json!({"success": true, "attempt": current}),
+                                )
+                            } else {
+                                error_response_for(&req, ErrorCode::MethodNotFound, "unknown route")
+                            };
 
-                        let mut writer = BufWriter::new(stream);
-                        if write_message(&mut writer, &resp).is_ok() {
-                            let _ = writer.flush();
-                        }
+                            let mut writer = BufWriter::new(stream);
+                            if write_message(&mut writer, &resp).is_ok() {
+                                let _ = writer.flush();
+                            }
+                        });
                     }
                     Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
+                        thread::sleep(Duration::from_millis(5));
                     }
                     Err(_) => break,
                 }


### PR DESCRIPTION
Two additive, non-breaking improvements for embedders building on the shipped `WebSocketServer` + `PeerRegistry` surface. Both close friction points where the escape hatch existed but left real boilerplate; neither grows repe toward a web framework or a general identity store.

The larger items are intentionally **deferred** per the crate's own "hold higher-level surfaces until a second distinct consumer exists" discipline: R2 (a built-in HTTP route table), Option A (generic `PeerRegistry<K>`), and Option C (opaque `PeerHandle` tag).

## Friction 1 — one-port co-hosting

Co-hosting a few plain-HTTP routes (a `/healthz` probe, a small JSON `GET`) beside a REPE WebSocket endpoint on one TCP port was possible but all-manual: the docs sketched the peek-then-fork but stubbed out the two hardest parts (`looks_like_websocket_upgrade` and `serve_http`).

- **`is_websocket_upgrade(&TcpStream) -> io::Result<bool>`** — a non-destructive WS-vs-HTTP classifier. It uses `TcpStream::peek`, leaving the request bytes intact for the subsequent `WebSocketServer::accept` (which replays the handshake from the start of the stream). It's a sniff — it looks for an `Upgrade: websocket` header and matches the `websocket` token *only* inside that header's value, so `GET /websocket-status` isn't misclassified — and `accept` still performs the authoritative RFC 6455 validation on the `true` branch, so a false positive fails the handshake rather than corrupting anything. The docs spell out the **misclassification asymmetry** (a false positive is caught by `accept`; a false negative — an `Upgrade` header split across TCP segments or beyond the 1 KiB peek window — routes to the HTTP handler with no recovery) and that the peek blocks until the client sends a byte, so a production embedder should wrap it in a `tokio::time::timeout` to avoid a slowloris pinning the task.
- **`examples/websocket_cohosting.rs`** — a runnable end-to-end demo that fills in both stubs: the classifier plus a minimal, dependency-free `serve_http` (`/healthz` + a JSON `GET`), driving both forks against one port. Linked from the co-hosting section of `docs/websocket.md`.

## Friction 2 — addressing peers by an embedder key

An embedder whose client identity is a UUID/token (not the server-minted `PeerId`) had to maintain a parallel `HashMap<TheirKey, PeerId>` and keep it in sync on connect/disconnect.

- **`PeerRegistry` alias index** — `PeerId` stays canonical, so `with_peer_registry` auto-insert is unchanged. Added `alias(peer_id, key)`, `get_by(&key)` (generic borrowed lookup like `HashMap::get`), `key_for(peer_id)`, and `aliases_for(peer_id)`. `key_for` / `aliases_for` map a `PeerId` from a `broadcast_notify_*` result back to the embedder's identity. A reverse index lets `remove` purge a peer's aliases without scanning, so disconnect cleanup is automatic.
- **`HandshakeContext` + `on_peer_connect_with_handshake`** — the companion hook. It exposes the upgrade request's `path()`, `query()`, and `header(name)`, so an embedder whose key rides in the handshake can derive it and `alias` the peer at connect time. It fires *after* the plain `on_peer_connect` hooks (so a `with_peer_registry` insert has already landed and the peer is present for `alias`). Context is threaded through the built-in `serve*` loops and the new `accept_with_handshake` / `serve_connection_with_handshake` / `serve_connection_with_cancel_and_handshake` co-hosting methods. Capture is **pay-for-what-you-use**: the accept path only builds a `HandshakeContext` when such a hook is registered (or `accept_with_handshake` is called). Two properties make it safe for the auth/token use case it's built for: `header(name)` is **fail-closed** — a value that isn't valid (visible ASCII) text is dropped at capture rather than lossily mangled, so a non-ASCII token reads as absent instead of a silently corrupted key — and `HandshakeContext`'s `Debug` is hand-written to redact header values and the query string, so a routine `tracing::debug!(?ctx)` can't leak the very credential the use case keys on.

## Compatibility

Strictly additive. No existing signature changes; `PeerRegistry::new()` and the existing `accept` / `serve_connection` paths are untouched.

## Tests / checks

- `cargo test --features websocket`: **212 passed, 0 failed** — registry alias unit tests, classifier unit tests + a peek-without-consuming integration test, handshake-hook integration tests (including that plain `serve_connection` does *not* fire the handshake hook), and `HandshakeContext` fail-closed-capture and credential-redacting-`Debug` unit tests.
- Hardened a flaky transport-retry test fixture (`TransportFlakyServer`): it now services each connection on its own thread and advances its attempt counter only once a request has been read, so the failure budget tracks real call attempts and a slow/idle peer can't stall the client's retries. This removes an intermittent failure under CPU contention (0 failures in 400 runs under 16× contention that previously failed ~6% of the time); asserted attempt counts are unchanged.
- Clean: `cargo fmt --check`, `cargo clippy` (default **and** `websocket`, `--all-targets`), `cargo doc --all-features` (`-D warnings`), and `cargo check --target wasm32-unknown-unknown --features websocket-wasm`.
- Both `examples/websocket_cohosting.rs` and `examples/websocket_graceful_server.rs` run end to end.
