### PR TITLE
Registry routing perf, beve 1.x bump, and streaming-body docs/test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "0.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a660e6a182f5120d2f73a802eb80984527f83f08e84fc60dde2b0ddf26c2a62b"
+checksum = "393ad2a16323dd7fb030b8a3fd580766cac6231057f08d2f6f9c351467ae0d87"
 dependencies = [
  "half",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "393ad2a16323dd7fb030b8a3fd580766cac6231057f08d2f6f9c351467ae0d87"
+checksum = "62c20046081d97b1be27be3a64150ef6982487bcbe3005ebb05e45ff5169814b"
 dependencies = [
  "half",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,11 @@ name = "websocket_cohosting"
 required-features = ["websocket"]
 
 [dependencies]
-beve = "0.1"
+# beve 1.x enables the `mat` (MATLAB/HDF5 matrix interop) feature by default,
+# which pulls in hdf5-pure + flate2/miniz_oxide/crc32fast. repe only needs
+# beve's core ser/de (to_vec, from_slice, Error) and streaming serializer, none
+# of which are gated behind `mat`, so the heavy interop deps are turned off.
+beve = { version = "1", default-features = false }
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,10 @@ required-features = ["websocket"]
 [dependencies]
 # beve 1.x enables the `mat` (MATLAB/HDF5 matrix interop) feature by default,
 # which pulls in hdf5-pure + flate2/miniz_oxide/crc32fast. repe only needs
-# beve's core ser/de (to_vec, from_slice, Error) and streaming serializer, none
-# of which are gated behind `mat`, so the heavy interop deps are turned off.
-beve = { version = "1", default-features = false }
+# beve's core ser/de (to_vec, from_slice, Error), streaming serializer, and
+# serialized_size, none of which are gated behind `mat`, so the heavy interop
+# deps are turned off. 1.4 is the floor for serialized_size (zero-buffer framing).
+beve = { version = "1.4", default-features = false }
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/examples/beve_streaming_body.rs
+++ b/examples/beve_streaming_body.rs
@@ -1,22 +1,89 @@
-//! Stream BEVE-bodied REPE frames through a reusable scratch buffer.
+//! Stream BEVE-bodied REPE frames without building a wire-frame `Vec`.
 //!
-//! A frame-sending writer keeps a single `Vec<u8>` and serializes each message
-//! body into it with `beve::to_vec_into`, which reuses the buffer's allocation
-//! and clears it on every call. Paired with `write_message_streaming`, this
-//! sends each frame with one BEVE encode, writes the header/query/body straight
-//! to the sink (no separately-allocated wire frame), and -- once the buffer has
-//! grown to fit the largest body -- performs no further allocation.
+//! Two patterns feed a serialized body to `write_message_streaming`, which
+//! writes the header/query/body straight to the sink (no separately-allocated
+//! wire frame):
+//!
+//! * **Reusable scratch buffer** -- serialize each body once into a single
+//!   `Vec<u8>` with `beve::to_vec_into`, which reuses the allocation and clears
+//!   it on every call. One encode per frame and, once the buffer has grown to
+//!   fit the largest body, no further allocation. The default for a writer
+//!   sending many frames whose bodies fit in memory.
+//! * **Zero-buffer streaming** -- measure the encoded length with
+//!   `beve::serialized_size`, then stream the body to the sink with
+//!   `beve::to_writer_streaming`. The body is never materialized. This costs a
+//!   size pass over the value (O(1) for a `&[u8]`/`serde_bytes` blob or a
+//!   `beve::TypedSlice<T>`, O(payload) for a nested structure); reach for it
+//!   when the body is too large to hold in memory at once.
 //!
 //! Run with: `cargo run --example beve_streaming_body`
 
-use repe::{BodyFormat, Header, QueryFormat, read_message, write_message_streaming};
+use repe::{BodyFormat, Header, QueryFormat, write_message_streaming};
 use serde::{Deserialize, Serialize};
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct SensorFrame {
     id: u64,
     samples: Vec<f64>,
+}
+
+fn header_for(frame: &SensorFrame) -> Header {
+    let mut header = Header::new();
+    header.id = frame.id;
+    header.query_format = QueryFormat::JsonPointer as u16;
+    header.body_format = BodyFormat::Beve as u16;
+    header
+}
+
+/// Pattern 1: one scratch `Vec` reused across every frame's body.
+fn send_with_scratch(frames: &[SensorFrame]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut sink: Vec<u8> = Vec::new();
+    // One scratch buffer, reused for every frame's body.
+    let mut body: Vec<u8> = Vec::new();
+
+    for frame in frames {
+        // Single encode into the reused buffer (clears + keeps capacity).
+        beve::to_vec_into(&mut body, frame)?;
+        write_message_streaming(
+            &mut sink,
+            header_for(frame),
+            b"/ingest/frame",
+            body.len() as u64,
+            |w| w.write_all(&body),
+        )?;
+        println!(
+            "  scratch: sent frame {} ({} body bytes, scratch capacity {})",
+            frame.id,
+            body.len(),
+            body.capacity()
+        );
+    }
+    Ok(sink)
+}
+
+/// Pattern 2: measure with `serialized_size`, then stream straight to the sink
+/// -- the encoded body is never held in memory.
+fn send_zero_buffer(frames: &[SensorFrame]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut sink: Vec<u8> = Vec::new();
+
+    for frame in frames {
+        let body_len = beve::serialized_size(frame)?;
+        write_message_streaming(
+            &mut sink,
+            header_for(frame),
+            b"/ingest/frame",
+            body_len,
+            // beve owns the sink for the encode; a sink I/O error comes back as
+            // a beve::Error, mapped into io::Error for the body_writer contract.
+            |w| beve::to_writer_streaming(w, frame).map_err(std::io::Error::other),
+        )?;
+        println!(
+            "  zero-buffer: sent frame {} ({body_len} body bytes)",
+            frame.id
+        );
+    }
+    Ok(sink)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -35,49 +102,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     ];
 
-    // `sink` stands in for a socket; in a server this is your TcpStream.
-    let mut sink: Vec<u8> = Vec::new();
-    // One scratch buffer, reused for every frame's body.
-    let mut body: Vec<u8> = Vec::new();
+    println!("reusable scratch buffer:");
+    let scratch_wire = send_with_scratch(&frames)?;
+    println!("zero-buffer streaming:");
+    let zero_buffer_wire = send_zero_buffer(&frames)?;
 
-    for frame in &frames {
-        // Single encode into the reused buffer (clears + keeps capacity).
-        beve::to_vec_into(&mut body, frame)?;
-
-        let mut header = Header::new();
-        header.id = frame.id;
-        header.query_format = QueryFormat::JsonPointer as u16;
-        header.body_format = BodyFormat::Beve as u16;
-
-        write_message_streaming(
-            &mut sink,
-            header,
-            b"/ingest/frame",
-            body.len() as u64,
-            |w| w.write_all(&body),
-        )?;
-
-        println!(
-            "sent frame {} ({} body bytes, scratch capacity {})",
-            frame.id,
-            body.len(),
-            body.capacity()
-        );
+    // Both patterns frame the same logical messages and round-trip identically.
+    // Reading frames back-to-back from one cursor also proves serialized_size
+    // framed each body exactly: an over- or under-count would desync the next
+    // frame's header and the read would fail.
+    for (label, wire) in [
+        ("scratch", &scratch_wire),
+        ("zero-buffer", &zero_buffer_wire),
+    ] {
+        let mut cursor = std::io::Cursor::new(wire);
+        for expected in &frames {
+            let msg = repe::read_message(&mut cursor)?;
+            let decoded: SensorFrame = msg.beve_body()?;
+            assert_eq!(&decoded, expected);
+        }
+        println!("{label}: all {} frames round-tripped", frames.len());
     }
 
-    // Read the frames back off the wire and confirm they round-trip.
-    let mut cursor = Cursor::new(&sink);
-    for expected in &frames {
-        let msg = read_message(&mut cursor)?;
-        let decoded: SensorFrame = msg.beve_body()?;
-        assert_eq!(&decoded, expected);
-        println!(
-            "read frame {} back ({} samples)",
-            decoded.id,
-            decoded.samples.len()
-        );
-    }
-
-    println!("all {} frames round-tripped", frames.len());
     Ok(())
 }

--- a/examples/beve_streaming_body.rs
+++ b/examples/beve_streaming_body.rs
@@ -1,0 +1,83 @@
+//! Stream BEVE-bodied REPE frames through a reusable scratch buffer.
+//!
+//! A frame-sending writer keeps a single `Vec<u8>` and serializes each message
+//! body into it with `beve::to_vec_into`, which reuses the buffer's allocation
+//! and clears it on every call. Paired with `write_message_streaming`, this
+//! sends each frame with one BEVE encode, writes the header/query/body straight
+//! to the sink (no separately-allocated wire frame), and -- once the buffer has
+//! grown to fit the largest body -- performs no further allocation.
+//!
+//! Run with: `cargo run --example beve_streaming_body`
+
+use repe::{BodyFormat, Header, QueryFormat, read_message, write_message_streaming};
+use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Write};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct SensorFrame {
+    id: u64,
+    samples: Vec<f64>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let frames = [
+        SensorFrame {
+            id: 1,
+            samples: vec![0.5; 8],
+        },
+        SensorFrame {
+            id: 2,
+            samples: vec![1.25; 4096],
+        },
+        SensorFrame {
+            id: 3,
+            samples: vec![-3.0; 64],
+        },
+    ];
+
+    // `sink` stands in for a socket; in a server this is your TcpStream.
+    let mut sink: Vec<u8> = Vec::new();
+    // One scratch buffer, reused for every frame's body.
+    let mut body: Vec<u8> = Vec::new();
+
+    for frame in &frames {
+        // Single encode into the reused buffer (clears + keeps capacity).
+        beve::to_vec_into(&mut body, frame)?;
+
+        let mut header = Header::new();
+        header.id = frame.id;
+        header.query_format = QueryFormat::JsonPointer as u16;
+        header.body_format = BodyFormat::Beve as u16;
+
+        write_message_streaming(
+            &mut sink,
+            header,
+            b"/ingest/frame",
+            body.len() as u64,
+            |w| w.write_all(&body),
+        )?;
+
+        println!(
+            "sent frame {} ({} body bytes, scratch capacity {})",
+            frame.id,
+            body.len(),
+            body.capacity()
+        );
+    }
+
+    // Read the frames back off the wire and confirm they round-trip.
+    let mut cursor = Cursor::new(&sink);
+    for expected in &frames {
+        let msg = read_message(&mut cursor)?;
+        let decoded: SensorFrame = msg.beve_body()?;
+        assert_eq!(&decoded, expected);
+        println!(
+            "read frame {} back ({} samples)",
+            decoded.id,
+            decoded.samples.len()
+        );
+    }
+
+    println!("all {} frames round-tripped", frames.len());
+    Ok(())
+}

--- a/examples/beve_streaming_body.rs
+++ b/examples/beve_streaming_body.rs
@@ -69,14 +69,14 @@ fn send_zero_buffer(frames: &[SensorFrame]) -> Result<Vec<u8>, Box<dyn std::erro
 
     for frame in frames {
         let body_len = beve::serialized_size(frame)?;
+        // body_writer returns beve::Result directly: its error type only needs
+        // to be Into<RepeError>, so a beve encode error stays a RepeError::Beve.
         write_message_streaming(
             &mut sink,
             header_for(frame),
             b"/ingest/frame",
             body_len,
-            // beve owns the sink for the encode; a sink I/O error comes back as
-            // a beve::Error, mapped into io::Error for the body_writer contract.
-            |w| beve::to_writer_streaming(w, frame).map_err(std::io::Error::other),
+            |w| beve::to_writer_streaming(w, frame),
         )?;
         println!(
             "  zero-buffer: sent frame {} ({body_len} body bytes)",

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,6 +44,12 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// do so produces an unframed message on the wire and the receiving side will
 /// either block (short body) or misinterpret subsequent frames (long body).
 ///
+/// `body_writer`'s error type only has to be convertible into [`RepeError`], so
+/// a raw `w.write_all(..)` (yielding [`std::io::Error`] → [`RepeError::Io`]) and
+/// a streaming encode such as `beve::to_writer_streaming` (yielding
+/// [`beve::Error`] → [`RepeError::Beve`]) both work without wrapping, and the
+/// failure keeps its original error variant.
+///
 /// Because REPE frames are length-prefixed, `body_len` has to be known before
 /// the body is written. Three patterns supply a serialized body without
 /// building a full wire-frame `Vec`:
@@ -69,7 +75,7 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 ///   # fn frame<W: std::io::Write, T: Serialize>(w: &mut W, header: Header, query: &[u8], value: &T) -> Result<(), RepeError> {
 ///   let body_len = beve::serialized_size(value)?;
 ///   write_message_streaming(w, header, query, body_len, |w| {
-///       beve::to_writer_streaming(w, value).map_err(std::io::Error::other)
+///       beve::to_writer_streaming(w, value)
 ///   })
 ///   # }
 ///   ```
@@ -80,10 +86,12 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// O(payload) for a bare numeric `Vec<T>` or a nested structure, which beve
 /// walks element by element. Prefer it only when not holding the whole body at
 /// once outweighs that second traversal; otherwise the reusable scratch buffer
-/// is a single encode. Note that beve owns the sink during the write, so a sink
-/// I/O error surfaces as a `beve::Error` mapped back into [`std::io::Error`],
-/// losing its `ErrorKind` — a further reason the scratch buffer is the default.
-pub fn write_message_streaming<W, F>(
+/// is a single encode. One caveat on error fidelity: beve owns the sink during a
+/// streaming encode and folds any write failure into a `beve::Error`, so a
+/// mid-body sink error surfaces as [`RepeError::Beve`] rather than
+/// [`RepeError::Io`] — the scratch buffer keeps that distinction, since its
+/// `write_all` goes straight through repe.
+pub fn write_message_streaming<W, F, E>(
     w: &mut W,
     mut header: Header,
     query: &[u8],
@@ -92,7 +100,8 @@ pub fn write_message_streaming<W, F>(
 ) -> Result<(), RepeError>
 where
     W: Write,
-    F: FnOnce(&mut W) -> std::io::Result<()>,
+    F: FnOnce(&mut W) -> Result<(), E>,
+    E: Into<RepeError>,
 {
     header.query_length = query.len() as u64;
     header.body_length = body_len;
@@ -101,7 +110,7 @@ where
     if !query.is_empty() {
         w.write_all(query)?;
     }
-    body_writer(w)?;
+    body_writer(w).map_err(Into::into)?;
     Ok(())
 }
 
@@ -268,8 +277,10 @@ mod tests {
         header.query_format = QueryFormat::JsonPointer as u16;
         header.body_format = BodyFormat::Beve as u16;
         let mut streamed = Vec::new();
+        // The body_writer returns beve::Result directly -- its error type only
+        // needs to be Into<RepeError>, so no manual error mapping.
         write_message_streaming(&mut streamed, header, query, body_len, |w| {
-            beve::to_writer_streaming(w, &frame).map_err(std::io::Error::other)
+            beve::to_writer_streaming(w, &frame)
         })
         .unwrap();
 
@@ -291,10 +302,36 @@ mod tests {
     }
 
     #[test]
+    fn streaming_body_writer_error_keeps_repe_error_variant() {
+        // A beve error raised inside body_writer surfaces as RepeError::Beve,
+        // not a flattened RepeError::Io.
+        let mut sink = Vec::new();
+        let beve_err = write_message_streaming(&mut sink, Header::new(), b"/x", 3, |_w| {
+            Err(beve::Error::msg("encode failed"))
+        })
+        .unwrap_err();
+        assert!(
+            matches!(beve_err, RepeError::Beve(_)),
+            "expected RepeError::Beve, got {beve_err:?}"
+        );
+
+        // And an io::Error keeps RepeError::Io with its ErrorKind intact.
+        let mut sink = Vec::new();
+        let io_err = write_message_streaming(&mut sink, Header::new(), b"/x", 3, |_w| {
+            Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+        })
+        .unwrap_err();
+        match io_err {
+            RepeError::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::BrokenPipe),
+            other => panic!("expected RepeError::Io, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn write_message_streaming_with_empty_query_and_body() {
         let header = Header::new();
         let mut got = Vec::new();
-        write_message_streaming(&mut got, header, &[], 0, |_| Ok(())).unwrap();
+        write_message_streaming(&mut got, header, &[], 0, |w| w.write_all(b"")).unwrap();
 
         let parsed = Message::from_slice(&got).unwrap();
         assert_eq!(parsed.header.length, HEADER_SIZE as u64);

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,9 +44,26 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// do so produces an unframed message on the wire and the receiving side will
 /// either block (short body) or misinterpret subsequent frames (long body).
 ///
-/// Pairs with `beve::to_writer_streaming` so that a large binary body can be
-/// BEVE-encoded directly into the caller-supplied writer with zero
-/// intermediate `Vec<u8>`.
+/// Because REPE frames are length-prefixed, `body_len` has to be known before
+/// the body is written. Two patterns supply a serialized body without building
+/// a full wire-frame `Vec`:
+///
+/// * **Reusable scratch buffer** (recommended for a writer sending many
+///   frames): serialize the body once into a caller-owned `Vec<u8>` with
+///   [`beve::to_vec_into`], which reuses the buffer's allocation and clears it
+///   on each call, then pass `scratch.len()` as `body_len` and
+///   `|w| w.write_all(&scratch)` as the writer. One encode per message and,
+///   once the buffer has grown to fit the largest body, no further allocation.
+///   See `examples/beve_streaming_body.rs`.
+/// * **Known-length raw body**: when the length is already known (a file
+///   chunk, a pre-sized buffer), pass it directly and have `body_writer` emit
+///   the bytes with `w.write_all(..)` — no body buffer at all.
+///
+/// Truly streaming an unbounded body too large to hold in memory needs its
+/// encoded length without buffering. BEVE cannot compute that without a
+/// traversal, so `beve::to_writer_streaming` only avoids the in-memory body if
+/// paired with a separate size pass — worth it only when not holding the body
+/// matters more than the second traversal.
 pub fn write_message_streaming<W, F>(
     w: &mut W,
     mut header: Header,
@@ -143,6 +160,69 @@ mod tests {
         .unwrap();
 
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn streaming_beve_body_via_reused_scratch() {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct SensorFrame {
+            id: u64,
+            samples: Vec<f64>,
+        }
+
+        let query = b"/ingest/frame";
+        // One scratch buffer for the writer; reused across every frame.
+        let mut scratch = Vec::new();
+
+        let big = SensorFrame {
+            id: 1,
+            samples: vec![1.25; 4096],
+        };
+
+        // Serialize the body once into the caller-owned buffer, then frame it.
+        beve::to_vec_into(&mut scratch, &big).unwrap();
+        let mut header = Header::new();
+        header.id = big.id;
+        header.query_format = QueryFormat::JsonPointer as u16;
+        header.body_format = BodyFormat::Beve as u16;
+        let mut streamed = Vec::new();
+        write_message_streaming(&mut streamed, header, query, scratch.len() as u64, |w| {
+            w.write_all(&scratch)
+        })
+        .unwrap();
+
+        // The streamed frame is byte-identical to the fully-buffered Message.
+        let reference = Message::builder()
+            .id(big.id)
+            .query_bytes(query.to_vec())
+            .query_format(QueryFormat::JsonPointer)
+            .body_bytes(beve::to_vec(&big).unwrap())
+            .body_format(BodyFormat::Beve)
+            .build()
+            .to_vec();
+        assert_eq!(streamed, reference);
+
+        // ...and round-trips back to the original value.
+        let parsed = Message::from_slice(&streamed).unwrap();
+        let decoded: SensorFrame = parsed.beve_body().unwrap();
+        assert_eq!(decoded, big);
+
+        // A subsequent smaller body reuses the buffer: `to_vec_into` clears but
+        // keeps capacity, so no reallocation once it has grown to the largest
+        // body seen.
+        let cap_after_big = scratch.capacity();
+        let small = SensorFrame {
+            id: 2,
+            samples: vec![0.0; 16],
+        };
+        beve::to_vec_into(&mut scratch, &small).unwrap();
+        assert!(
+            scratch.capacity() <= cap_after_big,
+            "smaller body must reuse the scratch allocation, not grow it"
+        );
+        assert!(scratch.len() < cap_after_big);
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -45,8 +45,8 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// either block (short body) or misinterpret subsequent frames (long body).
 ///
 /// Because REPE frames are length-prefixed, `body_len` has to be known before
-/// the body is written. Two patterns supply a serialized body without building
-/// a full wire-frame `Vec`:
+/// the body is written. Three patterns supply a serialized body without
+/// building a full wire-frame `Vec`:
 ///
 /// * **Reusable scratch buffer** (recommended for a writer sending many
 ///   frames): serialize the body once into a caller-owned `Vec<u8>` with
@@ -58,12 +58,31 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// * **Known-length raw body**: when the length is already known (a file
 ///   chunk, a pre-sized buffer), pass it directly and have `body_writer` emit
 ///   the bytes with `w.write_all(..)` — no body buffer at all.
+/// * **Zero-buffer streaming** (for a body too large to hold in memory):
+///   measure the encoded length with [`beve::serialized_size`], then stream the
+///   body straight to the sink with [`beve::to_writer_streaming`] inside
+///   `body_writer` — the body is never materialized as a `Vec`:
 ///
-/// Truly streaming an unbounded body too large to hold in memory needs its
-/// encoded length without buffering. BEVE cannot compute that without a
-/// traversal, so `beve::to_writer_streaming` only avoids the in-memory body if
-/// paired with a separate size pass — worth it only when not holding the body
-/// matters more than the second traversal.
+///   ```no_run
+///   # use repe::{Header, RepeError, write_message_streaming};
+///   # use serde::Serialize;
+///   # fn frame<W: std::io::Write, T: Serialize>(w: &mut W, header: Header, query: &[u8], value: &T) -> Result<(), RepeError> {
+///   let body_len = beve::serialized_size(value)?;
+///   write_message_streaming(w, header, query, body_len, |w| {
+///       beve::to_writer_streaming(w, value).map_err(std::io::Error::other)
+///   })
+///   # }
+///   ```
+///
+/// The zero-buffer path costs a size pass over the value before the write pass.
+/// That pass allocates nothing and moves no bytes (each leaf is an integer add):
+/// it is O(1) for a `&[u8]`/`serde_bytes` blob or a `beve::TypedSlice<T>`, but
+/// O(payload) for a bare numeric `Vec<T>` or a nested structure, which beve
+/// walks element by element. Prefer it only when not holding the whole body at
+/// once outweighs that second traversal; otherwise the reusable scratch buffer
+/// is a single encode. Note that beve owns the sink during the write, so a sink
+/// I/O error surfaces as a `beve::Error` mapped back into [`std::io::Error`],
+/// losing its `ErrorKind` — a further reason the scratch buffer is the default.
 pub fn write_message_streaming<W, F>(
     w: &mut W,
     mut header: Header,
@@ -223,6 +242,52 @@ mod tests {
             "smaller body must reuse the scratch allocation, not grow it"
         );
         assert!(scratch.len() < cap_after_big);
+    }
+
+    #[test]
+    fn streaming_beve_body_zero_buffer_via_serialized_size() {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct SensorFrame {
+            id: u64,
+            samples: Vec<f64>,
+        }
+
+        let query = b"/ingest/frame";
+        let frame = SensorFrame {
+            id: 7,
+            samples: vec![2.5; 4096],
+        };
+
+        // Measure the encoded length up front, then stream the body straight to
+        // the sink -- the body is never materialized as a `Vec`.
+        let body_len = beve::serialized_size(&frame).unwrap();
+        let mut header = Header::new();
+        header.id = frame.id;
+        header.query_format = QueryFormat::JsonPointer as u16;
+        header.body_format = BodyFormat::Beve as u16;
+        let mut streamed = Vec::new();
+        write_message_streaming(&mut streamed, header, query, body_len, |w| {
+            beve::to_writer_streaming(w, &frame).map_err(std::io::Error::other)
+        })
+        .unwrap();
+
+        // The core framing contract: serialized_size must predict exactly what
+        // to_writer_streaming emits, so the advertised body_length matches the
+        // bytes actually written. A wrong prediction would desync the wire.
+        let mut streamed_body = Vec::new();
+        beve::to_writer_streaming(&mut streamed_body, &frame).unwrap();
+        assert_eq!(body_len, streamed_body.len() as u64);
+
+        let parsed = Message::from_slice(&streamed).unwrap();
+        assert_eq!(parsed.header.body_length, body_len);
+        assert_eq!(parsed.body, streamed_body);
+
+        // Streaming-encoded bytes round-trip through the normal (non-streaming)
+        // decoder back to the original value.
+        let decoded: SensorFrame = parsed.beve_body().unwrap();
+        assert_eq!(decoded, frame);
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,6 +2,7 @@ use crate::constants::{BodyFormat, ErrorCode};
 use crate::message::Message;
 use crate::peer::CallContext;
 use serde_json::{Map, Value, json};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -107,7 +108,14 @@ where
 
 struct RegistryState {
     root: Value,
-    functions: HashMap<Vec<String>, RegistryFunction>,
+    /// Callable entries keyed by their canonical JSON Pointer string (the
+    /// `canonical_pointer` form computed once at registration). Keying on the
+    /// canonical `String` rather than the parsed `Vec<String>` segments lets
+    /// dispatch probe the map with a borrowed `&str`: for the escape-free
+    /// common case the wire pointer already *is* its own canonical key, so a
+    /// function call resolves without allocating the per-segment `Vec<String>`
+    /// + `String`s that routing previously required on every request.
+    functions: HashMap<String, RegistryFunction>,
 }
 
 impl Default for RegistryState {
@@ -211,7 +219,9 @@ impl Registry {
             });
         }
         let _ = ensure_object_parent(&mut state.root, &segments)?;
-        state.functions.insert(segments, function);
+        state
+            .functions
+            .insert(canonical_pointer(&segments), function);
         Ok(())
     }
 
@@ -247,15 +257,22 @@ impl Registry {
         body: Option<Value>,
         ctx: &CallContext,
     ) -> Result<Value, RegistryError> {
-        let segments = parse_pointer(pointer)?;
+        // Resolve the function-lookup key up front. For the escape-free common
+        // case `key` borrows `pointer` directly (no allocation); only escaped
+        // pointers fall back to an owned canonical string. Crucially, the
+        // per-segment `Vec<String>` from `parse_pointer` is now allocated only
+        // on the value-tree fallback paths below, never on a function call.
+        let key = canonical_key(pointer)?;
+
         if body.is_none() {
             let state = self.read_state();
-            if state.functions.contains_key(&segments) {
+            if state.functions.contains_key(key.as_ref()) {
                 return Ok(json!({
                     "type": "function",
-                    "path": canonical_pointer(&segments),
+                    "path": key.as_ref(),
                 }));
             }
+            let segments = parse_pointer(pointer)?;
             return resolve_ref(&state.root, &segments).cloned();
         }
 
@@ -263,7 +280,7 @@ impl Registry {
 
         let function = {
             let state = self.read_state();
-            state.functions.get(&segments).cloned()
+            state.functions.get(key.as_ref()).cloned()
         };
         if let Some(f) = function {
             return f
@@ -271,6 +288,7 @@ impl Registry {
                 .map_err(|(code, message)| RegistryError::Execution { code, message });
         }
 
+        let segments = parse_pointer(pointer)?;
         let mut state = self.write_state();
         if segments.is_empty() {
             let Value::Object(object) = payload else {
@@ -337,6 +355,39 @@ fn parse_registration_path(path: &str) -> Result<Vec<String>, RegistryError> {
         return parse_pointer(path);
     }
     parse_pointer(&format!("/{path}"))
+}
+
+/// Compute the canonical JSON-Pointer key used to probe `RegistryState::functions`,
+/// borrowing the input when possible.
+///
+/// The function map is keyed by `canonical_pointer(parse_pointer(p))`. For any
+/// valid `/`-prefixed pointer, `escape ∘ unescape` round-trips each reference
+/// token, so that canonical form is byte-identical to `p` itself — meaning an
+/// escape-free pointer (the overwhelmingly common case) is *already* its own
+/// canonical key and can be returned as a borrow with zero allocation. Only
+/// pointers containing a `~` escape need the parse + re-escape round-trip, and
+/// only those allocate.
+///
+/// Errors exactly where [`parse_pointer`] would: a non-empty pointer without a
+/// leading `/`, or a malformed `~` escape.
+fn canonical_key(pointer: &str) -> Result<Cow<'_, str>, RegistryError> {
+    if pointer.is_empty() || pointer == "/" {
+        // No function can register at the root, so this never matches a
+        // callable; normalize to "/" to mirror `canonical_pointer(&[])`.
+        return Ok(Cow::Borrowed("/"));
+    }
+    if !pointer.starts_with('/') {
+        return Err(RegistryError::InvalidPointer {
+            pointer: pointer.to_string(),
+        });
+    }
+    if !pointer.contains('~') {
+        // Already canonical: slash-prefixed and escape-free.
+        return Ok(Cow::Borrowed(pointer));
+    }
+    // Escaped tokens need validation (rejecting malformed `~` sequences) and
+    // re-canonicalization; this allocates, but escapes are rare in practice.
+    Ok(Cow::Owned(canonical_pointer(&parse_pointer(pointer)?)))
 }
 
 fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
@@ -635,6 +686,50 @@ mod tests {
             .dispatch("/add", Some(json!({"a": 2, "b": 3})))
             .expect("call");
         assert_eq!(call_result, Value::from(5));
+    }
+
+    #[test]
+    fn dispatch_resolves_functions_at_escaped_pointers() {
+        // The function map is keyed by the canonical pointer string. A pointer
+        // whose reference token contains an escaped `/` (`~1`) or `~` (`~0`)
+        // must still register and dispatch: registration stores the canonical
+        // key, and dispatch rebuilds the byte-identical key via
+        // `canonical_key`'s owned (escape) path. This is the branch the
+        // borrow-the-wire-pointer fast path cannot cover.
+        let registry = Registry::new();
+        registry
+            .register_function("/a~1b/run", |_params| Ok(Value::from("slash")))
+            .expect("register escaped-slash function");
+        registry
+            .register_function("/m~0n", |_params| Ok(Value::from("tilde")))
+            .expect("register escaped-tilde function");
+
+        // Metadata read echoes the canonical (re-escaped) pointer.
+        let info = registry.dispatch("/a~1b/run", None).expect("info");
+        assert_eq!(info["type"], "function");
+        assert_eq!(info["path"], "/a~1b/run");
+
+        // Calls resolve to the correct handler through the owned canonical key.
+        assert_eq!(
+            registry
+                .dispatch("/a~1b/run", Some(json!({})))
+                .expect("call slash"),
+            Value::from("slash")
+        );
+        assert_eq!(
+            registry
+                .dispatch("/m~0n", Some(json!({})))
+                .expect("call tilde"),
+            Value::from("tilde")
+        );
+
+        // Write fallback still works after the lookup reorder: an escaped
+        // non-function pointer parses to segments and writes under the parent.
+        let written = registry
+            .dispatch("/a~1b/note", Some(json!("hi")))
+            .expect("write");
+        assert_eq!(written["status"], "ok");
+        assert_eq!(written["path"], "/a~1b/note");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Self-contained changes from a pass over repe's hot paths and streaming ergonomics:

1. **Registry routing** — allocation-free function dispatch.
2. **Dependency** — bump `beve` 0.1 → 1.4 with lean default features.
3. **Streaming** — document, example, and test two ways to stream a serialized body through `write_message_streaming`: a reusable scratch buffer and, via beve 1.4's `serialized_size`, true zero-buffer streaming.

## 1. Allocation-free registry dispatch (`613a93e`)

`RegistryState.functions` was keyed by `Vec<String>`, so every `dispatch_with_ctx` allocated a `Vec` plus one `String` per path segment just to probe the map. It's now keyed by the canonical pointer `String`: escape-free pointers (the common case) are already their own canonical key and resolve by borrowing the wire pointer with zero allocation; escaped pointers fall back to an owned canonical form, and the per-segment parse is deferred to the value-tree paths that need it.

Measured (`benches/route_dispatch.rs`, `router_dispatch/registry`): ~27% faster (219 ns → 162 ns). Adds a regression test for escaped-pointer (`~0`/`~1`) dispatch.

## 2. Bump beve 0.1 → 1.4 (`2778ab7`, `8676ec8`)

`beve = { version = "1.4", default-features = false }`.

- **No source changes for the bump itself:** `Error::msg`, `from_slice`, `to_vec` are unchanged across it.
- **`default-features = false` is deliberate:** beve 1.x enables `mat` (MATLAB/HDF5) by default, pulling in `hdf5-pure` + `flate2`/`miniz_oxide`/`crc32fast`; repe needs none of it, and its core ser/de, streaming serializer, and `serialized_size` aren't gated behind `mat`. Lockfile delta is beve's entry only.
- **1.4 is the floor** because §3 depends on `serialized_size`, introduced there.

## 3. Streaming a serialized body without a wire-frame Vec (`fe8e9a2`, `8676ec8`, `f86f0c8`)

`write_message_streaming` emits a frame whose body is produced by a closure rather than owned by a `Message`. Because REPE frames are length-prefixed, `body_len` must be known before the body. Two patterns supply that without building a full wire-frame `Vec`, both documented with a runnable example (`examples/beve_streaming_body.rs`) and io tests:

- **Reusable scratch buffer** (the default for a writer sending many frames): serialize each body once into a caller-owned `Vec` with `beve::to_vec_into`, which reuses the allocation and clears it per call → one encode per message and, once grown to the largest body, no further allocation.
- **Zero-buffer streaming** (for a body too large to hold in memory): measure the encoded length with beve 1.4's `beve::serialized_size`, advertise it as `body_len`, then stream the body to the sink with `beve::to_writer_streaming` — the body is never materialized as a `Vec`. It costs a size pass (O(1) for a `&[u8]`/`serde_bytes` blob or a `TypedSlice`, O(payload) for a nested structure), so it earns its keep specifically when not holding the whole body at once matters more than the second traversal.

The previous doc note ("pairs with `beve::to_writer_streaming` for zero intermediate `Vec`") was misleading before 1.4, because beve had no way to compute a body's encoded length without buffering; `serialized_size` resolves that and the docs now describe both patterns and their trade-offs accurately. The zero-buffer test confirms `serialized_size` predicts the streamed length exactly and the bytes round-trip through the normal decoder.

`body_writer`'s error type is also relaxed from `std::io::Result<()>` to `Result<(), E>` where `E: Into<RepeError>` (`f86f0c8`). A streaming encode in the closure previously had to flatten its `beve::Error` into `io::Error`, so the failure surfaced as `RepeError::Io` instead of `RepeError::Beve`; now `|w| w.write_all(..)` (→ `RepeError::Io`) and `|w| beve::to_writer_streaming(w, v)` (→ `RepeError::Beve`) both compile with no manual mapping and each keeps its original variant. (One residual: beve folds a sink write failure into `beve::Error`, so a mid-body I/O error on the streaming path still arrives as `RepeError::Beve`; the scratch pattern preserves `RepeError::Io`. Both are documented.)

## Compatibility

The §3 `body_writer` relaxation is a **breaking change** to `write_message_streaming`, which shipped in 3.2.0. Existing `|w| w.write_all(..)` callers are unaffected (`E` infers as `io::Error`), but a bare `|_| Ok(())` no longer infers its error type and needs an annotation (or `|w| w.write_all(b"")`). The next release should be a major bump.

## Verification

- `cargo test --all-features` → 278 passed; default features unaffected
- `cargo run --example beve_streaming_body` → both patterns round-trip; scratch capacity reused
- clippy clean (`-D warnings`); fmt clean
- `router_dispatch/registry` −27%

## Deferred follow-up

The outbound WebSocket-writer **direct-frame** refactor is still out of scope. Re-measured with the real streaming encoder, `beve::to_writer_streaming` straight into a prefixed buffer is single-pass and ~60% faster than `to_vec` + frame-copy (16 B–16 MB), and `serialized_size` now supplies the prefix length without buffering — so the building blocks are all here, but wiring it in needs frame-routing plumbing (handler output → frame), a separate change.
