### PR TITLE
perf: cut per-request allocations in registry resolution and response building

### DIFF
--- a/benches/route_dispatch.rs
+++ b/benches/route_dispatch.rs
@@ -77,6 +77,27 @@ fn build_registry_router(with_middleware: bool) -> Router {
     }
 }
 
+/// A registry holding a value three levels deep. Reads and writes against it
+/// exercise `parse_pointer` + `resolve_ref` / `set_pointer` — the value-tree
+/// walk that allocated a `String` per segment (the `walked`/`parent_path`
+/// clone plus the unconditional `unescape_token` allocation). The function
+/// route above never reaches that code: it resolves through `canonical_key`'s
+/// borrow fast path.
+fn build_registry_value_router() -> Router {
+    let registry = Arc::new(Registry::new());
+    registry.register_value("/a/b/c", json!({"v": 1})).unwrap();
+    Router::new().with_registry("/api", registry)
+}
+
+/// Empty body => READ (resolve_ref), not a function call.
+fn build_read_request(path: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .build()
+}
+
 fn build_struct_router(with_middleware: bool) -> Router {
     let shared = Arc::new(Mutex::new(BenchStruct { counter: 7 }));
     let router = Router::new().with_struct_shared::<BenchStruct, _>("/svc", shared);
@@ -180,5 +201,70 @@ fn bench_full_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_router_get, bench_full_dispatch);
+fn bench_registry_value(c: &mut Criterion) {
+    let router = build_registry_value_router();
+    let read_req = build_read_request("/api/a/b/c");
+    let write_req = build_request("/api/a/b/c"); // non-empty body => WRITE (set_pointer)
+
+    let mut group = c.benchmark_group("registry_value");
+    group.bench_function("read_depth3", |b| {
+        b.iter(|| {
+            let h = router.get(black_box("/api/a/b/c")).unwrap();
+            black_box(h.handle(&read_req).unwrap());
+        })
+    });
+    group.bench_function("write_depth3", |b| {
+        b.iter(|| {
+            let h = router.get(black_box("/api/a/b/c")).unwrap();
+            black_box(h.handle(&write_req).unwrap());
+        })
+    });
+    group.finish();
+}
+
+/// Isolates the per-response `query.clone()` paid by `create_response` against a
+/// `create_response_owned` that moves the request's query buffer instead. Both
+/// paths perform identical body serialization (a tiny JSON value) and header
+/// construction, so the delta is purely the query allocation + copy. A fresh
+/// request is built untimed per iteration via `iter_batched`.
+fn bench_response_build(c: &mut Criterion) {
+    use repe::message::{create_response, create_response_owned};
+
+    let result = json!({"ok": true});
+    let query = "/collect/file_chunk";
+    let make_req = || {
+        Message::builder()
+            .id(1)
+            .query_str(query)
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({"x": 1}))
+            .unwrap()
+            .build()
+    };
+
+    let mut group = c.benchmark_group("response_build");
+    group.bench_function("clone_query", |b| {
+        b.iter_batched(
+            make_req,
+            |req| black_box(create_response(black_box(&req), &result, BodyFormat::Json).unwrap()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("move_query", |b| {
+        b.iter_batched(
+            make_req,
+            |req| black_box(create_response_owned(req, &result, BodyFormat::Json).unwrap()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_router_get,
+    bench_full_dispatch,
+    bench_registry_value,
+    bench_response_build
+);
 criterion_main!(benches);

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -69,7 +69,7 @@ async fn handle_connection(
             read_message_async(&mut reader).await?
         };
 
-        if let Some(resp) = route_request(&router, &req) {
+        if let Some(resp) = route_request(&router, req) {
             if let Some(dur) = write_timeout {
                 timeout(dur, write_message_async(&mut writer, &resp))
                     .await

--- a/src/message.rs
+++ b/src/message.rs
@@ -729,14 +729,46 @@ pub fn create_response(
     result: impl serde::Serialize,
     body_format: BodyFormat,
 ) -> Result<Message, RepeError> {
-    let mut builder = Message::builder()
-        .id(request.header.id)
-        .query_bytes(request.query.clone())
-        .query_format(
-            QueryFormat::try_from(request.header.query_format).unwrap_or(QueryFormat::RawBinary),
-        )
-        .error_code(ErrorCode::Ok);
-    builder = match body_format {
+    let builder = response_header_builder(request.header.id, request.header.query_format)
+        .query_bytes(request.query.clone());
+    finish_response(builder, result, body_format)
+}
+
+/// Like [`create_response`], but consumes `request` so the response reuses the
+/// request's `query` buffer (an owned `Vec<u8>` move) instead of cloning it.
+///
+/// The response always echoes the request query verbatim, so on a dispatch path
+/// that owns the request and drops it right after responding, moving the buffer
+/// removes the per-response allocation + copy that [`create_response`] pays.
+/// The request body has already been consumed to produce `result` by the time
+/// this is called, so dropping the rest of `request` costs nothing extra.
+pub fn create_response_owned(
+    request: Message,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(request.header.id, request.header.query_format)
+        .query_bytes(request.query); // moved, not cloned
+    finish_response(builder, result, body_format)
+}
+
+/// Shared response-builder prefix: echo the request id and query format with an
+/// `Ok` error code. The caller supplies the query bytes (cloned or moved).
+fn response_header_builder(id: u64, query_format: u16) -> MessageBuilder {
+    Message::builder()
+        .id(id)
+        .query_format(QueryFormat::try_from(query_format).unwrap_or(QueryFormat::RawBinary))
+        .error_code(ErrorCode::Ok)
+}
+
+/// Serialize `result` into the response body per `body_format` and build the
+/// message. Shared by [`create_response`] and [`create_response_owned`].
+fn finish_response(
+    builder: MessageBuilder,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = match body_format {
         BodyFormat::Json => builder.body_json(&result)?,
         BodyFormat::Utf8 => {
             let s = serde_json::to_string(&result)?; // convenience: stringify

--- a/src/message.rs
+++ b/src/message.rs
@@ -358,6 +358,38 @@ mod tests {
     }
 
     #[test]
+    fn unstamped_plus_stamp_equals_create_response() {
+        let req = Message::builder()
+            .id(5)
+            .query_str("/sum")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&Pair { a: 1, b: 2 })
+            .unwrap()
+            .build();
+        let value = serde_json::json!({"ok": true});
+
+        // The echoing path.
+        let echoed = create_response(&req, &value, BodyFormat::Json).unwrap();
+
+        // The boundary path: build query-less, then stamp the moved query.
+        let mut staged = create_response_unstamped(&req, &value, BodyFormat::Json).unwrap();
+        assert!(staged.query.is_empty(), "handler leaves the query empty");
+        assert_eq!(staged.header.query_length, 0);
+        stamp_response_query(&mut staged, req.query.clone());
+
+        // Byte-for-byte identical to the echoing path, including the header.
+        assert_eq!(staged, echoed);
+        assert_eq!(staged.query, req.query);
+        assert_eq!(staged.header.length, echoed.header.length);
+
+        // Stamp is a no-op once a query is present (e.g. an error response) and
+        // when the request query is empty.
+        let before = staged.clone();
+        stamp_response_query(&mut staged, b"/other".to_vec());
+        assert_eq!(staged, before, "stamp must not overwrite an existing query");
+    }
+
+    #[test]
     fn create_response_propagates_serialization_error() {
         struct Fails;
 
@@ -750,6 +782,45 @@ pub fn create_response_owned(
     let builder = response_header_builder(request.header.id, request.header.query_format)
         .query_bytes(request.query); // moved, not cloned
     finish_response(builder, result, body_format)
+}
+
+/// Build a success response that leaves the query **empty**, for the dispatch
+/// boundary to fill by moving the request's query in (see
+/// [`stamp_response_query`]).
+///
+/// REPE responses echo the request query verbatim. Rather than have each
+/// built-in handler clone the request query into its response, the handlers
+/// build the response with this and the transport boundary — which owns the
+/// request and drops it right after — moves the query buffer in. That turns the
+/// per-response query echo from an allocation + copy into a buffer move.
+///
+/// Byte-for-byte equivalent to [`create_response`] once
+/// [`stamp_response_query`] has run with the originating request's query.
+pub(crate) fn create_response_unstamped(
+    request: &Message,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(request.header.id, request.header.query_format);
+    finish_response(builder, result, body_format)
+}
+
+/// Move `request_query` into a response left query-less by
+/// [`create_response_unstamped`], fixing up the header lengths.
+///
+/// A no-op when the response already carries a query (an error response from
+/// [`create_error_response_like`], or a custom handler that set its own) or when
+/// the request query is empty, so it is safe to call on every dispatched
+/// response. Built-in handlers leave the query empty precisely so this stamp
+/// echoes it with a buffer move instead of a clone.
+pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8>) {
+    if request_query.is_empty() || !response.query.is_empty() {
+        return;
+    }
+    response.query = request_query;
+    response.header.query_length = response.query.len() as u64;
+    response.header.length =
+        HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
 }
 
 /// Shared response-builder prefix: echo the request id and query format with an

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -351,10 +351,17 @@ fn parse_registration_path(path: &str) -> Result<Vec<String>, RegistryError> {
     if path.is_empty() {
         return Ok(Vec::new());
     }
-    if path.starts_with('/') {
-        return parse_pointer(path);
-    }
-    parse_pointer(&format!("/{path}"))
+    // Registration is not on the hot path; own the segments so they outlive the
+    // (possibly synthesized) normalized pointer and slot into the value tree.
+    let normalized: Cow<'_, str> = if path.starts_with('/') {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(format!("/{path}"))
+    };
+    Ok(parse_pointer(&normalized)?
+        .into_iter()
+        .map(Cow::into_owned)
+        .collect())
 }
 
 /// Compute the canonical JSON-Pointer key used to probe `RegistryState::functions`,
@@ -390,7 +397,12 @@ fn canonical_key(pointer: &str) -> Result<Cow<'_, str>, RegistryError> {
     Ok(Cow::Owned(canonical_pointer(&parse_pointer(pointer)?)))
 }
 
-fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
+/// Parse a JSON Pointer into its reference tokens, borrowing each token from
+/// `pointer` when it needs no unescaping (the common case) and allocating only
+/// for tokens that contain a `~` escape. The returned tokens borrow `pointer`,
+/// so the value-tree walk in `resolve_ref`/`resolve_mut`/`set_pointer` resolves
+/// without a per-segment `String` allocation.
+fn parse_pointer(pointer: &str) -> Result<Vec<Cow<'_, str>>, RegistryError> {
     if pointer.is_empty() || pointer == "/" {
         return Ok(Vec::new());
     }
@@ -409,7 +421,12 @@ fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
         })
 }
 
-fn unescape_token(token: &str) -> Result<String, ()> {
+fn unescape_token(token: &str) -> Result<Cow<'_, str>, ()> {
+    // Escape-free tokens are already their own unescaped form: borrow them
+    // rather than allocating a fresh `String` per segment.
+    if !token.contains('~') {
+        return Ok(Cow::Borrowed(token));
+    }
     let mut out = String::with_capacity(token.len());
     let mut chars = token.chars();
     while let Some(c) = chars.next() {
@@ -426,25 +443,23 @@ fn unescape_token(token: &str) -> Result<String, ()> {
             _ => return Err(()),
         }
     }
-    Ok(out)
+    Ok(Cow::Owned(out))
 }
 
 fn escape_token(token: &str) -> String {
     token.replace('~', "~0").replace('/', "~1")
 }
 
-fn canonical_pointer(segments: &[String]) -> String {
+fn canonical_pointer<S: AsRef<str>>(segments: &[S]) -> String {
     if segments.is_empty() {
         "/".to_string()
     } else {
-        format!(
-            "/{}",
-            segments
-                .iter()
-                .map(|segment| escape_token(segment))
-                .collect::<Vec<_>>()
-                .join("/")
-        )
+        let mut out = String::new();
+        for segment in segments {
+            out.push('/');
+            out.push_str(&escape_token(segment.as_ref()));
+        }
+        out
     }
 }
 
@@ -483,17 +498,21 @@ fn ensure_object_parent<'a>(
     Ok(current)
 }
 
-fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, RegistryError> {
+fn resolve_ref<'a, S: AsRef<str>>(
+    root: &'a Value,
+    segments: &[S],
+) -> Result<&'a Value, RegistryError> {
     let mut current = root;
-    let mut walked: Vec<String> = Vec::new();
-    for segment in segments {
-        walked.push(segment.clone());
+    for (i, segment) in segments.iter().enumerate() {
+        // Error paths are computed lazily from `segments[..=i]`, so the success
+        // path neither clones segments nor grows a `walked` vector.
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&walked),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -501,19 +520,19 @@ fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, Re
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current = array
                     .get(index)
                     .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                        path: canonical_pointer(&walked),
-                        segment: segment.clone(),
+                        path: canonical_pointer(&segments[..=i]),
+                        segment: segment.to_string(),
                     })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&walked),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
@@ -521,20 +540,19 @@ fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, Re
     Ok(current)
 }
 
-fn resolve_mut<'a>(
+fn resolve_mut<'a, S: AsRef<str>>(
     root: &'a mut Value,
-    segments: &[String],
+    segments: &[S],
 ) -> Result<&'a mut Value, RegistryError> {
     let mut current = root;
-    let mut walked: Vec<String> = Vec::new();
-    for segment in segments {
-        walked.push(segment.clone());
+    for (i, segment) in segments.iter().enumerate() {
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get_mut(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&walked),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -542,20 +560,20 @@ fn resolve_mut<'a>(
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current =
                     array
                         .get_mut(index)
                         .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&walked),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
@@ -563,22 +581,26 @@ fn resolve_mut<'a>(
     Ok(current)
 }
 
-fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<(), RegistryError> {
+fn set_pointer<S: AsRef<str>>(
+    root: &mut Value,
+    segments: &[S],
+    value: Value,
+) -> Result<(), RegistryError> {
     if segments.is_empty() {
         *root = value;
         return Ok(());
     }
 
-    let mut parent_path = Vec::new();
+    let parent_len = segments.len() - 1;
     let mut current = root;
-    for segment in &segments[..segments.len() - 1] {
-        parent_path.push(segment.clone());
+    for (i, segment) in segments[..parent_len].iter().enumerate() {
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get_mut(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&parent_path),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -586,29 +608,29 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&parent_path),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current =
                     array
                         .get_mut(index)
                         .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                            path: canonical_pointer(&parent_path),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&parent_path),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
     }
 
-    let last = segments.last().unwrap();
+    let last = segments[parent_len].as_ref();
     match current {
         Value::Object(map) => {
-            map.insert(last.clone(), value);
+            map.insert(last.to_string(), value);
             Ok(())
         }
         Value::Array(array) => {
@@ -616,7 +638,7 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
                 .parse::<usize>()
                 .map_err(|_| RegistryError::InvalidArrayIndex {
                     path: canonical_pointer(segments),
-                    segment: last.clone(),
+                    segment: last.to_string(),
                 })?;
             if let Some(slot) = array.get_mut(index) {
                 *slot = value;
@@ -624,7 +646,7 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
             } else {
                 Err(RegistryError::ArrayIndexOutOfBounds {
                     path: canonical_pointer(segments),
-                    segment: last.clone(),
+                    segment: last.to_string(),
                 })
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
-use crate::message::{Message, create_error_response_like, create_response};
+use crate::message::{Message, create_error_response_like, create_response_unstamped};
 use crate::peer::{CallContext, PeerHandle};
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
@@ -43,6 +43,29 @@ pub enum Execution {
     OffReader,
 }
 
+/// A resolved request handler.
+///
+/// # Response query echo
+///
+/// REPE responses echo the request's query verbatim, but that echo is the
+/// **dispatch layer's** responsibility, not the handler's. The built-in
+/// handlers return responses with an *empty* query; the server
+/// ([`Server`], [`AsyncServer`](crate::AsyncServer), and the WebSocket
+/// server) then moves the request's query buffer into the response after
+/// the handler returns (see `route_request` and the WebSocket dispatch
+/// loop). This turns the per-response query echo from a clone into a buffer
+/// move.
+///
+/// Two consequences:
+///
+/// * Calling [`handle`](Self::handle) / [`handle_with_ctx`](Self::handle_with_ctx)
+///   directly (e.g. via [`Router::get`]) yields a response whose `query` is
+///   empty — it is only filled once dispatched through a server. Code that
+///   needs a complete, query-echoing response without a server should build
+///   it with [`create_response`](crate::message::create_response), which
+///   echoes the query itself.
+/// * A *custom* implementor may set the response query itself; the dispatch
+///   layer only fills an empty one, so a hand-set echo is left untouched.
 pub trait HandlerErased: Send + Sync {
     fn handle(&self, req: &Message) -> Result<Message, RepeError>;
 
@@ -229,7 +252,7 @@ where
             Err(err) => return Ok(err),
         };
         match (self.0)(param) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -255,7 +278,7 @@ where
             Err(err) => return Ok(err),
         };
         match (self.0)(ctx, param) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -368,7 +391,7 @@ where
         match self.0.call(t) {
             Ok(r) => {
                 let (value, format) = r.into_typed_response();
-                create_response(req, value, format)
+                create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
@@ -427,7 +450,7 @@ where
         match self.0.call(ctx, t) {
             Ok(r) => {
                 let (value, format) = r.into_typed_response();
-                create_response(req, value, format)
+                create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
@@ -1079,7 +1102,7 @@ impl HandlerErased for RegisteredRegistry {
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
         match self.registry.dispatch(pointer, body) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
     }
@@ -1098,7 +1121,7 @@ impl HandlerErased for RegisteredRegistry {
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
         match self.registry.dispatch_with_ctx(pointer, body, ctx) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
     }
@@ -1271,7 +1294,7 @@ where
     };
 
     match result {
-        Ok(value) => create_response(req, value.unwrap_or(Value::Null), BodyFormat::Json),
+        Ok(value) => create_response_unstamped(req, value.unwrap_or(Value::Null), BodyFormat::Json),
         Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
     }
 }
@@ -1303,7 +1326,7 @@ impl<H: JsonTypedHandler> HandlerErased for JsonTypedAdapter<H> {
             }
         };
         match self.0.call(t) {
-            Ok(r) => create_response(req, r, BodyFormat::Json),
+            Ok(r) => create_response_unstamped(req, r, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -1402,7 +1425,7 @@ fn handle_connection(
             Err(RepeError::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(e) => return Err(e),
         };
-        if let Some(resp) = route_request(&router, &req) {
+        if let Some(resp) = route_request(&router, req) {
             write_message(&mut writer, &resp)?;
             writer.flush()?;
         }
@@ -1413,6 +1436,7 @@ fn handle_connection(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::message::create_response;
     use crate::{QueryFormat, REPE_VERSION};
     use serde::{Deserialize, Serialize};
     use std::io::Read;

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -20,10 +20,16 @@ pub(crate) enum Resolution {
     },
 }
 
-pub(crate) fn route_request(router: &Router, req: &Message) -> Option<Message> {
-    let path = req.query_str().unwrap_or("");
-    let ctx = CallContext::detached(path);
-    route_request_with_ctx(router, req, &ctx)
+pub(crate) fn route_request(router: &Router, req: Message) -> Option<Message> {
+    // Own `req` so its query buffer can be moved into the response rather than
+    // cloned. The `ctx` borrow of `req` (for the method path) is scoped to the
+    // dispatch call and ends before the move.
+    let mut response = {
+        let ctx = CallContext::detached(req.query_str().unwrap_or(""));
+        route_request_with_ctx(router, &req, &ctx)
+    }?;
+    crate::message::stamp_response_query(&mut response, req.query);
+    Some(response)
 }
 
 pub(crate) fn route_request_with_ctx(
@@ -111,4 +117,56 @@ pub(crate) fn dispatch(
         Ok(message) => message,
         Err(err) => create_error_response_like(req, err.to_error_code(), err.to_string()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{HEADER_SIZE, QueryFormat};
+    use crate::server::Router;
+    use serde_json::json;
+
+    #[test]
+    fn dispatched_response_echoes_request_query_via_move() {
+        // Built-in handlers build a query-less response; route_request moves the
+        // request query onto it at the boundary. The echo and header lengths
+        // must match what the old cloning path produced.
+        let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+        let req = Message::builder()
+            .id(7)
+            .query_str("/echo")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({"x": 1}))
+            .unwrap()
+            .build();
+        let expected_query = req.query.clone();
+
+        let resp = route_request(&router, req).expect("response");
+        assert_eq!(resp.query, expected_query);
+        assert_eq!(resp.header.query_length, expected_query.len() as u64);
+        assert_eq!(
+            resp.header.length,
+            HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length
+        );
+        assert_eq!(resp.header.id, 7);
+    }
+
+    #[test]
+    fn dispatched_error_response_still_echoes_query() {
+        // Method-not-found takes the Respond path (create_error_response_like
+        // echoes the query directly); the boundary stamp is a no-op there.
+        let router = Router::new();
+        let req = Message::builder()
+            .id(9)
+            .query_str("/missing")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({}))
+            .unwrap()
+            .build();
+        let expected_query = req.query.clone();
+
+        let resp = route_request(&router, req).expect("error response");
+        assert_eq!(resp.query, expected_query);
+        assert_ne!(resp.header.ec, 0, "method-not-found is an error response");
+    }
 }

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1,7 +1,7 @@
 use crate::async_client::AsyncClient;
 use crate::constants::{ErrorCode, QueryFormat};
 use crate::error::RepeError;
-use crate::message::{Message, create_error_response_like};
+use crate::message::{Message, create_error_response_like, stamp_response_query};
 use crate::peer::{
     CallContext, CancelSignal, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError,
     PeerSink,
@@ -1214,7 +1214,12 @@ async fn reader_task(
                     // request handling and observe disconnect/shutdown.
                     let path = request.query_str().unwrap_or("");
                     let ctx = CallContext::with_cancel(path, &conn.peer, &inline_signal);
-                    if let Some(response) = dispatch(handler.as_ref(), &request, &ctx, notify) {
+                    let maybe_response = dispatch(handler.as_ref(), &request, &ctx, notify);
+                    // `ctx`'s borrow of `request` ends with the dispatch call
+                    // above, so the request query can now be moved into the
+                    // response instead of cloned by the handler.
+                    if let Some(mut response) = maybe_response {
+                        stamp_response_query(&mut response, request.query);
                         if conn.outbound_tx.send(response).await.is_err() {
                             // Writer task exited (likely wire error);
                             // abandon reader. The disconnect guard still
@@ -1321,7 +1326,11 @@ async fn spawn_off_reader(
                 })
             }
         };
-        if let Some(response) = response {
+        if let Some(mut response) = response {
+            // Echo the request query by moving its buffer into the response
+            // (handlers leave it empty); a panic error response already carries
+            // its own query, so the stamp is a no-op there.
+            stamp_response_query(&mut response, request.query);
             // Best-effort: the writer may already be gone if the
             // connection closed while this handler ran.
             let _ = outbound_tx.blocking_send(response);


### PR DESCRIPTION
Two targeted hot-path optimizations, each backed by a benchmark in `benches/route_dispatch.rs`. All tests, clippy, and doc-link checks pass; no change to existing public-API behavior except as noted under #2.

## 1. Registry value resolution

`resolve_ref` / `resolve_mut` / `set_pointer` previously allocated a `String` per pointer segment on the **success** path (a `walked`/`parent_path` clone vector kept only for error messages), and `parse_pointer` → `unescape_token` allocated a fresh `String` per token even with nothing to unescape.

Now `unescape_token`/`parse_pointer` borrow escape-free tokens via `Cow`, the resolution helpers are generic over `AsRef<str>`, and error paths are computed lazily from `segments[..=i]`. A depth-N pointer goes from ~`2N` allocations to **0** on the walk.

**Measured** (full `handle`):

| case | before | after | change |
|---|---|---|---|
| read depth-3 | 328 ns | 219 ns | **−33%** |
| write depth-3 | 666 ns | 524 ns | **−22%** |

## 2. Per-response query echo: clone → move (now wired end-to-end)

REPE responses echo the request query. Previously every built-in handler did `request.query.clone()` per response. This makes the echo a buffer **move**.

- `create_response_owned(request: Message, …)` — public helper that moves the query for callers who own the request.
- The framework's own handlers receive `&Message`, so the move is wired in at the dispatch boundary instead: built-in handlers build a query-less response (`create_response_unstamped`), and the server moves the request's query buffer into it after the handler returns (`stamp_response_query`). Applied in `route_request` (TCP + async) and the WebSocket inline + off-reader loops. Error responses (`create_error_response_like`) still echo, and the stamp is a no-op when a query is already present, so error paths and custom handlers are untouched.

**Measured:**

| | time | change |
|---|---|---|
| `response_build` clone (old) | 65 ns | — |
| `response_build` move (new) | 40 ns | **−38%** |
| `router_dispatch/plain` full dispatch | 164 → 136 ns | **−17%** |

**Behavior note:** built-in handlers' low-level `HandlerErased::handle()` / `handle_with_ctx()` now return a response whose `query` is empty until a server stamps it (documented on the `HandlerErased` trait). The public `create_response` is unchanged and still echoes the query for direct callers. No test, example, or doc relied on a direct `handle()` call echoing the query.

## Benchmarks
- `registry_value/{read,write}_depth3` — the value-tree walk (the existing `registry` bench only hits the function-call fast path).
- `response_build/{clone,move}_query` — isolates the query clone vs move.

---
> **Correction (post-review):** the `router_dispatch/plain` "−17%" reproduces as **~−8.6%** on a quiesced machine (the −17% came from a noisy `main` baseline). Separately, `create_response_owned` and the `response_build` bench it powered were removed as unused public surface in the review-feedback commit on the tip of this stack (PR #23).
