### PR TITLE
Document & test the reusable-scratch streaming body pattern

### DIFF
--- a/examples/beve_streaming_body.rs
+++ b/examples/beve_streaming_body.rs
@@ -1,0 +1,83 @@
+//! Stream BEVE-bodied REPE frames through a reusable scratch buffer.
+//!
+//! A frame-sending writer keeps a single `Vec<u8>` and serializes each message
+//! body into it with `beve::to_vec_into`, which reuses the buffer's allocation
+//! and clears it on every call. Paired with `write_message_streaming`, this
+//! sends each frame with one BEVE encode, writes the header/query/body straight
+//! to the sink (no separately-allocated wire frame), and -- once the buffer has
+//! grown to fit the largest body -- performs no further allocation.
+//!
+//! Run with: `cargo run --example beve_streaming_body`
+
+use repe::{BodyFormat, Header, QueryFormat, read_message, write_message_streaming};
+use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Write};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct SensorFrame {
+    id: u64,
+    samples: Vec<f64>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let frames = [
+        SensorFrame {
+            id: 1,
+            samples: vec![0.5; 8],
+        },
+        SensorFrame {
+            id: 2,
+            samples: vec![1.25; 4096],
+        },
+        SensorFrame {
+            id: 3,
+            samples: vec![-3.0; 64],
+        },
+    ];
+
+    // `sink` stands in for a socket; in a server this is your TcpStream.
+    let mut sink: Vec<u8> = Vec::new();
+    // One scratch buffer, reused for every frame's body.
+    let mut body: Vec<u8> = Vec::new();
+
+    for frame in &frames {
+        // Single encode into the reused buffer (clears + keeps capacity).
+        beve::to_vec_into(&mut body, frame)?;
+
+        let mut header = Header::new();
+        header.id = frame.id;
+        header.query_format = QueryFormat::JsonPointer as u16;
+        header.body_format = BodyFormat::Beve as u16;
+
+        write_message_streaming(
+            &mut sink,
+            header,
+            b"/ingest/frame",
+            body.len() as u64,
+            |w| w.write_all(&body),
+        )?;
+
+        println!(
+            "sent frame {} ({} body bytes, scratch capacity {})",
+            frame.id,
+            body.len(),
+            body.capacity()
+        );
+    }
+
+    // Read the frames back off the wire and confirm they round-trip.
+    let mut cursor = Cursor::new(&sink);
+    for expected in &frames {
+        let msg = read_message(&mut cursor)?;
+        let decoded: SensorFrame = msg.beve_body()?;
+        assert_eq!(&decoded, expected);
+        println!(
+            "read frame {} back ({} samples)",
+            decoded.id,
+            decoded.samples.len()
+        );
+    }
+
+    println!("all {} frames round-tripped", frames.len());
+    Ok(())
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,9 +44,26 @@ pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError
 /// do so produces an unframed message on the wire and the receiving side will
 /// either block (short body) or misinterpret subsequent frames (long body).
 ///
-/// Pairs with `beve::to_writer_streaming` so that a large binary body can be
-/// BEVE-encoded directly into the caller-supplied writer with zero
-/// intermediate `Vec<u8>`.
+/// Because REPE frames are length-prefixed, `body_len` has to be known before
+/// the body is written. Two patterns supply a serialized body without building
+/// a full wire-frame `Vec`:
+///
+/// * **Reusable scratch buffer** (recommended for a writer sending many
+///   frames): serialize the body once into a caller-owned `Vec<u8>` with
+///   [`beve::to_vec_into`], which reuses the buffer's allocation and clears it
+///   on each call, then pass `scratch.len()` as `body_len` and
+///   `|w| w.write_all(&scratch)` as the writer. One encode per message and,
+///   once the buffer has grown to fit the largest body, no further allocation.
+///   See `examples/beve_streaming_body.rs`.
+/// * **Known-length raw body**: when the length is already known (a file
+///   chunk, a pre-sized buffer), pass it directly and have `body_writer` emit
+///   the bytes with `w.write_all(..)` — no body buffer at all.
+///
+/// Truly streaming an unbounded body too large to hold in memory needs its
+/// encoded length without buffering. BEVE cannot compute that without a
+/// traversal, so `beve::to_writer_streaming` only avoids the in-memory body if
+/// paired with a separate size pass — worth it only when not holding the body
+/// matters more than the second traversal.
 pub fn write_message_streaming<W, F>(
     w: &mut W,
     mut header: Header,
@@ -143,6 +160,69 @@ mod tests {
         .unwrap();
 
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn streaming_beve_body_via_reused_scratch() {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct SensorFrame {
+            id: u64,
+            samples: Vec<f64>,
+        }
+
+        let query = b"/ingest/frame";
+        // One scratch buffer for the writer; reused across every frame.
+        let mut scratch = Vec::new();
+
+        let big = SensorFrame {
+            id: 1,
+            samples: vec![1.25; 4096],
+        };
+
+        // Serialize the body once into the caller-owned buffer, then frame it.
+        beve::to_vec_into(&mut scratch, &big).unwrap();
+        let mut header = Header::new();
+        header.id = big.id;
+        header.query_format = QueryFormat::JsonPointer as u16;
+        header.body_format = BodyFormat::Beve as u16;
+        let mut streamed = Vec::new();
+        write_message_streaming(&mut streamed, header, query, scratch.len() as u64, |w| {
+            w.write_all(&scratch)
+        })
+        .unwrap();
+
+        // The streamed frame is byte-identical to the fully-buffered Message.
+        let reference = Message::builder()
+            .id(big.id)
+            .query_bytes(query.to_vec())
+            .query_format(QueryFormat::JsonPointer)
+            .body_bytes(beve::to_vec(&big).unwrap())
+            .body_format(BodyFormat::Beve)
+            .build()
+            .to_vec();
+        assert_eq!(streamed, reference);
+
+        // ...and round-trips back to the original value.
+        let parsed = Message::from_slice(&streamed).unwrap();
+        let decoded: SensorFrame = parsed.beve_body().unwrap();
+        assert_eq!(decoded, big);
+
+        // A subsequent smaller body reuses the buffer: `to_vec_into` clears but
+        // keeps capacity, so no reallocation once it has grown to the largest
+        // body seen.
+        let cap_after_big = scratch.capacity();
+        let small = SensorFrame {
+            id: 2,
+            samples: vec![0.0; 16],
+        };
+        beve::to_vec_into(&mut scratch, &small).unwrap();
+        assert!(
+            scratch.capacity() <= cap_after_big,
+            "smaller body must reuse the scratch allocation, not grow it"
+        );
+        assert!(scratch.len() < cap_after_big);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Documents and tests the reusable-scratch pattern for streaming a serialized (BEVE) body through `write_message_streaming` — single encode, amortized-zero allocation, **no new API** on the repe or beve side.

> Stacked on #17 (needs beve 1.x for the example/test). Based on that branch; GitHub will retarget this to `main` once #17 merges.

## Changes

- **`write_message_streaming` doc rewrite.** The previous note ("pairs with `beve::to_writer_streaming` … with zero intermediate `Vec`") was misleading: REPE frames are length-prefixed, so `body_len` must be known before the body, which a streaming encoder can't supply for an arbitrary value without a size pass beve doesn't expose. The doc now describes the two patterns that actually work without building a wire-frame `Vec`:
  - **Reusable scratch buffer** (recommended for a writer sending many frames): `beve::to_vec_into` into a caller-owned `Vec`, which reuses the allocation and clears it per call → one encode per message and, once grown to the largest body, no further allocation.
  - **Known-length raw body**: pass the length directly and `write_all` the bytes.
  - Plus an honest note that truly-unbounded streaming needs a size pass (the case where a measuring serializer would earn its keep).
- **`examples/beve_streaming_body.rs`** — a writer reusing one scratch `Vec` across frames. Output shows the capacity growing to fit the largest body and then staying put for smaller ones.
- **io test** — asserts the streamed frame is byte-identical to the fully-buffered `Message` frame, round-trips via `beve_body`, and reuses the scratch allocation (no growth) for a smaller subsequent body.

## Verification

- `cargo test --all-features` → 275 passed
- `cargo run --example beve_streaming_body` → all frames round-trip; scratch capacity reused
- clippy clean, fmt clean

## Context

Re-measuring the deferred direct-frame idea with the *real* streaming encoder: `beve::to_writer_streaming` straight into a prefixed buffer is single-pass and ~60% faster than `to_vec` + frame-copy (16 B–16 MB), reversing the earlier "BEVE can't benefit" finding (that was an artifact of the old buffering `to_writer`). That in-memory win is for the WebSocket-writer path and still needs frame-routing plumbing — a separate change — but the number now justifies it.
