### PR TITLE
perf: borrowing dispatch primitives (read_message_into + handle_view), -40% allocs

### DIFF
--- a/benches/server_lifecycle.rs
+++ b/benches/server_lifecycle.rs
@@ -16,11 +16,14 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use repe::server::Router;
-use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use repe::{
+    CallContext, HEADER_SIZE, Message, MessageView, QueryFormat, read_message, read_message_into,
+    write_message, write_message_streaming,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::hint::black_box;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Serialize, Deserialize)]
 struct SumIn {
@@ -58,6 +61,23 @@ fn run_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
     write_message(out, &resp).expect("write");
 }
 
+/// The borrowing path: read into a reused buffer, parse a `MessageView`,
+/// dispatch via `handle_view`, and frame the response with the query echoed as
+/// a borrowed slice of the read buffer. No owned request `Message`.
+fn run_cycle_view(router: &Router, wire: &[u8], path: &str, buf: &mut Vec<u8>, out: &mut Vec<u8>) {
+    let mut reader = Cursor::new(wire);
+    read_message_into(&mut reader, buf).expect("read");
+    let view = MessageView::from_slice(buf).expect("view");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let resp = handler.handle_view(&view, &ctx).expect("dispatch");
+    out.clear();
+    write_message_streaming(out, resp.header, view.query, resp.body.len() as u64, |w| {
+        w.write_all(&resp.body)
+    })
+    .expect("write");
+}
+
 fn bench_server_lifecycle(c: &mut Criterion) {
     let json_router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
     let typed_router = Router::new()
@@ -75,6 +95,33 @@ fn bench_server_lifecycle(c: &mut Criterion) {
         b.iter(|| run_cycle(black_box(&typed_router), black_box(&typed_wire), "/sum", &mut out))
     });
     group.finish();
+
+    // Borrowing path: same work, reusable read buffer + MessageView dispatch.
+    let mut buf = Vec::with_capacity(256);
+    let mut view_group = c.benchmark_group("server_lifecycle_view");
+    view_group.bench_function("json_echo", |b| {
+        b.iter(|| {
+            run_cycle_view(
+                black_box(&json_router),
+                black_box(&json_wire),
+                "/echo",
+                &mut buf,
+                &mut out,
+            )
+        })
+    });
+    view_group.bench_function("typed_sum", |b| {
+        b.iter(|| {
+            run_cycle_view(
+                black_box(&typed_router),
+                black_box(&typed_wire),
+                "/sum",
+                &mut buf,
+                &mut out,
+            )
+        })
+    });
+    view_group.finish();
 }
 
 criterion_group!(benches, bench_server_lifecycle);

--- a/src/io.rs
+++ b/src/io.rs
@@ -18,6 +18,28 @@ pub fn read_message<R: Read>(r: &mut R) -> Result<Message, RepeError> {
     Message::new(header, query, body)
 }
 
+/// Read a full REPE message frame into `buf`, reusing its allocation across
+/// calls.
+///
+/// On success `buf` holds the complete wire frame (header + query + body) and
+/// can be parsed with [`MessageView::from_slice`](crate::MessageView::from_slice)
+/// to dispatch without the per-request query and body `Vec` allocations that
+/// [`read_message`] makes. A server reading many requests on one connection
+/// keeps one `buf` and reuses it, so steady-state framing is allocation-free.
+///
+/// `buf` is cleared first; its capacity is retained, so once it has grown to the
+/// largest frame seen no further allocation occurs.
+pub fn read_message_into<R: Read>(r: &mut R, buf: &mut Vec<u8>) -> Result<(), RepeError> {
+    buf.clear();
+    buf.resize(HEADER_SIZE, 0);
+    read_exact(r, &mut buf[..HEADER_SIZE])?;
+    let header = Header::decode(&buf[..HEADER_SIZE])?;
+    let total = HEADER_SIZE + header.query_length as usize + header.body_length as usize;
+    buf.resize(total, 0);
+    read_exact(r, &mut buf[HEADER_SIZE..total])?;
+    Ok(())
+}
+
 /// Write a full REPE message to a stream implementing `Write`.
 pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError> {
     let header_bytes = msg.header.encode();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use fleet::{
 };
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
-pub use io::{read_message, write_message, write_message_streaming};
+pub use io::{read_message, read_message_into, write_message, write_message_streaming};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::{Message, MessageView};
 pub use peer::{

--- a/src/message.rs
+++ b/src/message.rs
@@ -248,6 +248,19 @@ impl<'a> MessageView<'a> {
     pub fn query_str(&self) -> Result<&'a str, std::str::Utf8Error> {
         std::str::from_utf8(self.query)
     }
+
+    /// Copy this borrowed view into an owned [`Message`], allocating the query
+    /// and body. Used as the fallback for [`HandlerErased::handle_view`] when a
+    /// handler has not overridden the borrowing path.
+    ///
+    /// [`HandlerErased::handle_view`]: crate::server::HandlerErased::handle_view
+    pub fn to_message(&self) -> Message {
+        Message {
+            header: self.header,
+            query: self.query.to_vec(),
+            body: self.body.to_vec(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -821,6 +834,33 @@ pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8
     response.header.query_length = response.query.len() as u64;
     response.header.length =
         HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
+}
+
+/// Borrowing twin of [`create_response_unstamped`]: builds the same query-less
+/// success response from a [`MessageView`], without materializing an owned
+/// request. The view's query is echoed by the writer (e.g.
+/// [`write_message_streaming`] with the borrowed query), not by this builder.
+pub(crate) fn create_response_unstamped_view(
+    view: &MessageView,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(view.header.id, view.header.query_format);
+    finish_response(builder, result, body_format)
+}
+
+/// Borrowing, query-less error response from a [`MessageView`]. Mirrors
+/// [`create_error_response_like`] but leaves the query empty for the writer to
+/// supply from the borrowed view.
+pub(crate) fn create_error_response_unstamped_view(
+    view: &MessageView,
+    code: ErrorCode,
+    msg: impl AsRef<str>,
+) -> Message {
+    let mut err = create_error_message(code, msg.as_ref());
+    err.header.id = view.header.id;
+    err.header.query_format = view.header.query_format;
+    err
 }
 
 /// Shared response-builder prefix: echo the request id and query format with an

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,10 @@ use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
-use crate::message::{Message, create_error_response_like, create_response_unstamped};
+use crate::message::{
+    Message, MessageView, create_error_response_like, create_error_response_unstamped_view,
+    create_response_unstamped, create_response_unstamped_view,
+};
 use crate::peer::{CallContext, PeerHandle};
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
@@ -83,6 +86,26 @@ pub trait HandlerErased: Send + Sync {
     /// [`CallContext::detached`]).
     fn handle_with_ctx(&self, req: &Message, _ctx: &CallContext) -> Result<Message, RepeError> {
         self.handle(req)
+    }
+
+    /// Borrowing dispatch: handle a request given a borrowed [`MessageView`]
+    /// instead of an owned [`Message`].
+    ///
+    /// A server that reads each frame into a reusable per-connection buffer (see
+    /// [`read_message_into`](crate::read_message_into)) can dispatch through this
+    /// method without the per-request query and body `Vec` allocations that an
+    /// owned [`Message`] requires. As with [`handle_with_ctx`](Self::handle_with_ctx),
+    /// the returned response leaves its query empty; the writer supplies the
+    /// echoed query from the borrowed view.
+    ///
+    /// The default implementation materializes an owned [`Message`] from the view
+    /// (copying the query and body) and delegates to
+    /// [`handle_with_ctx`](Self::handle_with_ctx), so existing handlers work
+    /// unchanged. The built-in handlers override it to decode straight from the
+    /// borrowed body and skip those copies.
+    #[doc(hidden)]
+    fn handle_view(&self, view: &MessageView, ctx: &CallContext) -> Result<Message, RepeError> {
+        self.handle_with_ctx(&view.to_message(), ctx)
     }
 
     /// Where this handler should be dispatched. Defaults to
@@ -238,6 +261,24 @@ fn decode_json_param(req: &Message) -> Result<Result<Value, Message>, RepeError>
     Ok(Ok(value))
 }
 
+/// Borrowing twin of [`decode_json_param`]: decode the request body straight
+/// from the borrowed view, with no owned `Message`. The UTF-8 branch parses the
+/// bytes directly (`from_slice`) rather than via an intermediate `String`.
+fn decode_json_param_view(view: &MessageView) -> Result<Result<Value, Message>, RepeError> {
+    let value: Value = match BodyFormat::try_from(view.header.body_format) {
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(view.body)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(view.body)?,
+        _ => {
+            return Ok(Err(create_error_response_unstamped_view(
+                view,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
+}
+
 struct JsonHandler<F>(F)
 where
     F: Fn(Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static;
@@ -254,6 +295,17 @@ where
         match (self.0)(param) {
             Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+
+    fn handle_view(&self, view: &MessageView, _ctx: &CallContext) -> Result<Message, RepeError> {
+        let param = match decode_json_param_view(view)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match (self.0)(param) {
+            Ok(value) => create_response_unstamped_view(view, value, BodyFormat::Json),
+            Err((code, msg)) => Ok(create_error_response_unstamped_view(view, code, msg)),
         }
     }
 }
@@ -371,6 +423,27 @@ where
     Ok(Ok(value))
 }
 
+/// Borrowing twin of [`decode_typed_param`]: deserialize `T` straight from the
+/// borrowed view body, with no owned `Message` and no intermediate `String` on
+/// the UTF-8 branch.
+fn decode_typed_param_view<T>(view: &MessageView) -> Result<Result<T, Message>, RepeError>
+where
+    T: DeserializeOwned,
+{
+    let value: T = match BodyFormat::try_from(view.header.body_format) {
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(view.body)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(view.body)?,
+        _ => {
+            return Ok(Err(create_error_response_unstamped_view(
+                view,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
+}
+
 struct TypedHandler<T, R, F>(F, std::marker::PhantomData<(T, R)>)
 where
     T: DeserializeOwned + Send + Sync + 'static,
@@ -394,6 +467,20 @@ where
                 create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+
+    fn handle_view(&self, view: &MessageView, _ctx: &CallContext) -> Result<Message, RepeError> {
+        let t: T = match decode_typed_param_view(view)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match self.0.call(t) {
+            Ok(r) => {
+                let (value, format) = r.into_typed_response();
+                create_response_unstamped_view(view, value, format)
+            }
+            Err((code, msg)) => Ok(create_error_response_unstamped_view(view, code, msg)),
         }
     }
 }

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -20,10 +20,13 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::hint::black_box;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 use repe::server::Router;
-use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use repe::{
+    CallContext, HEADER_SIZE, Message, MessageView, QueryFormat, read_message, read_message_into,
+    write_message, write_message_streaming,
+};
 use serde_json::json;
 
 thread_local! {
@@ -94,6 +97,32 @@ fn dispatch_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
     write_message(out, &resp).expect("write");
 }
 
+/// The borrowing path: read into a reused buffer, parse a `MessageView`,
+/// dispatch via `handle_view`, and write the response framing the query as a
+/// borrowed slice of the read buffer (`write_message_streaming`). No owned
+/// request `Message`, so the read query/body `Vec`s never exist.
+fn dispatch_cycle_view(
+    router: &Router,
+    wire: &[u8],
+    path: &str,
+    buf: &mut Vec<u8>,
+    out: &mut Vec<u8>,
+) {
+    let mut reader = Cursor::new(wire);
+    read_message_into(&mut reader, buf).expect("read");
+    let view = MessageView::from_slice(buf).expect("view");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let resp = handler.handle_view(&view, &ctx).expect("dispatch");
+    out.clear();
+    // The response is query-less; echo the query straight from the borrowed
+    // view, so no query buffer is allocated on the response side either.
+    write_message_streaming(out, resp.header, view.query, resp.body.len() as u64, |w| {
+        w.write_all(&resp.body)
+    })
+    .expect("write");
+}
+
 #[test]
 fn framing_round_trip_allocates_only_query_and_body() {
     // The pure framing path, no dispatch: `read_message` allocates exactly one
@@ -155,5 +184,37 @@ fn json_dispatch_allocation_budget() {
         allocs, EXPECTED,
         "per-request allocation budget changed (was {EXPECTED}, now {allocs}); \
          a reduction is good news — update EXPECTED; an increase is a regression"
+    );
+}
+
+#[test]
+fn json_dispatch_view_allocation_budget() {
+    // The borrowing read path for the same `{"x":1}` echo. The two read-side
+    // Vecs (query + body) are gone — the read buffer is reused and the response
+    // echoes the query as a borrowed slice — leaving only serde_json's payload
+    // work:
+    //
+    //   0  read_message_into (reuses `buf`) + MessageView (borrows)
+    //   2  serde_json decode of `{"x":1}` to Value
+    //   1  serde_json encode of the response body
+    //   0  query echo (borrowed from the view by the writer)
+    //   0  write_message_streaming (reuses `out`)
+    //   ----
+    //   3   (down from 5 on the owned path)
+    const EXPECTED: usize = 3;
+    let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+    let wire = request("/echo", json!({"x": 1}));
+    let mut buf = Vec::new();
+    let mut out = Vec::new();
+
+    // Warm up both reused buffers.
+    dispatch_cycle_view(&router, &wire, "/echo", &mut buf, &mut out);
+
+    let (_, allocs) =
+        count_allocs(|| dispatch_cycle_view(&router, &wire, "/echo", &mut buf, &mut out));
+
+    assert_eq!(
+        allocs, EXPECTED,
+        "borrowing-path allocation budget changed (was {EXPECTED}, now {allocs})"
     );
 }


### PR DESCRIPTION
A zero-read-allocation dispatch path, proven against the measurement foundation (#21) before any server wiring. Additive only — existing handlers and behavior are unchanged.

> Stacked on #21 (base = `perf/measurement-foundation`). Server wiring follows in a separate PR.

## The win

A server can read each frame into a **reusable per-connection buffer**, dispatch from a borrowed `MessageView`, and frame the response echoing the query as a **borrowed slice** of that buffer — so the two per-request read allocations (the query + body `Vec`s) never happen, and the response side allocates no query buffer either.

| | allocations | latency |
|---|---|---|
| `json_echo` owned → view | 5 → **3** (−40%) | 341 → **316 ns** (−7%) |
| `typed_sum` owned → view | 5 → **3** (−40%) | 176 → **137 ns** (−22%) |

(Typed gains more because framing is a bigger share of its cost.) Pinned in `tests/allocations.rs`, benched in `benches/server_lifecycle.rs`.

## New surface

- **`read_message_into(reader, &mut buf)`** — reads a full frame into a reusable buffer; pair with `MessageView::from_slice`.
- **`HandlerErased::handle_view(&MessageView, ctx)`** (`#[doc(hidden)]`) — borrowing dispatch returning a query-less response. The default materializes an owned `Message` and delegates to `handle_with_ctx`, so **every existing handler works unchanged**; `JsonHandler` and `TypedHandler` override it to decode straight from the borrowed body.
- **`MessageView::to_message()`** — owned copy (the fallback).
- pub(crate) view response builders in `message.rs`.

The response is written with `write_message_streaming`, framing the borrowed `view.query` directly.

## Not in this PR
Wiring the built-in servers to use this path (a borrowing `route_request_view`, a tokio `read_message_into_async`, the TCP/async/WebSocket loops). That's the next PR. The WebSocket off-reader path spawns a task that outlives the read buffer, so it will stay on the owned fallback.

---
> **Correction (post-review):** the **5→3 (−40%)** allocation win applies to `with_json`/`with_typed` routes, which override `handle_view`. Context-aware, struct, registry, and middleware-wrapped routes use the owning `handle_view` default (`MessageView::to_message`) and keep the owned count until overridden. The latency figures are for the overriding routes. `handle_view` was also promoted out of `#[doc(hidden)]` in PR #23.
