### PR TITLE
perf: zero-allocation borrowing server dispatch (registry, query-echo, TCP/async/WebSocket)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+- Borrowing, zero-allocation read path for server dispatch. `read_message_into(reader, &mut Vec<u8>)` and `read_message_into_async` read a full frame into a reusable per-connection buffer; pair with `MessageView::from_slice`/`from_slice_exact` (the latter rejects trailing bytes, for one-message-per-frame transports) to dispatch via the new `HandlerErased::handle_view(&MessageView, &CallContext)` without the per-request query and body `Vec` allocations an owned `Message` requires. `handle_view`'s default materializes an owned `Message` (`MessageView::to_message`) and delegates to `handle_with_ctx`, so every existing handler works unchanged; the built-in JSON and typed handlers (`with_json` / `with_typed`) override it to decode straight from the borrowed body.
+- A measurement harness for the server hot path: `tests/allocations.rs` pins the per-request allocation count of read → dispatch → echo → write with a thread-local counting `#[global_allocator]` and `assert_eq` budgets (so a regression up *or* a deliberate reduction down is caught), and `benches/server_lifecycle.rs` measures the same cycle end-to-end.
+
+### Changed
+- The TCP, async, and WebSocket-inline servers now dispatch off the borrowing read path. The TCP and async servers keep one reusable read buffer per connection and frame the response echoing the query straight out of it, so steady-state request framing for `with_json`/`with_typed` routes allocates nothing (per-request allocations 5 → 3; `server_lifecycle` `json_echo` ~341→316 ns, `typed_sum` ~176→137 ns). The WebSocket inline path borrows the request from the tungstenite payload, eliminating the request body copy (5 → 4; the response query is still copied because the outbound channel carries owned messages framed later by the writer task); the WebSocket off-reader path keeps the owned decode (its spawned task outlives the read buffer).
+- Per-response query echo is now a buffer move (owned/WebSocket path) or a borrow (TCP/async), not a clone. Built-in handler responses leave the query empty and the dispatch layer supplies it; a handler that sets its own response query is left untouched. Registry JSON-pointer resolution borrows escape-free tokens (`Cow`) and builds error-path strings lazily, taking a depth-N pointer walk from ~`2N` `String` allocations to zero (`registry_value` read −33%, write −22%). Owned JSON/typed decoders parse a `Utf8`-framed body with strict `from_slice` (matching the borrowing path; drops a per-request `String`).
+
+### Notes
+- The 5→3 / "framing allocates nothing" win applies to `with_json`/`with_typed` routes, which override `handle_view`. Context-aware, struct, registry, and middleware-wrapped routes use the owning `handle_view` default (a correct owned copy) and keep the owned allocation count until overridden; middleware-wrapped routes are structurally bound to the owned path because the `Middleware` trait takes `&Message`.
+- Behavior change to a public trait method, documented on `HandlerErased`: built-in handlers' `handle` / `handle_with_ctx` now return a response whose `query` is *empty* — the dispatch layer fills it. Code that calls a handler directly (e.g. via `Router::get`) and needs a complete, query-echoing response should build it with `create_response`, which echoes the query itself. The owned/WebSocket error path and success frames are byte-identical to before. (One edge improvement: a `Utf8`-framed body containing invalid UTF-8 is now rejected strictly rather than lossily substituted.)
+
 ## [3.2.0] - 2026-05-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,10 @@ harness = false
 # middleware pipeline so the hoisted middleware wrap is visible.
 name = "route_dispatch"
 harness = false
+
+[[bench]]
+# End-to-end server request lifecycle (read -> route -> dispatch -> echo ->
+# write) over an in-memory transport, for JSON and typed handlers. Pairs with
+# `tests/allocations.rs`, which pins the allocation count of the same cycle.
+name = "server_lifecycle"
+harness = false

--- a/benches/route_dispatch.rs
+++ b/benches/route_dispatch.rs
@@ -77,6 +77,27 @@ fn build_registry_router(with_middleware: bool) -> Router {
     }
 }
 
+/// A registry holding a value three levels deep. Reads and writes against it
+/// exercise `parse_pointer` + `resolve_ref` / `set_pointer` — the value-tree
+/// walk that allocated a `String` per segment (the `walked`/`parent_path`
+/// clone plus the unconditional `unescape_token` allocation). The function
+/// route above never reaches that code: it resolves through `canonical_key`'s
+/// borrow fast path.
+fn build_registry_value_router() -> Router {
+    let registry = Arc::new(Registry::new());
+    registry.register_value("/a/b/c", json!({"v": 1})).unwrap();
+    Router::new().with_registry("/api", registry)
+}
+
+/// Empty body => READ (resolve_ref), not a function call.
+fn build_read_request(path: &str) -> Message {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .build()
+}
+
 fn build_struct_router(with_middleware: bool) -> Router {
     let shared = Arc::new(Mutex::new(BenchStruct { counter: 7 }));
     let router = Router::new().with_struct_shared::<BenchStruct, _>("/svc", shared);
@@ -180,5 +201,70 @@ fn bench_full_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_router_get, bench_full_dispatch);
+fn bench_registry_value(c: &mut Criterion) {
+    let router = build_registry_value_router();
+    let read_req = build_read_request("/api/a/b/c");
+    let write_req = build_request("/api/a/b/c"); // non-empty body => WRITE (set_pointer)
+
+    let mut group = c.benchmark_group("registry_value");
+    group.bench_function("read_depth3", |b| {
+        b.iter(|| {
+            let h = router.get(black_box("/api/a/b/c")).unwrap();
+            black_box(h.handle(&read_req).unwrap());
+        })
+    });
+    group.bench_function("write_depth3", |b| {
+        b.iter(|| {
+            let h = router.get(black_box("/api/a/b/c")).unwrap();
+            black_box(h.handle(&write_req).unwrap());
+        })
+    });
+    group.finish();
+}
+
+/// Isolates the per-response `query.clone()` paid by `create_response` against a
+/// `create_response_owned` that moves the request's query buffer instead. Both
+/// paths perform identical body serialization (a tiny JSON value) and header
+/// construction, so the delta is purely the query allocation + copy. A fresh
+/// request is built untimed per iteration via `iter_batched`.
+fn bench_response_build(c: &mut Criterion) {
+    use repe::message::{create_response, create_response_owned};
+
+    let result = json!({"ok": true});
+    let query = "/collect/file_chunk";
+    let make_req = || {
+        Message::builder()
+            .id(1)
+            .query_str(query)
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({"x": 1}))
+            .unwrap()
+            .build()
+    };
+
+    let mut group = c.benchmark_group("response_build");
+    group.bench_function("clone_query", |b| {
+        b.iter_batched(
+            make_req,
+            |req| black_box(create_response(black_box(&req), &result, BodyFormat::Json).unwrap()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("move_query", |b| {
+        b.iter_batched(
+            make_req,
+            |req| black_box(create_response_owned(req, &result, BodyFormat::Json).unwrap()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_router_get,
+    bench_full_dispatch,
+    bench_registry_value,
+    bench_response_build
+);
 criterion_main!(benches);

--- a/benches/route_dispatch.rs
+++ b/benches/route_dispatch.rs
@@ -222,49 +222,10 @@ fn bench_registry_value(c: &mut Criterion) {
     group.finish();
 }
 
-/// Isolates the per-response `query.clone()` paid by `create_response` against a
-/// `create_response_owned` that moves the request's query buffer instead. Both
-/// paths perform identical body serialization (a tiny JSON value) and header
-/// construction, so the delta is purely the query allocation + copy. A fresh
-/// request is built untimed per iteration via `iter_batched`.
-fn bench_response_build(c: &mut Criterion) {
-    use repe::message::{create_response, create_response_owned};
-
-    let result = json!({"ok": true});
-    let query = "/collect/file_chunk";
-    let make_req = || {
-        Message::builder()
-            .id(1)
-            .query_str(query)
-            .query_format(QueryFormat::JsonPointer)
-            .body_json(&json!({"x": 1}))
-            .unwrap()
-            .build()
-    };
-
-    let mut group = c.benchmark_group("response_build");
-    group.bench_function("clone_query", |b| {
-        b.iter_batched(
-            make_req,
-            |req| black_box(create_response(black_box(&req), &result, BodyFormat::Json).unwrap()),
-            criterion::BatchSize::SmallInput,
-        );
-    });
-    group.bench_function("move_query", |b| {
-        b.iter_batched(
-            make_req,
-            |req| black_box(create_response_owned(req, &result, BodyFormat::Json).unwrap()),
-            criterion::BatchSize::SmallInput,
-        );
-    });
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_router_get,
     bench_full_dispatch,
-    bench_registry_value,
-    bench_response_build
+    bench_registry_value
 );
 criterion_main!(benches);

--- a/benches/server_lifecycle.rs
+++ b/benches/server_lifecycle.rs
@@ -89,10 +89,24 @@ fn bench_server_lifecycle(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("server_lifecycle");
     group.bench_function("json_echo", |b| {
-        b.iter(|| run_cycle(black_box(&json_router), black_box(&json_wire), "/echo", &mut out))
+        b.iter(|| {
+            run_cycle(
+                black_box(&json_router),
+                black_box(&json_wire),
+                "/echo",
+                &mut out,
+            )
+        })
     });
     group.bench_function("typed_sum", |b| {
-        b.iter(|| run_cycle(black_box(&typed_router), black_box(&typed_wire), "/sum", &mut out))
+        b.iter(|| {
+            run_cycle(
+                black_box(&typed_router),
+                black_box(&typed_wire),
+                "/sum",
+                &mut out,
+            )
+        })
     });
     group.finish();
 

--- a/benches/server_lifecycle.rs
+++ b/benches/server_lifecycle.rs
@@ -1,0 +1,81 @@
+//! Full server request-lifecycle throughput.
+//!
+//! Measures the per-request cost a server pays end-to-end, minus the socket
+//! syscalls: read a framed request off an in-memory cursor, route + dispatch
+//! it, echo the query, and write the framed response into a reused buffer.
+//!
+//! Composed from public APIs because the internal `route_request` is
+//! `pub(crate)`; the dispatch-boundary query-echo move (the server moves the
+//! request query into the handler's query-less response) is replicated via the
+//! public `Message`/`Header` fields so the measured work matches a real server.
+//!
+//! Pairs with `tests/allocations.rs`, which pins the allocation count of the
+//! same cycle. Two handler shapes are covered: a `serde_json::Value` echo
+//! (`with_json`, the Value round-trip path) and a typed handler (`with_typed`,
+//! which deserializes straight into a struct and skips the Value round-trip).
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use repe::server::Router;
+use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::hint::black_box;
+use std::io::Cursor;
+
+#[derive(Serialize, Deserialize)]
+struct SumIn {
+    a: i64,
+    b: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SumOut {
+    sum: i64,
+}
+
+fn frame(path: &str, body: &serde_json::Value) -> Vec<u8> {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_json(body)
+        .unwrap()
+        .build()
+        .to_vec()
+}
+
+fn run_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
+    let mut reader = Cursor::new(wire);
+    let req = read_message(&mut reader).expect("read");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let mut resp = handler.handle_with_ctx(&req, &ctx).expect("dispatch");
+    // Replicate the dispatch-boundary query-echo move.
+    resp.query = req.query;
+    resp.header.query_length = resp.query.len() as u64;
+    resp.header.length = HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
+    out.clear();
+    write_message(out, &resp).expect("write");
+}
+
+fn bench_server_lifecycle(c: &mut Criterion) {
+    let json_router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+    let typed_router = Router::new()
+        .with_typed::<SumIn, SumOut, _>("/sum", |i: SumIn| Ok(SumOut { sum: i.a + i.b }));
+
+    let json_wire = frame("/echo", &json!({"x": 1, "y": "hello"}));
+    let typed_wire = frame("/sum", &json!({"a": 2, "b": 3}));
+    let mut out = Vec::with_capacity(256);
+
+    let mut group = c.benchmark_group("server_lifecycle");
+    group.bench_function("json_echo", |b| {
+        b.iter(|| run_cycle(black_box(&json_router), black_box(&json_wire), "/echo", &mut out))
+    });
+    group.bench_function("typed_sum", |b| {
+        b.iter(|| run_cycle(black_box(&typed_router), black_box(&typed_wire), "/sum", &mut out))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_server_lifecycle);
+criterion_main!(benches);

--- a/benches/server_lifecycle.rs
+++ b/benches/server_lifecycle.rs
@@ -16,11 +16,14 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use repe::server::Router;
-use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use repe::{
+    CallContext, HEADER_SIZE, Message, MessageView, QueryFormat, read_message, read_message_into,
+    write_message, write_message_streaming,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::hint::black_box;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Serialize, Deserialize)]
 struct SumIn {
@@ -58,6 +61,23 @@ fn run_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
     write_message(out, &resp).expect("write");
 }
 
+/// The borrowing path: read into a reused buffer, parse a `MessageView`,
+/// dispatch via `handle_view`, and frame the response with the query echoed as
+/// a borrowed slice of the read buffer. No owned request `Message`.
+fn run_cycle_view(router: &Router, wire: &[u8], path: &str, buf: &mut Vec<u8>, out: &mut Vec<u8>) {
+    let mut reader = Cursor::new(wire);
+    read_message_into(&mut reader, buf).expect("read");
+    let view = MessageView::from_slice(buf).expect("view");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let resp = handler.handle_view(&view, &ctx).expect("dispatch");
+    out.clear();
+    write_message_streaming(out, resp.header, view.query, resp.body.len() as u64, |w| {
+        w.write_all(&resp.body)
+    })
+    .expect("write");
+}
+
 fn bench_server_lifecycle(c: &mut Criterion) {
     let json_router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
     let typed_router = Router::new()
@@ -75,6 +95,33 @@ fn bench_server_lifecycle(c: &mut Criterion) {
         b.iter(|| run_cycle(black_box(&typed_router), black_box(&typed_wire), "/sum", &mut out))
     });
     group.finish();
+
+    // Borrowing path: same work, reusable read buffer + MessageView dispatch.
+    let mut buf = Vec::with_capacity(256);
+    let mut view_group = c.benchmark_group("server_lifecycle_view");
+    view_group.bench_function("json_echo", |b| {
+        b.iter(|| {
+            run_cycle_view(
+                black_box(&json_router),
+                black_box(&json_wire),
+                "/echo",
+                &mut buf,
+                &mut out,
+            )
+        })
+    });
+    view_group.bench_function("typed_sum", |b| {
+        b.iter(|| {
+            run_cycle_view(
+                black_box(&typed_router),
+                black_box(&typed_wire),
+                "/sum",
+                &mut buf,
+                &mut out,
+            )
+        })
+    });
+    view_group.finish();
 }
 
 criterion_group!(benches, bench_server_lifecycle);

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -16,6 +16,25 @@ pub async fn read_message_async<R: AsyncRead + Unpin>(r: &mut R) -> Result<Messa
     Message::new(header, query, body)
 }
 
+/// Async counterpart of [`read_message_into`](crate::read_message_into): read a
+/// full REPE frame into `buf`, reusing its allocation across calls. On success
+/// `buf` holds the complete wire frame; parse it with
+/// [`MessageView::from_slice`](crate::MessageView::from_slice) to dispatch
+/// without per-request query/body allocations.
+pub async fn read_message_into_async<R: AsyncRead + Unpin>(
+    r: &mut R,
+    buf: &mut Vec<u8>,
+) -> Result<(), RepeError> {
+    buf.clear();
+    buf.resize(HEADER_SIZE, 0);
+    r.read_exact(&mut buf[..HEADER_SIZE]).await?;
+    let header = Header::decode(&buf[..HEADER_SIZE])?;
+    let total = HEADER_SIZE + header.query_length as usize + header.body_length as usize;
+    buf.resize(total, 0);
+    r.read_exact(&mut buf[HEADER_SIZE..total]).await?;
+    Ok(())
+}
+
 pub async fn write_message_async<W: AsyncWrite + Unpin>(
     w: &mut W,
     msg: &Message,

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -69,7 +69,7 @@ async fn handle_connection(
             read_message_async(&mut reader).await?
         };
 
-        if let Some(resp) = route_request(&router, &req) {
+        if let Some(resp) = route_request(&router, req) {
             if let Some(dur) = write_timeout {
                 timeout(dur, write_message_async(&mut writer, &resp))
                     .await

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -76,14 +76,16 @@ async fn handle_connection(
 
         let view = MessageView::from_slice(&buf)?;
         if let Some(resp) = route_request_view(&router, &view) {
-            // Echo the query as a borrowed slice of `buf`; no response query buffer.
+            // Echo the request query (a borrowed slice of `buf`) unless the
+            // handler set its own; no response query buffer either way.
+            let echo = crate::message::response_echo_query(&resp, view.query);
             if let Some(dur) = write_timeout {
-                timeout(dur, write_view_response(&mut writer, &resp, view.query))
+                timeout(dur, write_view_response(&mut writer, &resp, echo))
                     .await
                     .ok();
                 timeout(dur, writer.flush()).await.ok();
             } else {
-                write_view_response(&mut writer, &resp, view.query).await?;
+                write_view_response(&mut writer, &resp, echo).await?;
                 writer.flush().await?;
             }
         }

--- a/src/async_server.rs
+++ b/src/async_server.rs
@@ -1,9 +1,10 @@
-use crate::async_io::{read_message_async, write_message_async};
+use crate::async_io::read_message_into_async;
+use crate::constants::HEADER_SIZE;
 use crate::error::RepeError;
-use crate::message::Message;
+use crate::message::{Message, MessageView};
 use crate::server::Router;
-use crate::server_request::route_request;
-use tokio::io::AsyncWriteExt;
+use crate::server_request::route_request_view;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::io::{BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 use tokio::time::{Duration, timeout};
@@ -59,28 +60,55 @@ async fn handle_connection(
     let (read_half, write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
     let mut writer = BufWriter::new(write_half);
+    // Reused across every request on this connection so steady-state framing
+    // allocates nothing: each frame is parsed as a borrowed `MessageView` and
+    // the response echoes the query straight out of `buf`.
+    let mut buf = Vec::new();
     loop {
-        let req: Message = if let Some(dur) = read_timeout {
-            match timeout(dur, read_message_async(&mut reader)).await {
+        if let Some(dur) = read_timeout {
+            match timeout(dur, read_message_into_async(&mut reader, &mut buf)).await {
                 Ok(r) => r?,
                 Err(_) => return Ok(()),
             }
         } else {
-            read_message_async(&mut reader).await?
-        };
+            read_message_into_async(&mut reader, &mut buf).await?;
+        }
 
-        if let Some(resp) = route_request(&router, req) {
+        let view = MessageView::from_slice(&buf)?;
+        if let Some(resp) = route_request_view(&router, &view) {
+            // Echo the query as a borrowed slice of `buf`; no response query buffer.
             if let Some(dur) = write_timeout {
-                timeout(dur, write_message_async(&mut writer, &resp))
+                timeout(dur, write_view_response(&mut writer, &resp, view.query))
                     .await
                     .ok();
                 timeout(dur, writer.flush()).await.ok();
             } else {
-                write_message_async(&mut writer, &resp).await?;
+                write_view_response(&mut writer, &resp, view.query).await?;
                 writer.flush().await?;
             }
         }
     }
+}
+
+/// Write a query-less response framed with an externally supplied (borrowed)
+/// query, the async counterpart of the TCP server's `write_message_streaming`
+/// call. Patches the header's `query_length`/`length` to match `query`.
+async fn write_view_response<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    resp: &Message,
+    query: &[u8],
+) -> Result<(), RepeError> {
+    let mut header = resp.header;
+    header.query_length = query.len() as u64;
+    header.length = HEADER_SIZE as u64 + header.query_length + header.body_length;
+    writer.write_all(&header.encode()).await?;
+    if !query.is_empty() {
+        writer.write_all(query).await?;
+    }
+    if !resp.body.is_empty() {
+        writer.write_all(&resp.body).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/io.rs
+++ b/src/io.rs
@@ -18,6 +18,28 @@ pub fn read_message<R: Read>(r: &mut R) -> Result<Message, RepeError> {
     Message::new(header, query, body)
 }
 
+/// Read a full REPE message frame into `buf`, reusing its allocation across
+/// calls.
+///
+/// On success `buf` holds the complete wire frame (header + query + body) and
+/// can be parsed with [`MessageView::from_slice`](crate::MessageView::from_slice)
+/// to dispatch without the per-request query and body `Vec` allocations that
+/// [`read_message`] makes. A server reading many requests on one connection
+/// keeps one `buf` and reuses it, so steady-state framing is allocation-free.
+///
+/// `buf` is cleared first; its capacity is retained, so once it has grown to the
+/// largest frame seen no further allocation occurs.
+pub fn read_message_into<R: Read>(r: &mut R, buf: &mut Vec<u8>) -> Result<(), RepeError> {
+    buf.clear();
+    buf.resize(HEADER_SIZE, 0);
+    read_exact(r, &mut buf[..HEADER_SIZE])?;
+    let header = Header::decode(&buf[..HEADER_SIZE])?;
+    let total = HEADER_SIZE + header.query_length as usize + header.body_length as usize;
+    buf.resize(total, 0);
+    read_exact(r, &mut buf[HEADER_SIZE..total])?;
+    Ok(())
+}
+
 /// Write a full REPE message to a stream implementing `Write`.
 pub fn write_message<W: Write>(w: &mut W, msg: &Message) -> Result<(), RepeError> {
     let header_bytes = msg.header.encode();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use fleet::{
 };
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
-pub use io::{read_message, write_message, write_message_streaming};
+pub use io::{read_message, read_message_into, write_message, write_message_streaming};
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 pub use message::{Message, MessageView};
 pub use peer::{

--- a/src/message.rs
+++ b/src/message.rs
@@ -248,6 +248,19 @@ impl<'a> MessageView<'a> {
     pub fn query_str(&self) -> Result<&'a str, std::str::Utf8Error> {
         std::str::from_utf8(self.query)
     }
+
+    /// Copy this borrowed view into an owned [`Message`], allocating the query
+    /// and body. Used as the fallback for [`HandlerErased::handle_view`] when a
+    /// handler has not overridden the borrowing path.
+    ///
+    /// [`HandlerErased::handle_view`]: crate::server::HandlerErased::handle_view
+    pub fn to_message(&self) -> Message {
+        Message {
+            header: self.header,
+            query: self.query.to_vec(),
+            body: self.body.to_vec(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -821,6 +834,33 @@ pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8
     response.header.query_length = response.query.len() as u64;
     response.header.length =
         HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
+}
+
+/// Borrowing twin of [`create_response_unstamped`]: builds the same query-less
+/// success response from a [`MessageView`], without materializing an owned
+/// request. The view's query is echoed by the writer (e.g.
+/// [`write_message_streaming`] with the borrowed query), not by this builder.
+pub(crate) fn create_response_unstamped_view(
+    view: &MessageView,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(view.header.id, view.header.query_format);
+    finish_response(builder, result, body_format)
+}
+
+/// Borrowing, query-less error response from a [`MessageView`]. Mirrors
+/// [`create_error_response_like`] but leaves the query empty for the writer to
+/// supply from the borrowed view.
+pub(crate) fn create_error_response_unstamped_view(
+    view: &MessageView,
+    code: ErrorCode,
+    msg: impl AsRef<str>,
+) -> Message {
+    let mut err = create_error_message(code, msg.as_ref());
+    err.header.id = view.header.id;
+    err.header.query_format = view.header.query_format;
+    err
 }
 
 /// Shared response-builder prefix: echo the request id and query format with an

--- a/src/message.rs
+++ b/src/message.rs
@@ -244,6 +244,22 @@ impl<'a> MessageView<'a> {
         })
     }
 
+    /// Like [`from_slice`](Self::from_slice) but rejects trailing bytes: errors
+    /// if `buf` is longer than the framed message. The borrowing counterpart of
+    /// [`Message::from_slice_exact`], for transports (e.g. a WebSocket binary
+    /// frame) that carry exactly one message per buffer.
+    pub fn from_slice_exact(buf: &'a [u8]) -> Result<Self, RepeError> {
+        let view = Self::from_slice(buf)?;
+        let expected = HEADER_SIZE + view.query.len() + view.body.len();
+        if buf.len() != expected {
+            return Err(RepeError::LengthMismatch {
+                expected: expected as u64,
+                got: buf.len() as u64,
+            });
+        }
+        Ok(view)
+    }
+
     /// View the query as a `&str`. Errors if the query is not valid UTF-8.
     pub fn query_str(&self) -> Result<&'a str, std::str::Utf8Error> {
         std::str::from_utf8(self.query)

--- a/src/message.rs
+++ b/src/message.rs
@@ -729,14 +729,46 @@ pub fn create_response(
     result: impl serde::Serialize,
     body_format: BodyFormat,
 ) -> Result<Message, RepeError> {
-    let mut builder = Message::builder()
-        .id(request.header.id)
-        .query_bytes(request.query.clone())
-        .query_format(
-            QueryFormat::try_from(request.header.query_format).unwrap_or(QueryFormat::RawBinary),
-        )
-        .error_code(ErrorCode::Ok);
-    builder = match body_format {
+    let builder = response_header_builder(request.header.id, request.header.query_format)
+        .query_bytes(request.query.clone());
+    finish_response(builder, result, body_format)
+}
+
+/// Like [`create_response`], but consumes `request` so the response reuses the
+/// request's `query` buffer (an owned `Vec<u8>` move) instead of cloning it.
+///
+/// The response always echoes the request query verbatim, so on a dispatch path
+/// that owns the request and drops it right after responding, moving the buffer
+/// removes the per-response allocation + copy that [`create_response`] pays.
+/// The request body has already been consumed to produce `result` by the time
+/// this is called, so dropping the rest of `request` costs nothing extra.
+pub fn create_response_owned(
+    request: Message,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(request.header.id, request.header.query_format)
+        .query_bytes(request.query); // moved, not cloned
+    finish_response(builder, result, body_format)
+}
+
+/// Shared response-builder prefix: echo the request id and query format with an
+/// `Ok` error code. The caller supplies the query bytes (cloned or moved).
+fn response_header_builder(id: u64, query_format: u16) -> MessageBuilder {
+    Message::builder()
+        .id(id)
+        .query_format(QueryFormat::try_from(query_format).unwrap_or(QueryFormat::RawBinary))
+        .error_code(ErrorCode::Ok)
+}
+
+/// Serialize `result` into the response body per `body_format` and build the
+/// message. Shared by [`create_response`] and [`create_response_owned`].
+fn finish_response(
+    builder: MessageBuilder,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = match body_format {
         BodyFormat::Json => builder.body_json(&result)?,
         BodyFormat::Utf8 => {
             let s = serde_json::to_string(&result)?; // convenience: stringify

--- a/src/message.rs
+++ b/src/message.rs
@@ -826,6 +826,9 @@ pub(crate) fn create_response_unstamped(
 /// the request query is empty, so it is safe to call on every dispatched
 /// response. Built-in handlers leave the query empty precisely so this stamp
 /// echoes it with a buffer move instead of a clone.
+// Used by the owned dispatch boundary, which the WebSocket server takes; the
+// TCP/async servers echo the query through the borrowing path instead.
+#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8>) {
     if request_query.is_empty() || !response.query.is_empty() {
         return;

--- a/src/message.rs
+++ b/src/message.rs
@@ -403,6 +403,45 @@ mod tests {
     }
 
     #[test]
+    fn error_response_view_matches_owned_query_format() {
+        // The borrowing error path must frame byte-identically to the owned
+        // (WebSocket) path. Both leave query_format at the create_error_message
+        // default (RawBinary), so a JsonPointer request still yields the same
+        // error frame regardless of transport.
+        let req = Message::builder()
+            .id(9)
+            .query_str("/missing")
+            .query_format(QueryFormat::JsonPointer)
+            .body_utf8("{}")
+            .build();
+        let owned = create_error_response_like(&req, ErrorCode::MethodNotFound, "nope");
+
+        let bytes = req.to_vec();
+        let view = MessageView::from_slice(&bytes).unwrap();
+        let viewed = create_error_response_unstamped_view(&view, ErrorCode::MethodNotFound, "nope");
+
+        assert_eq!(viewed.header.query_format, owned.header.query_format);
+        assert_eq!(viewed.header.id, owned.header.id);
+        assert_eq!(viewed.header.ec, owned.header.ec);
+        assert_eq!(viewed.body, owned.body);
+    }
+
+    #[test]
+    fn response_echo_query_prefers_a_handler_set_query() {
+        // Empty response query -> echo the request query (the common case).
+        let empty = Message::builder().id(1).build();
+        assert_eq!(response_echo_query(&empty, b"/req"), b"/req");
+
+        // A query the handler set itself is preserved, not overwritten.
+        let custom = Message::builder()
+            .id(1)
+            .query_str("/handler-set")
+            .query_format(QueryFormat::JsonPointer)
+            .build();
+        assert_eq!(response_echo_query(&custom, b"/req"), b"/handler-set");
+    }
+
+    #[test]
     fn create_response_propagates_serialization_error() {
         struct Fails;
 
@@ -779,24 +818,6 @@ pub fn create_response(
     finish_response(builder, result, body_format)
 }
 
-/// Like [`create_response`], but consumes `request` so the response reuses the
-/// request's `query` buffer (an owned `Vec<u8>` move) instead of cloning it.
-///
-/// The response always echoes the request query verbatim, so on a dispatch path
-/// that owns the request and drops it right after responding, moving the buffer
-/// removes the per-response allocation + copy that [`create_response`] pays.
-/// The request body has already been consumed to produce `result` by the time
-/// this is called, so dropping the rest of `request` costs nothing extra.
-pub fn create_response_owned(
-    request: Message,
-    result: impl serde::Serialize,
-    body_format: BodyFormat,
-) -> Result<Message, RepeError> {
-    let builder = response_header_builder(request.header.id, request.header.query_format)
-        .query_bytes(request.query); // moved, not cloned
-    finish_response(builder, result, body_format)
-}
-
 /// Build a success response that leaves the query **empty**, for the dispatch
 /// boundary to fill by moving the request's query in (see
 /// [`stamp_response_query`]).
@@ -839,6 +860,22 @@ pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8
         HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
 }
 
+/// Pick the query bytes the borrowing dispatch path frames `response` with.
+///
+/// The borrowing twin of [`stamp_response_query`]: the request query (a borrowed
+/// slice of the read buffer) is echoed when the handler left the response query
+/// empty, but a query the handler set itself is preserved. Keeps the TCP/async
+/// borrowing writers consistent with the owned/WebSocket path on the
+/// [`HandlerErased`](crate::server::HandlerErased) custom-response-query
+/// contract, instead of unconditionally overwriting with the request query.
+pub(crate) fn response_echo_query<'a>(response: &'a Message, request_query: &'a [u8]) -> &'a [u8] {
+    if response.query.is_empty() {
+        request_query
+    } else {
+        &response.query
+    }
+}
+
 /// Borrowing twin of [`create_response_unstamped`]: builds the same query-less
 /// success response from a [`MessageView`], without materializing an owned
 /// request. The view's query is echoed by the writer (e.g.
@@ -853,8 +890,10 @@ pub(crate) fn create_response_unstamped_view(
 }
 
 /// Borrowing, query-less error response from a [`MessageView`]. Mirrors
-/// [`create_error_response_like`] but leaves the query empty for the writer to
-/// supply from the borrowed view.
+/// [`create_error_response_like`] exactly: it sets only the request id and leaves
+/// the query empty (for the writer to supply from the borrowed view) and the
+/// `query_format` at its [`create_error_message`] default, so a view-path error
+/// frame is byte-identical to the owned/WebSocket path's.
 pub(crate) fn create_error_response_unstamped_view(
     view: &MessageView,
     code: ErrorCode,
@@ -862,7 +901,6 @@ pub(crate) fn create_error_response_unstamped_view(
 ) -> Message {
     let mut err = create_error_message(code, msg.as_ref());
     err.header.id = view.header.id;
-    err.header.query_format = view.header.query_format;
     err
 }
 
@@ -876,7 +914,8 @@ fn response_header_builder(id: u64, query_format: u16) -> MessageBuilder {
 }
 
 /// Serialize `result` into the response body per `body_format` and build the
-/// message. Shared by [`create_response`] and [`create_response_owned`].
+/// message. Shared by [`create_response`], [`create_response_unstamped`], and the
+/// `*_view` builders.
 fn finish_response(
     builder: MessageBuilder,
     result: impl serde::Serialize,

--- a/src/message.rs
+++ b/src/message.rs
@@ -358,6 +358,38 @@ mod tests {
     }
 
     #[test]
+    fn unstamped_plus_stamp_equals_create_response() {
+        let req = Message::builder()
+            .id(5)
+            .query_str("/sum")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&Pair { a: 1, b: 2 })
+            .unwrap()
+            .build();
+        let value = serde_json::json!({"ok": true});
+
+        // The echoing path.
+        let echoed = create_response(&req, &value, BodyFormat::Json).unwrap();
+
+        // The boundary path: build query-less, then stamp the moved query.
+        let mut staged = create_response_unstamped(&req, &value, BodyFormat::Json).unwrap();
+        assert!(staged.query.is_empty(), "handler leaves the query empty");
+        assert_eq!(staged.header.query_length, 0);
+        stamp_response_query(&mut staged, req.query.clone());
+
+        // Byte-for-byte identical to the echoing path, including the header.
+        assert_eq!(staged, echoed);
+        assert_eq!(staged.query, req.query);
+        assert_eq!(staged.header.length, echoed.header.length);
+
+        // Stamp is a no-op once a query is present (e.g. an error response) and
+        // when the request query is empty.
+        let before = staged.clone();
+        stamp_response_query(&mut staged, b"/other".to_vec());
+        assert_eq!(staged, before, "stamp must not overwrite an existing query");
+    }
+
+    #[test]
     fn create_response_propagates_serialization_error() {
         struct Fails;
 
@@ -750,6 +782,45 @@ pub fn create_response_owned(
     let builder = response_header_builder(request.header.id, request.header.query_format)
         .query_bytes(request.query); // moved, not cloned
     finish_response(builder, result, body_format)
+}
+
+/// Build a success response that leaves the query **empty**, for the dispatch
+/// boundary to fill by moving the request's query in (see
+/// [`stamp_response_query`]).
+///
+/// REPE responses echo the request query verbatim. Rather than have each
+/// built-in handler clone the request query into its response, the handlers
+/// build the response with this and the transport boundary — which owns the
+/// request and drops it right after — moves the query buffer in. That turns the
+/// per-response query echo from an allocation + copy into a buffer move.
+///
+/// Byte-for-byte equivalent to [`create_response`] once
+/// [`stamp_response_query`] has run with the originating request's query.
+pub(crate) fn create_response_unstamped(
+    request: &Message,
+    result: impl serde::Serialize,
+    body_format: BodyFormat,
+) -> Result<Message, RepeError> {
+    let builder = response_header_builder(request.header.id, request.header.query_format);
+    finish_response(builder, result, body_format)
+}
+
+/// Move `request_query` into a response left query-less by
+/// [`create_response_unstamped`], fixing up the header lengths.
+///
+/// A no-op when the response already carries a query (an error response from
+/// [`create_error_response_like`], or a custom handler that set its own) or when
+/// the request query is empty, so it is safe to call on every dispatched
+/// response. Built-in handlers leave the query empty precisely so this stamp
+/// echoes it with a buffer move instead of a clone.
+pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8>) {
+    if request_query.is_empty() || !response.query.is_empty() {
+        return;
+    }
+    response.query = request_query;
+    response.header.query_length = response.query.len() as u64;
+    response.header.length =
+        HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
 }
 
 /// Shared response-builder prefix: echo the request id and query format with an

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@ use crate::constants::{BodyFormat, ErrorCode, HEADER_SIZE, QueryFormat};
 use crate::error::RepeError;
 use crate::header::Header;
 use beve::{Error as BeveError, from_slice as beve_from_slice, to_vec as beve_to_vec};
+use std::borrow::Cow;
 use std::io::{self, Write};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -400,11 +401,13 @@ mod tests {
         // The echoing path.
         let echoed = create_response(&req, &value, BodyFormat::Json).unwrap();
 
-        // The boundary path: build query-less, then stamp the moved query.
+        // The boundary path: build query-less, then stamp the request query in.
+        // The off-reader boundary owns its request, so it moves the buffer in
+        // (`Cow::Owned`, no copy).
         let mut staged = create_response_unstamped(&req, &value, BodyFormat::Json).unwrap();
         assert!(staged.query.is_empty(), "handler leaves the query empty");
         assert_eq!(staged.header.query_length, 0);
-        stamp_response_query(&mut staged, req.query.clone());
+        stamp_response_query(&mut staged, Cow::Owned(req.query.clone()));
 
         // Byte-for-byte identical to the echoing path, including the header.
         assert_eq!(staged, echoed);
@@ -412,9 +415,9 @@ mod tests {
         assert_eq!(staged.header.length, echoed.header.length);
 
         // Stamp is a no-op once a query is present (e.g. an error response) and
-        // when the request query is empty.
+        // when the request query is empty; a borrowed query is then never copied.
         let before = staged.clone();
-        stamp_response_query(&mut staged, b"/other".to_vec());
+        stamp_response_query(&mut staged, Cow::Borrowed(&b"/other"[..]));
         assert_eq!(staged, before, "stamp must not overwrite an existing query");
     }
 
@@ -855,22 +858,27 @@ pub(crate) fn create_response_unstamped(
     finish_response(builder, result, body_format)
 }
 
-/// Move `request_query` into a response left query-less by
-/// [`create_response_unstamped`], fixing up the header lengths.
+/// Echo `request_query` into a response left query-less by
+/// [`create_response_unstamped`] / [`create_response_unstamped_view`], fixing up
+/// the header lengths.
 ///
 /// A no-op when the response already carries a query (an error response from
 /// [`create_error_response_like`], or a custom handler that set its own) or when
 /// the request query is empty, so it is safe to call on every dispatched
-/// response. Built-in handlers leave the query empty precisely so this stamp
-/// echoes it with a buffer move instead of a clone.
-// Used by the owned dispatch boundary, which the WebSocket server takes; the
-// TCP/async servers echo the query through the borrowing path instead.
+/// response. Takes a [`Cow`] so the owned/WebSocket off-reader boundary moves its
+/// request query buffer straight in (`Cow::Owned`, no copy), while the
+/// WebSocket-inline path passes a borrowed slice of the read buffer
+/// (`Cow::Borrowed`) that is copied only when the stamp actually commits -- so a
+/// custom-query handler that set its own response query pays no allocation.
+// Used only by the WebSocket server: the off-reader path moves its owned request
+// query in, the inline path copies the borrowed view query. The TCP/async servers
+// echo through `response_echo_query` (a pure borrow) instead.
 #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
-pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8>) {
+pub(crate) fn stamp_response_query(response: &mut Message, request_query: Cow<[u8]>) {
     if request_query.is_empty() || !response.query.is_empty() {
         return;
     }
-    response.query = request_query;
+    response.query = request_query.into_owned();
     response.header.query_length = response.query.len() as u64;
     response.header.length =
         HEADER_SIZE as u64 + response.header.query_length + response.header.body_length;
@@ -884,6 +892,9 @@ pub(crate) fn stamp_response_query(response: &mut Message, request_query: Vec<u8
 /// borrowing writers consistent with the owned/WebSocket path on the
 /// [`HandlerErased`](crate::server::HandlerErased) custom-response-query
 /// contract, instead of unconditionally overwriting with the request query.
+// Called only from the TCP and async servers' borrowing writers, both
+// `#[cfg(not(target_arch = "wasm32"))]`, so it is dead on a wasm build.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn response_echo_query<'a>(response: &'a Message, request_query: &'a [u8]) -> &'a [u8] {
     if response.query.is_empty() {
         request_query

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -351,10 +351,17 @@ fn parse_registration_path(path: &str) -> Result<Vec<String>, RegistryError> {
     if path.is_empty() {
         return Ok(Vec::new());
     }
-    if path.starts_with('/') {
-        return parse_pointer(path);
-    }
-    parse_pointer(&format!("/{path}"))
+    // Registration is not on the hot path; own the segments so they outlive the
+    // (possibly synthesized) normalized pointer and slot into the value tree.
+    let normalized: Cow<'_, str> = if path.starts_with('/') {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(format!("/{path}"))
+    };
+    Ok(parse_pointer(&normalized)?
+        .into_iter()
+        .map(Cow::into_owned)
+        .collect())
 }
 
 /// Compute the canonical JSON-Pointer key used to probe `RegistryState::functions`,
@@ -390,7 +397,12 @@ fn canonical_key(pointer: &str) -> Result<Cow<'_, str>, RegistryError> {
     Ok(Cow::Owned(canonical_pointer(&parse_pointer(pointer)?)))
 }
 
-fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
+/// Parse a JSON Pointer into its reference tokens, borrowing each token from
+/// `pointer` when it needs no unescaping (the common case) and allocating only
+/// for tokens that contain a `~` escape. The returned tokens borrow `pointer`,
+/// so the value-tree walk in `resolve_ref`/`resolve_mut`/`set_pointer` resolves
+/// without a per-segment `String` allocation.
+fn parse_pointer(pointer: &str) -> Result<Vec<Cow<'_, str>>, RegistryError> {
     if pointer.is_empty() || pointer == "/" {
         return Ok(Vec::new());
     }
@@ -409,7 +421,12 @@ fn parse_pointer(pointer: &str) -> Result<Vec<String>, RegistryError> {
         })
 }
 
-fn unescape_token(token: &str) -> Result<String, ()> {
+fn unescape_token(token: &str) -> Result<Cow<'_, str>, ()> {
+    // Escape-free tokens are already their own unescaped form: borrow them
+    // rather than allocating a fresh `String` per segment.
+    if !token.contains('~') {
+        return Ok(Cow::Borrowed(token));
+    }
     let mut out = String::with_capacity(token.len());
     let mut chars = token.chars();
     while let Some(c) = chars.next() {
@@ -426,25 +443,23 @@ fn unescape_token(token: &str) -> Result<String, ()> {
             _ => return Err(()),
         }
     }
-    Ok(out)
+    Ok(Cow::Owned(out))
 }
 
 fn escape_token(token: &str) -> String {
     token.replace('~', "~0").replace('/', "~1")
 }
 
-fn canonical_pointer(segments: &[String]) -> String {
+fn canonical_pointer<S: AsRef<str>>(segments: &[S]) -> String {
     if segments.is_empty() {
         "/".to_string()
     } else {
-        format!(
-            "/{}",
-            segments
-                .iter()
-                .map(|segment| escape_token(segment))
-                .collect::<Vec<_>>()
-                .join("/")
-        )
+        let mut out = String::new();
+        for segment in segments {
+            out.push('/');
+            out.push_str(&escape_token(segment.as_ref()));
+        }
+        out
     }
 }
 
@@ -483,17 +498,21 @@ fn ensure_object_parent<'a>(
     Ok(current)
 }
 
-fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, RegistryError> {
+fn resolve_ref<'a, S: AsRef<str>>(
+    root: &'a Value,
+    segments: &[S],
+) -> Result<&'a Value, RegistryError> {
     let mut current = root;
-    let mut walked: Vec<String> = Vec::new();
-    for segment in segments {
-        walked.push(segment.clone());
+    for (i, segment) in segments.iter().enumerate() {
+        // Error paths are computed lazily from `segments[..=i]`, so the success
+        // path neither clones segments nor grows a `walked` vector.
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&walked),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -501,19 +520,19 @@ fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, Re
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current = array
                     .get(index)
                     .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                        path: canonical_pointer(&walked),
-                        segment: segment.clone(),
+                        path: canonical_pointer(&segments[..=i]),
+                        segment: segment.to_string(),
                     })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&walked),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
@@ -521,20 +540,19 @@ fn resolve_ref<'a>(root: &'a Value, segments: &[String]) -> Result<&'a Value, Re
     Ok(current)
 }
 
-fn resolve_mut<'a>(
+fn resolve_mut<'a, S: AsRef<str>>(
     root: &'a mut Value,
-    segments: &[String],
+    segments: &[S],
 ) -> Result<&'a mut Value, RegistryError> {
     let mut current = root;
-    let mut walked: Vec<String> = Vec::new();
-    for segment in segments {
-        walked.push(segment.clone());
+    for (i, segment) in segments.iter().enumerate() {
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get_mut(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&walked),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -542,20 +560,20 @@ fn resolve_mut<'a>(
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current =
                     array
                         .get_mut(index)
                         .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                            path: canonical_pointer(&walked),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&walked),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
@@ -563,22 +581,26 @@ fn resolve_mut<'a>(
     Ok(current)
 }
 
-fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<(), RegistryError> {
+fn set_pointer<S: AsRef<str>>(
+    root: &mut Value,
+    segments: &[S],
+    value: Value,
+) -> Result<(), RegistryError> {
     if segments.is_empty() {
         *root = value;
         return Ok(());
     }
 
-    let mut parent_path = Vec::new();
+    let parent_len = segments.len() - 1;
     let mut current = root;
-    for segment in &segments[..segments.len() - 1] {
-        parent_path.push(segment.clone());
+    for (i, segment) in segments[..parent_len].iter().enumerate() {
+        let segment = segment.as_ref();
         match current {
             Value::Object(map) => {
                 current = map
                     .get_mut(segment)
                     .ok_or_else(|| RegistryError::PathNotFound {
-                        path: canonical_pointer(&parent_path),
+                        path: canonical_pointer(&segments[..=i]),
                     })?;
             }
             Value::Array(array) => {
@@ -586,29 +608,29 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
                     segment
                         .parse::<usize>()
                         .map_err(|_| RegistryError::InvalidArrayIndex {
-                            path: canonical_pointer(&parent_path),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
                 current =
                     array
                         .get_mut(index)
                         .ok_or_else(|| RegistryError::ArrayIndexOutOfBounds {
-                            path: canonical_pointer(&parent_path),
-                            segment: segment.clone(),
+                            path: canonical_pointer(&segments[..=i]),
+                            segment: segment.to_string(),
                         })?;
             }
             _ => {
                 return Err(RegistryError::PathNotFound {
-                    path: canonical_pointer(&parent_path),
+                    path: canonical_pointer(&segments[..=i]),
                 });
             }
         }
     }
 
-    let last = segments.last().unwrap();
+    let last = segments[parent_len].as_ref();
     match current {
         Value::Object(map) => {
-            map.insert(last.clone(), value);
+            map.insert(last.to_string(), value);
             Ok(())
         }
         Value::Array(array) => {
@@ -616,7 +638,7 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
                 .parse::<usize>()
                 .map_err(|_| RegistryError::InvalidArrayIndex {
                     path: canonical_pointer(segments),
-                    segment: last.clone(),
+                    segment: last.to_string(),
                 })?;
             if let Some(slot) = array.get_mut(index) {
                 *slot = value;
@@ -624,7 +646,7 @@ fn set_pointer(root: &mut Value, segments: &[String], value: Value) -> Result<()
             } else {
                 Err(RegistryError::ArrayIndexOutOfBounds {
                     path: canonical_pointer(segments),
-                    segment: last.clone(),
+                    segment: last.to_string(),
                 })
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1520,9 +1520,13 @@ fn handle_connection(
             // handler set its own — matching the owned path's stamp rule — so no
             // query buffer is copied into the response on the common path.
             let echo = crate::message::response_echo_query(&resp, view.query);
-            write_message_streaming(&mut writer, resp.header, echo, resp.body.len() as u64, |w| {
-                w.write_all(&resp.body)
-            })?;
+            write_message_streaming(
+                &mut writer,
+                resp.header,
+                echo,
+                resp.body.len() as u64,
+                |w| w.write_all(&resp.body),
+            )?;
             writer.flush()?;
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,10 @@ use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
-use crate::message::{Message, create_error_response_like, create_response_unstamped};
+use crate::message::{
+    Message, MessageView, create_error_response_like, create_error_response_unstamped_view,
+    create_response_unstamped, create_response_unstamped_view,
+};
 use crate::peer::{CallContext, PeerHandle};
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
@@ -83,6 +86,26 @@ pub trait HandlerErased: Send + Sync {
     /// [`CallContext::detached`]).
     fn handle_with_ctx(&self, req: &Message, _ctx: &CallContext) -> Result<Message, RepeError> {
         self.handle(req)
+    }
+
+    /// Borrowing dispatch: handle a request given a borrowed [`MessageView`]
+    /// instead of an owned [`Message`].
+    ///
+    /// A server that reads each frame into a reusable per-connection buffer (see
+    /// [`read_message_into`](crate::read_message_into)) can dispatch through this
+    /// method without the per-request query and body `Vec` allocations that an
+    /// owned [`Message`] requires. As with [`handle_with_ctx`](Self::handle_with_ctx),
+    /// the returned response leaves its query empty; the writer supplies the
+    /// echoed query from the borrowed view.
+    ///
+    /// The default implementation materializes an owned [`Message`] from the view
+    /// (copying the query and body) and delegates to
+    /// [`handle_with_ctx`](Self::handle_with_ctx), so existing handlers work
+    /// unchanged. The built-in handlers override it to decode straight from the
+    /// borrowed body and skip those copies.
+    #[doc(hidden)]
+    fn handle_view(&self, view: &MessageView, ctx: &CallContext) -> Result<Message, RepeError> {
+        self.handle_with_ctx(&view.to_message(), ctx)
     }
 
     /// Where this handler should be dispatched. Defaults to
@@ -238,6 +261,24 @@ fn decode_json_param(req: &Message) -> Result<Result<Value, Message>, RepeError>
     Ok(Ok(value))
 }
 
+/// Borrowing twin of [`decode_json_param`]: decode the request body straight
+/// from the borrowed view, with no owned `Message`. The UTF-8 branch parses the
+/// bytes directly (`from_slice`) rather than via an intermediate `String`.
+fn decode_json_param_view(view: &MessageView) -> Result<Result<Value, Message>, RepeError> {
+    let value: Value = match BodyFormat::try_from(view.header.body_format) {
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(view.body)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(view.body)?,
+        _ => {
+            return Ok(Err(create_error_response_unstamped_view(
+                view,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
+}
+
 struct JsonHandler<F>(F)
 where
     F: Fn(Value) -> Result<Value, (ErrorCode, String)> + Send + Sync + 'static;
@@ -254,6 +295,17 @@ where
         match (self.0)(param) {
             Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+
+    fn handle_view(&self, view: &MessageView, _ctx: &CallContext) -> Result<Message, RepeError> {
+        let param = match decode_json_param_view(view)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match (self.0)(param) {
+            Ok(value) => create_response_unstamped_view(view, value, BodyFormat::Json),
+            Err((code, msg)) => Ok(create_error_response_unstamped_view(view, code, msg)),
         }
     }
 }
@@ -371,6 +423,27 @@ where
     Ok(Ok(value))
 }
 
+/// Borrowing twin of [`decode_typed_param`]: deserialize `T` straight from the
+/// borrowed view body, with no owned `Message` and no intermediate `String` on
+/// the UTF-8 branch.
+fn decode_typed_param_view<T>(view: &MessageView) -> Result<Result<T, Message>, RepeError>
+where
+    T: DeserializeOwned,
+{
+    let value: T = match BodyFormat::try_from(view.header.body_format) {
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(view.body)?,
+        Ok(BodyFormat::Beve) => beve_from_slice(view.body)?,
+        _ => {
+            return Ok(Err(create_error_response_unstamped_view(
+                view,
+                ErrorCode::InvalidBody,
+                "Expected JSON body",
+            )));
+        }
+    };
+    Ok(Ok(value))
+}
+
 struct TypedHandler<T, R, F>(F, std::marker::PhantomData<(T, R)>)
 where
     T: DeserializeOwned + Send + Sync + 'static,
@@ -394,6 +467,20 @@ where
                 create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+
+    fn handle_view(&self, view: &MessageView, _ctx: &CallContext) -> Result<Message, RepeError> {
+        let t: T = match decode_typed_param_view(view)? {
+            Ok(v) => v,
+            Err(err) => return Ok(err),
+        };
+        match self.0.call(t) {
+            Ok(r) => {
+                let (value, format) = r.into_typed_response();
+                create_response_unstamped_view(view, value, format)
+            }
+            Err((code, msg)) => Ok(create_error_response_unstamped_view(view, code, msg)),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::io::{read_message, write_message};
+use crate::io::{read_message_into, write_message_streaming};
 use crate::message::{
     Message, MessageView, create_error_response_like, create_error_response_unstamped_view,
     create_response_unstamped, create_response_unstamped_view,
@@ -9,7 +9,7 @@ use crate::message::{
 use crate::peer::{CallContext, PeerHandle};
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::server_request::route_request;
+use crate::server_request::route_request_view;
 use crate::structs::RepeStruct;
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
@@ -1506,14 +1506,23 @@ fn handle_connection(
     stream.set_write_timeout(write_timeout)?;
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut writer = BufWriter::new(stream);
+    // One read buffer reused for every request on this connection, so steady-
+    // state request framing allocates nothing: the frame is parsed as a borrowed
+    // `MessageView` and the response echoes the query straight out of `buf`.
+    let mut buf = Vec::new();
     while running.load(Ordering::SeqCst) {
-        let req = match read_message(&mut reader) {
-            Ok(m) => m,
+        match read_message_into(&mut reader, &mut buf) {
+            Ok(()) => {}
             Err(RepeError::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(e) => return Err(e),
-        };
-        if let Some(resp) = route_request(&router, req) {
-            write_message(&mut writer, &resp)?;
+        }
+        let view = MessageView::from_slice(&buf)?;
+        if let Some(resp) = route_request_view(&router, &view) {
+            // Frame the query-less response, echoing the query as a borrowed
+            // slice of `buf` rather than copying it into the response.
+            write_message_streaming(&mut writer, resp.header, view.query, resp.body.len() as u64, |w| {
+                w.write_all(&resp.body)
+            })?;
             writer.flush()?;
         }
     }
@@ -1523,6 +1532,7 @@ fn handle_connection(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::io::{read_message, write_message};
     use crate::message::create_response;
     use crate::{QueryFormat, REPE_VERSION};
     use serde::{Deserialize, Serialize};

--- a/src/server.rs
+++ b/src/server.rs
@@ -251,8 +251,9 @@ impl<H: HandlerErased> HandlerErased for OffReaderHandler<H> {
 
 fn decode_json_param(req: &Message) -> Result<Result<Value, Message>, RepeError> {
     let value: Value = match BodyFormat::try_from(req.header.body_format) {
-        Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
-        Ok(BodyFormat::Utf8) => serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?,
+        // JSON requires UTF-8, so a Utf8-framed body parses straight from the
+        // bytes too — strict and allocation-free, matching the borrowing path.
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(&req.body)?,
         Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
         _ => {
             return Ok(Err(create_error_response_like(
@@ -413,8 +414,7 @@ where
     T: DeserializeOwned,
 {
     let value: T = match BodyFormat::try_from(req.header.body_format) {
-        Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
-        Ok(BodyFormat::Utf8) => serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?,
+        Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(&req.body)?,
         Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
         _ => {
             return Ok(Err(create_error_response_like(
@@ -1275,11 +1275,8 @@ where
             None
         } else {
             match BodyFormat::try_from(req.header.body_format) {
-                Ok(BodyFormat::Json) => {
+                Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => {
                     Some(serde_json::from_slice::<Value>(&req.body).map_err(RepeError::from)?)
-                }
-                Ok(BodyFormat::Utf8) => {
-                    Some(serde_json::from_str::<Value>(&req.body_utf8()).map_err(RepeError::from)?)
                 }
                 Ok(BodyFormat::Beve) => Some(beve_from_slice(&req.body)?),
                 Ok(BodyFormat::RawBinary) | Err(_) => {
@@ -1403,10 +1400,7 @@ struct JsonTypedAdapter<H: JsonTypedHandler>(H);
 impl<H: JsonTypedHandler> HandlerErased for JsonTypedAdapter<H> {
     fn handle(&self, req: &Message) -> Result<Message, RepeError> {
         let t: H::In = match BodyFormat::try_from(req.header.body_format) {
-            Ok(BodyFormat::Json) => serde_json::from_slice(&req.body)?,
-            Ok(BodyFormat::Utf8) => {
-                serde_json::from_str(&req.body_utf8()).map_err(RepeError::from)?
-            }
+            Ok(BodyFormat::Json) | Ok(BodyFormat::Utf8) => serde_json::from_slice(&req.body)?,
             Ok(BodyFormat::Beve) => beve_from_slice(&req.body)?,
             _ => {
                 return Ok(create_error_response_like(

--- a/src/server.rs
+++ b/src/server.rs
@@ -51,13 +51,13 @@ pub enum Execution {
 /// # Response query echo
 ///
 /// REPE responses echo the request's query verbatim, but that echo is the
-/// **dispatch layer's** responsibility, not the handler's. The built-in
-/// handlers return responses with an *empty* query; the server
-/// ([`Server`], [`AsyncServer`](crate::AsyncServer), and the WebSocket
-/// server) then moves the request's query buffer into the response after
-/// the handler returns (see `route_request` and the WebSocket dispatch
-/// loop). This turns the per-response query echo from a clone into a buffer
-/// move.
+/// **dispatch layer's** responsibility, not the handler's: the built-in
+/// handlers return responses with an *empty* query. The WebSocket server moves
+/// the request's query buffer into the response after the handler returns; the
+/// TCP ([`Server`]) and async ([`AsyncServer`](crate::AsyncServer)) servers
+/// take the borrowing [`handle_view`](Self::handle_view) path and frame the
+/// response with the query borrowed straight from their read buffer. Either way
+/// the per-response query echo costs no allocation.
 ///
 /// Two consequences:
 ///
@@ -67,8 +67,9 @@ pub enum Execution {
 ///   needs a complete, query-echoing response without a server should build
 ///   it with [`create_response`](crate::message::create_response), which
 ///   echoes the query itself.
-/// * A *custom* implementor may set the response query itself; the dispatch
-///   layer only fills an empty one, so a hand-set echo is left untouched.
+/// * A *custom* implementor may set the response query itself; both the owned
+///   and the borrowing dispatch paths only fill an empty one, so a hand-set
+///   echo is left untouched.
 pub trait HandlerErased: Send + Sync {
     fn handle(&self, req: &Message) -> Result<Message, RepeError>;
 
@@ -80,10 +81,11 @@ pub trait HandlerErased: Send + Sync {
     /// push notifies to the originator during request handling) or
     /// the dispatched method. The built-in
     /// `WebSocketServer` invokes this method per request with a
-    /// [`CallContext`] carrying the peer; the TCP servers invoke
-    /// `handle` directly, so context-aware handlers also need to
-    /// behave correctly when no peer is available (see
-    /// [`CallContext::detached`]).
+    /// [`CallContext`] carrying the peer; the TCP and async servers
+    /// reach it through [`handle_view`](Self::handle_view)'s default
+    /// with a peer-less [`CallContext::detached`] context, so
+    /// context-aware handlers must also behave correctly when no peer
+    /// is available.
     fn handle_with_ctx(&self, req: &Message, _ctx: &CallContext) -> Result<Message, RepeError> {
         self.handle(req)
     }
@@ -92,7 +94,7 @@ pub trait HandlerErased: Send + Sync {
     /// instead of an owned [`Message`].
     ///
     /// A server that reads each frame into a reusable per-connection buffer (see
-    /// [`read_message_into`](crate::read_message_into)) can dispatch through this
+    /// [`read_message_into`]) can dispatch through this
     /// method without the per-request query and body `Vec` allocations that an
     /// owned [`Message`] requires. As with [`handle_with_ctx`](Self::handle_with_ctx),
     /// the returned response leaves its query empty; the writer supplies the
@@ -101,9 +103,11 @@ pub trait HandlerErased: Send + Sync {
     /// The default implementation materializes an owned [`Message`] from the view
     /// (copying the query and body) and delegates to
     /// [`handle_with_ctx`](Self::handle_with_ctx), so existing handlers work
-    /// unchanged. The built-in handlers override it to decode straight from the
-    /// borrowed body and skip those copies.
-    #[doc(hidden)]
+    /// unchanged. The built-in JSON and typed handlers ([`Router::with_json`] /
+    /// [`Router::with_typed`]) override it to decode straight from the borrowed
+    /// body and skip those copies; the other built-ins (context-aware, struct,
+    /// registry, and any middleware-wrapped route) use the owning default until
+    /// they are likewise overridden.
     fn handle_view(&self, view: &MessageView, ctx: &CallContext) -> Result<Message, RepeError> {
         self.handle_with_ctx(&view.to_message(), ctx)
     }
@@ -1518,9 +1522,11 @@ fn handle_connection(
         }
         let view = MessageView::from_slice(&buf)?;
         if let Some(resp) = route_request_view(&router, &view) {
-            // Frame the query-less response, echoing the query as a borrowed
-            // slice of `buf` rather than copying it into the response.
-            write_message_streaming(&mut writer, resp.header, view.query, resp.body.len() as u64, |w| {
+            // Echo the request query (a borrowed slice of `buf`) unless the
+            // handler set its own — matching the owned path's stamp rule — so no
+            // query buffer is copied into the response on the common path.
+            let echo = crate::message::response_echo_query(&resp, view.query);
+            write_message_streaming(&mut writer, resp.header, echo, resp.body.len() as u64, |w| {
                 w.write_all(&resp.body)
             })?;
             writer.flush()?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use crate::constants::{BodyFormat, ErrorCode};
 use crate::error::RepeError;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::{read_message, write_message};
-use crate::message::{Message, create_error_response_like, create_response};
+use crate::message::{Message, create_error_response_like, create_response_unstamped};
 use crate::peer::{CallContext, PeerHandle};
 use crate::registry::Registry;
 #[cfg(not(target_arch = "wasm32"))]
@@ -43,6 +43,29 @@ pub enum Execution {
     OffReader,
 }
 
+/// A resolved request handler.
+///
+/// # Response query echo
+///
+/// REPE responses echo the request's query verbatim, but that echo is the
+/// **dispatch layer's** responsibility, not the handler's. The built-in
+/// handlers return responses with an *empty* query; the server
+/// ([`Server`], [`AsyncServer`](crate::AsyncServer), and the WebSocket
+/// server) then moves the request's query buffer into the response after
+/// the handler returns (see `route_request` and the WebSocket dispatch
+/// loop). This turns the per-response query echo from a clone into a buffer
+/// move.
+///
+/// Two consequences:
+///
+/// * Calling [`handle`](Self::handle) / [`handle_with_ctx`](Self::handle_with_ctx)
+///   directly (e.g. via [`Router::get`]) yields a response whose `query` is
+///   empty — it is only filled once dispatched through a server. Code that
+///   needs a complete, query-echoing response without a server should build
+///   it with [`create_response`](crate::message::create_response), which
+///   echoes the query itself.
+/// * A *custom* implementor may set the response query itself; the dispatch
+///   layer only fills an empty one, so a hand-set echo is left untouched.
 pub trait HandlerErased: Send + Sync {
     fn handle(&self, req: &Message) -> Result<Message, RepeError>;
 
@@ -229,7 +252,7 @@ where
             Err(err) => return Ok(err),
         };
         match (self.0)(param) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -255,7 +278,7 @@ where
             Err(err) => return Ok(err),
         };
         match (self.0)(ctx, param) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -368,7 +391,7 @@ where
         match self.0.call(t) {
             Ok(r) => {
                 let (value, format) = r.into_typed_response();
-                create_response(req, value, format)
+                create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
@@ -427,7 +450,7 @@ where
         match self.0.call(ctx, t) {
             Ok(r) => {
                 let (value, format) = r.into_typed_response();
-                create_response(req, value, format)
+                create_response_unstamped(req, value, format)
             }
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
@@ -1079,7 +1102,7 @@ impl HandlerErased for RegisteredRegistry {
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
         match self.registry.dispatch(pointer, body) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
     }
@@ -1098,7 +1121,7 @@ impl HandlerErased for RegisteredRegistry {
             Err(err) => return Ok(create_error_response_like(req, err.code(), err.to_string())),
         };
         match self.registry.dispatch_with_ctx(pointer, body, ctx) {
-            Ok(value) => create_response(req, value, BodyFormat::Json),
+            Ok(value) => create_response_unstamped(req, value, BodyFormat::Json),
             Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
         }
     }
@@ -1271,7 +1294,7 @@ where
     };
 
     match result {
-        Ok(value) => create_response(req, value.unwrap_or(Value::Null), BodyFormat::Json),
+        Ok(value) => create_response_unstamped(req, value.unwrap_or(Value::Null), BodyFormat::Json),
         Err(err) => Ok(create_error_response_like(req, err.code(), err.to_string())),
     }
 }
@@ -1303,7 +1326,7 @@ impl<H: JsonTypedHandler> HandlerErased for JsonTypedAdapter<H> {
             }
         };
         match self.0.call(t) {
-            Ok(r) => create_response(req, r, BodyFormat::Json),
+            Ok(r) => create_response_unstamped(req, r, BodyFormat::Json),
             Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
         }
     }
@@ -1402,7 +1425,7 @@ fn handle_connection(
             Err(RepeError::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(e) => return Err(e),
         };
-        if let Some(resp) = route_request(&router, &req) {
+        if let Some(resp) = route_request(&router, req) {
             write_message(&mut writer, &resp)?;
             writer.flush()?;
         }
@@ -1413,6 +1436,7 @@ fn handle_connection(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use crate::message::create_response;
     use crate::{QueryFormat, REPE_VERSION};
     use serde::{Deserialize, Serialize};
     use std::io::Read;

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -33,11 +33,14 @@ pub(crate) enum Resolution {
 /// the eventual response (and its query echo) is built. Shared by the owned
 /// path ([`resolve`]) and the borrowing path ([`route_request_view`]) so the
 /// two cannot drift on what counts as a valid request.
-enum RouteOutcome {
-    /// A handler resolved; dispatch it.
+enum RouteOutcome<'a> {
+    /// A handler resolved; dispatch it. `path` is the already-validated query
+    /// string (borrowed from the request), so the caller need not re-validate it
+    /// to build a [`CallContext`].
     Dispatch {
         handler: Arc<dyn HandlerErased>,
         notify: bool,
+        path: &'a str,
     },
     /// Validation failed or the method was not found: send an error response
     /// with this code and message for a non-notify, or nothing for a notify.
@@ -48,7 +51,7 @@ enum RouteOutcome {
     },
 }
 
-fn route(router: &Router, header: &Header, query: &[u8]) -> RouteOutcome {
+fn route<'a>(router: &Router, header: &Header, query: &'a [u8]) -> RouteOutcome<'a> {
     let notify = header.notify == 1;
 
     if header.version != REPE_VERSION {
@@ -81,7 +84,11 @@ fn route(router: &Router, header: &Header, query: &[u8]) -> RouteOutcome {
     };
 
     match router.get(path) {
-        Some(handler) => RouteOutcome::Dispatch { handler, notify },
+        Some(handler) => RouteOutcome::Dispatch {
+            handler,
+            notify,
+            path,
+        },
         None => RouteOutcome::Reject {
             notify,
             code: ErrorCode::MethodNotFound,
@@ -99,7 +106,9 @@ fn route(router: &Router, header: &Header, query: &[u8]) -> RouteOutcome {
 #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) fn resolve(router: &Router, req: &Message) -> Resolution {
     match route(router, &req.header, &req.query) {
-        RouteOutcome::Dispatch { handler, notify } => Resolution::Dispatch { handler, notify },
+        RouteOutcome::Dispatch { handler, notify, .. } => {
+            Resolution::Dispatch { handler, notify }
+        }
         RouteOutcome::Reject {
             notify,
             code,
@@ -116,8 +125,12 @@ pub(crate) fn resolve(router: &Router, req: &Message) -> Resolution {
 /// Returns `None` for a notify or a validation failure on a notify.
 pub(crate) fn route_request_view(router: &Router, view: &MessageView) -> Option<Message> {
     match route(router, &view.header, view.query) {
-        RouteOutcome::Dispatch { handler, notify } => {
-            let ctx = CallContext::detached(view.query_str().unwrap_or(""));
+        RouteOutcome::Dispatch {
+            handler,
+            notify,
+            path,
+        } => {
+            let ctx = CallContext::detached(path);
             dispatch_view(handler.as_ref(), view, &ctx, notify)
         }
         RouteOutcome::Reject {

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -1,5 +1,8 @@
 use crate::constants::{ErrorCode, QueryFormat, REPE_VERSION};
-use crate::message::{Message, create_error_response_like};
+use crate::header::Header;
+use crate::message::{
+    Message, MessageView, create_error_response_like, create_error_response_unstamped_view,
+};
 use crate::peer::CallContext;
 use crate::server::{HandlerErased, Router};
 use std::sync::Arc;
@@ -7,6 +10,12 @@ use std::sync::Arc;
 /// Outcome of [`resolve`]: either a ready response (or `None`, for a
 /// notify or a request that produced no handler), or a resolved handler
 /// to hand to [`dispatch`].
+///
+/// The owned-`Message` resolve/dispatch path is used by the WebSocket server,
+/// which decodes whole frames from tungstenite payloads; the TCP and async
+/// servers take the borrowing [`route_request_view`] path instead. Hence these
+/// are allowed to be unused when the `websocket` feature is off.
+#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) enum Resolution {
     /// Routing finished without invoking a handler — version/query
     /// validation failed, or the method was not found. Send the inner
@@ -20,26 +29,64 @@ pub(crate) enum Resolution {
     },
 }
 
-pub(crate) fn route_request(router: &Router, req: Message) -> Option<Message> {
-    // Own `req` so its query buffer can be moved into the response rather than
-    // cloned. The `ctx` borrow of `req` (for the method path) is scoped to the
-    // dispatch call and ends before the move.
-    let mut response = {
-        let ctx = CallContext::detached(req.query_str().unwrap_or(""));
-        route_request_with_ctx(router, &req, &ctx)
-    }?;
-    crate::message::stamp_response_query(&mut response, req.query);
-    Some(response)
+/// Validate the request envelope and look up the handler, independent of how
+/// the eventual response (and its query echo) is built. Shared by the owned
+/// path ([`resolve`]) and the borrowing path ([`route_request_view`]) so the
+/// two cannot drift on what counts as a valid request.
+enum RouteOutcome {
+    /// A handler resolved; dispatch it.
+    Dispatch {
+        handler: Arc<dyn HandlerErased>,
+        notify: bool,
+    },
+    /// Validation failed or the method was not found: send an error response
+    /// with this code and message for a non-notify, or nothing for a notify.
+    Reject {
+        notify: bool,
+        code: ErrorCode,
+        message: String,
+    },
 }
 
-pub(crate) fn route_request_with_ctx(
-    router: &Router,
-    req: &Message,
-    ctx: &CallContext,
-) -> Option<Message> {
-    match resolve(router, req) {
-        Resolution::Respond(resp) => resp,
-        Resolution::Dispatch { handler, notify } => dispatch(handler.as_ref(), req, ctx, notify),
+fn route(router: &Router, header: &Header, query: &[u8]) -> RouteOutcome {
+    let notify = header.notify == 1;
+
+    if header.version != REPE_VERSION {
+        return RouteOutcome::Reject {
+            notify,
+            code: ErrorCode::VersionMismatch,
+            message: format!("Unsupported REPE version {}", header.version),
+        };
+    }
+
+    let qf = QueryFormat::try_from(header.query_format).unwrap_or(QueryFormat::RawBinary);
+    let path = match qf {
+        QueryFormat::JsonPointer => match std::str::from_utf8(query) {
+            Ok(path) => path,
+            Err(_) => {
+                return RouteOutcome::Reject {
+                    notify,
+                    code: ErrorCode::InvalidQuery,
+                    message: "Query must be valid UTF-8".to_string(),
+                };
+            }
+        },
+        QueryFormat::RawBinary => {
+            return RouteOutcome::Reject {
+                notify,
+                code: ErrorCode::InvalidQuery,
+                message: "Raw binary queries are not supported by this server".to_string(),
+            };
+        }
+    };
+
+    match router.get(path) {
+        Some(handler) => RouteOutcome::Dispatch { handler, notify },
+        None => RouteOutcome::Reject {
+            notify,
+            code: ErrorCode::MethodNotFound,
+            message: format!("Method not found: {path}"),
+        },
     }
 }
 
@@ -49,60 +96,60 @@ pub(crate) fn route_request_with_ctx(
 /// [`dispatch`] — inline, or on a blocking thread — while the
 /// validation and error-response synthesis stay identical to the
 /// inline path.
+#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) fn resolve(router: &Router, req: &Message) -> Resolution {
-    let notify = req.header.notify == 1;
-
-    if req.header.version != REPE_VERSION {
-        return Resolution::Respond((!notify).then(|| {
-            create_error_response_like(
-                req,
-                ErrorCode::VersionMismatch,
-                format!("Unsupported REPE version {}", req.header.version),
-            )
-        }));
+    match route(router, &req.header, &req.query) {
+        RouteOutcome::Dispatch { handler, notify } => Resolution::Dispatch { handler, notify },
+        RouteOutcome::Reject {
+            notify,
+            code,
+            message,
+        } => Resolution::Respond((!notify).then(|| create_error_response_like(req, code, message))),
     }
+}
 
-    let qf = QueryFormat::try_from(req.header.query_format).unwrap_or(QueryFormat::RawBinary);
-    let path = match qf {
-        QueryFormat::JsonPointer => match req.query_str() {
-            Ok(path) => path,
-            Err(_) => {
-                return Resolution::Respond((!notify).then(|| {
-                    create_error_response_like(
-                        req,
-                        ErrorCode::InvalidQuery,
-                        "Query must be valid UTF-8",
-                    )
-                }));
-            }
-        },
-        QueryFormat::RawBinary => {
-            return Resolution::Respond((!notify).then(|| {
-                create_error_response_like(
-                    req,
-                    ErrorCode::InvalidQuery,
-                    "Raw binary queries are not supported by this server",
-                )
-            }));
+/// Borrowing twin of [`route_request`]: validate, resolve, and dispatch from a
+/// borrowed [`MessageView`], returning a **query-less** response. The caller
+/// frames the response echoing `view.query` (a borrowed slice of its read
+/// buffer), so the inbound path allocates no per-request query or body `Vec`.
+/// Returns `None` for a notify or a validation failure on a notify.
+pub(crate) fn route_request_view(router: &Router, view: &MessageView) -> Option<Message> {
+    match route(router, &view.header, view.query) {
+        RouteOutcome::Dispatch { handler, notify } => {
+            let ctx = CallContext::detached(view.query_str().unwrap_or(""));
+            dispatch_view(handler.as_ref(), view, &ctx, notify)
         }
-    };
-
-    match router.get(path) {
-        Some(handler) => Resolution::Dispatch { handler, notify },
-        None => Resolution::Respond((!notify).then(|| {
-            create_error_response_like(
-                req,
-                ErrorCode::MethodNotFound,
-                format!("Method not found: {path}"),
-            )
-        })),
+        RouteOutcome::Reject {
+            notify,
+            code,
+            message,
+        } => (!notify).then(|| create_error_response_unstamped_view(view, code, message)),
     }
+}
+
+/// Borrowing twin of [`dispatch`]: invoke `handler.handle_view` and map the
+/// result to a query-less response (or `None` for a notify).
+fn dispatch_view(
+    handler: &dyn HandlerErased,
+    view: &MessageView,
+    ctx: &CallContext,
+    notify: bool,
+) -> Option<Message> {
+    if notify {
+        let _ = handler.handle_view(view, ctx);
+        return None;
+    }
+    Some(match handler.handle_view(view, ctx) {
+        Ok(message) => message,
+        Err(err) => create_error_response_unstamped_view(view, err.to_error_code(), err.to_string()),
+    })
 }
 
 /// Invoke a resolved handler with `ctx`. For a notify, runs the handler
 /// for its side effects and returns `None`; otherwise maps the result
 /// to a response. Shared by the inline and off-reader dispatch paths so
 /// their outcomes are identical.
+#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) fn dispatch(
     handler: &dyn HandlerErased,
     req: &Message,
@@ -123,50 +170,63 @@ pub(crate) fn dispatch(
 mod tests {
     use super::*;
     use crate::constants::{HEADER_SIZE, QueryFormat};
+    use crate::io::write_message_streaming;
     use crate::server::Router;
     use serde_json::json;
+    use std::io::Write;
 
-    #[test]
-    fn dispatched_response_echoes_request_query_via_move() {
-        // Built-in handlers build a query-less response; route_request moves the
-        // request query onto it at the boundary. The echo and header lengths
-        // must match what the old cloning path produced.
-        let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
-        let req = Message::builder()
+    fn request_bytes(path: &str, body: serde_json::Value) -> Vec<u8> {
+        Message::builder()
             .id(7)
-            .query_str("/echo")
+            .query_str(path)
             .query_format(QueryFormat::JsonPointer)
-            .body_json(&json!({"x": 1}))
+            .body_json(&body)
             .unwrap()
-            .build();
-        let expected_query = req.query.clone();
-
-        let resp = route_request(&router, req).expect("response");
-        assert_eq!(resp.query, expected_query);
-        assert_eq!(resp.header.query_length, expected_query.len() as u64);
-        assert_eq!(
-            resp.header.length,
-            HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length
-        );
-        assert_eq!(resp.header.id, 7);
+            .build()
+            .to_vec()
     }
 
     #[test]
-    fn dispatched_error_response_still_echoes_query() {
-        // Method-not-found takes the Respond path (create_error_response_like
-        // echoes the query directly); the boundary stamp is a no-op there.
-        let router = Router::new();
-        let req = Message::builder()
-            .id(9)
-            .query_str("/missing")
-            .query_format(QueryFormat::JsonPointer)
-            .body_json(&json!({}))
-            .unwrap()
-            .build();
-        let expected_query = req.query.clone();
+    fn view_dispatch_returns_query_less_response_framed_with_borrowed_query() {
+        // The borrowing path returns a query-less response; the server frames it
+        // echoing the borrowed view query. The framed result must round-trip with
+        // the request query intact — what the old owned (cloning) path produced.
+        let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+        let wire = request_bytes("/echo", json!({"x": 1}));
+        let view = MessageView::from_slice(&wire).unwrap();
 
-        let resp = route_request(&router, req).expect("error response");
-        assert_eq!(resp.query, expected_query);
+        let resp = route_request_view(&router, &view).expect("response");
+        assert!(
+            resp.query.is_empty(),
+            "view dispatch leaves the query for the writer"
+        );
+
+        // Frame echoing the borrowed query, as the TCP/async servers do.
+        let mut out = Vec::new();
+        write_message_streaming(&mut out, resp.header, view.query, resp.body.len() as u64, |w| {
+            w.write_all(&resp.body)
+        })
+        .unwrap();
+
+        let framed = Message::from_slice(&out).unwrap();
+        assert_eq!(framed.query, view.query);
+        assert_eq!(framed.header.id, 7);
+        assert_eq!(
+            framed.header.length,
+            HEADER_SIZE as u64 + framed.header.query_length + framed.header.body_length
+        );
+        let echoed: serde_json::Value = framed.json_body().unwrap();
+        assert_eq!(echoed, json!({"x": 1}));
+    }
+
+    #[test]
+    fn view_dispatch_unknown_method_is_query_less_error() {
+        let router = Router::new();
+        let wire = request_bytes("/missing", json!({}));
+        let view = MessageView::from_slice(&wire).unwrap();
+
+        let resp = route_request_view(&router, &view).expect("error response");
+        assert!(resp.query.is_empty());
         assert_ne!(resp.header.ec, 0, "method-not-found is an error response");
     }
 }

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -7,33 +7,13 @@ use crate::peer::CallContext;
 use crate::server::{HandlerErased, Router};
 use std::sync::Arc;
 
-/// Outcome of [`resolve`]: either a ready response (or `None`, for a
-/// notify or a request that produced no handler), or a resolved handler
-/// to hand to [`dispatch`].
-///
-/// The owned-`Message` resolve/dispatch path is used by the WebSocket server,
-/// which decodes whole frames from tungstenite payloads; the TCP and async
-/// servers take the borrowing [`route_request_view`] path instead. Hence these
-/// are allowed to be unused when the `websocket` feature is off.
-#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
-pub(crate) enum Resolution {
-    /// Routing finished without invoking a handler — version/query
-    /// validation failed, or the method was not found. Send the inner
-    /// message, or nothing (`None`) for a notify.
-    Respond(Option<Message>),
-    /// Handler resolved. Run [`dispatch`]; `notify` controls whether a
-    /// response is produced.
-    Dispatch {
-        handler: Arc<dyn HandlerErased>,
-        notify: bool,
-    },
-}
-
 /// Validate the request envelope and look up the handler, independent of how
-/// the eventual response (and its query echo) is built. Shared by the owned
-/// path ([`resolve`]) and the borrowing path ([`route_request_view`]) so the
-/// two cannot drift on what counts as a valid request.
-enum RouteOutcome<'a> {
+/// the eventual response (and its query echo) is built. Shared by the TCP/async
+/// borrowing path ([`route_request_view`]) and the WebSocket reader (which
+/// resolves a borrowed [`MessageView`], then dispatches inline via
+/// [`dispatch_view`] or materializes an owned message for an off-reader handler),
+/// so they cannot drift on what counts as a valid request.
+pub(crate) enum RouteOutcome<'a> {
     /// A handler resolved; dispatch it. `path` is the already-validated query
     /// string (borrowed from the request), so the caller need not re-validate it
     /// to build a [`CallContext`].
@@ -51,7 +31,7 @@ enum RouteOutcome<'a> {
     },
 }
 
-fn route<'a>(router: &Router, header: &Header, query: &'a [u8]) -> RouteOutcome<'a> {
+pub(crate) fn route<'a>(router: &Router, header: &Header, query: &'a [u8]) -> RouteOutcome<'a> {
     let notify = header.notify == 1;
 
     if header.version != REPE_VERSION {
@@ -97,27 +77,7 @@ fn route<'a>(router: &Router, header: &Header, query: &'a [u8]) -> RouteOutcome<
     }
 }
 
-/// Validate the request envelope and look up the handler *without*
-/// invoking it. Splitting this out lets a caller (the WebSocket reader)
-/// inspect [`HandlerErased::execution`] and decide where to run
-/// [`dispatch`] — inline, or on a blocking thread — while the
-/// validation and error-response synthesis stay identical to the
-/// inline path.
-#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
-pub(crate) fn resolve(router: &Router, req: &Message) -> Resolution {
-    match route(router, &req.header, &req.query) {
-        RouteOutcome::Dispatch { handler, notify, .. } => {
-            Resolution::Dispatch { handler, notify }
-        }
-        RouteOutcome::Reject {
-            notify,
-            code,
-            message,
-        } => Resolution::Respond((!notify).then(|| create_error_response_like(req, code, message))),
-    }
-}
-
-/// Borrowing counterpart of the owned [`resolve`] + [`dispatch`] path: validate,
+/// Borrowing counterpart of the owned [`dispatch`] path: validate,
 /// resolve, and dispatch from a borrowed [`MessageView`], returning a
 /// **query-less** response. The caller frames the response echoing `view.query`
 /// (a borrowed slice of its read buffer), so the inbound path allocates no
@@ -142,8 +102,9 @@ pub(crate) fn route_request_view(router: &Router, view: &MessageView) -> Option<
 }
 
 /// Borrowing twin of [`dispatch`]: invoke `handler.handle_view` and map the
-/// result to a query-less response (or `None` for a notify).
-fn dispatch_view(
+/// result to a query-less response (or `None` for a notify). Used by the
+/// TCP/async borrowing path and the WebSocket inline path.
+pub(crate) fn dispatch_view(
     handler: &dyn HandlerErased,
     view: &MessageView,
     ctx: &CallContext,
@@ -159,10 +120,11 @@ fn dispatch_view(
     })
 }
 
-/// Invoke a resolved handler with `ctx`. For a notify, runs the handler
-/// for its side effects and returns `None`; otherwise maps the result
-/// to a response. Shared by the inline and off-reader dispatch paths so
-/// their outcomes are identical.
+/// Invoke a resolved handler with `ctx` on an owned [`Message`]. For a notify,
+/// runs the handler for its side effects and returns `None`; otherwise maps the
+/// result to a response. Used by the WebSocket off-reader path, whose spawned
+/// blocking task owns the request (it outlives the read buffer, so it cannot
+/// borrow a view).
 #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 pub(crate) fn dispatch(
     handler: &dyn HandlerErased,

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -108,10 +108,11 @@ pub(crate) fn resolve(router: &Router, req: &Message) -> Resolution {
     }
 }
 
-/// Borrowing twin of [`route_request`]: validate, resolve, and dispatch from a
-/// borrowed [`MessageView`], returning a **query-less** response. The caller
-/// frames the response echoing `view.query` (a borrowed slice of its read
-/// buffer), so the inbound path allocates no per-request query or body `Vec`.
+/// Borrowing counterpart of the owned [`resolve`] + [`dispatch`] path: validate,
+/// resolve, and dispatch from a borrowed [`MessageView`], returning a
+/// **query-less** response. The caller frames the response echoing `view.query`
+/// (a borrowed slice of its read buffer), so the inbound path allocates no
+/// per-request query or body `Vec`.
 /// Returns `None` for a notify or a validation failure on a notify.
 pub(crate) fn route_request_view(router: &Router, view: &MessageView) -> Option<Message> {
     match route(router, &view.header, view.query) {

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -20,10 +20,16 @@ pub(crate) enum Resolution {
     },
 }
 
-pub(crate) fn route_request(router: &Router, req: &Message) -> Option<Message> {
-    let path = req.query_str().unwrap_or("");
-    let ctx = CallContext::detached(path);
-    route_request_with_ctx(router, req, &ctx)
+pub(crate) fn route_request(router: &Router, req: Message) -> Option<Message> {
+    // Own `req` so its query buffer can be moved into the response rather than
+    // cloned. The `ctx` borrow of `req` (for the method path) is scoped to the
+    // dispatch call and ends before the move.
+    let mut response = {
+        let ctx = CallContext::detached(req.query_str().unwrap_or(""));
+        route_request_with_ctx(router, &req, &ctx)
+    }?;
+    crate::message::stamp_response_query(&mut response, req.query);
+    Some(response)
 }
 
 pub(crate) fn route_request_with_ctx(
@@ -111,4 +117,56 @@ pub(crate) fn dispatch(
         Ok(message) => message,
         Err(err) => create_error_response_like(req, err.to_error_code(), err.to_string()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{HEADER_SIZE, QueryFormat};
+    use crate::server::Router;
+    use serde_json::json;
+
+    #[test]
+    fn dispatched_response_echoes_request_query_via_move() {
+        // Built-in handlers build a query-less response; route_request moves the
+        // request query onto it at the boundary. The echo and header lengths
+        // must match what the old cloning path produced.
+        let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+        let req = Message::builder()
+            .id(7)
+            .query_str("/echo")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({"x": 1}))
+            .unwrap()
+            .build();
+        let expected_query = req.query.clone();
+
+        let resp = route_request(&router, req).expect("response");
+        assert_eq!(resp.query, expected_query);
+        assert_eq!(resp.header.query_length, expected_query.len() as u64);
+        assert_eq!(
+            resp.header.length,
+            HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length
+        );
+        assert_eq!(resp.header.id, 7);
+    }
+
+    #[test]
+    fn dispatched_error_response_still_echoes_query() {
+        // Method-not-found takes the Respond path (create_error_response_like
+        // echoes the query directly); the boundary stamp is a no-op there.
+        let router = Router::new();
+        let req = Message::builder()
+            .id(9)
+            .query_str("/missing")
+            .query_format(QueryFormat::JsonPointer)
+            .body_json(&json!({}))
+            .unwrap()
+            .build();
+        let expected_query = req.query.clone();
+
+        let resp = route_request(&router, req).expect("error response");
+        assert_eq!(resp.query, expected_query);
+        assert_ne!(resp.header.ec, 0, "method-not-found is an error response");
+    }
 }

--- a/src/server_request.rs
+++ b/src/server_request.rs
@@ -116,7 +116,9 @@ pub(crate) fn dispatch_view(
     }
     Some(match handler.handle_view(view, ctx) {
         Ok(message) => message,
-        Err(err) => create_error_response_unstamped_view(view, err.to_error_code(), err.to_string()),
+        Err(err) => {
+            create_error_response_unstamped_view(view, err.to_error_code(), err.to_string())
+        }
     })
 }
 
@@ -179,9 +181,13 @@ mod tests {
 
         // Frame echoing the borrowed query, as the TCP/async servers do.
         let mut out = Vec::new();
-        write_message_streaming(&mut out, resp.header, view.query, resp.body.len() as u64, |w| {
-            w.write_all(&resp.body)
-        })
+        write_message_streaming(
+            &mut out,
+            resp.header,
+            view.query,
+            resp.body.len() as u64,
+            |w| w.write_all(&resp.body),
+        )
         .unwrap();
 
         let framed = Message::from_slice(&out).unwrap();

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1,13 +1,16 @@
 use crate::async_client::AsyncClient;
 use crate::constants::{ErrorCode, QueryFormat};
 use crate::error::RepeError;
-use crate::message::{Message, create_error_response_like, stamp_response_query};
+use crate::message::{
+    Message, MessageView, create_error_response_like, create_error_response_unstamped_view,
+    stamp_response_query,
+};
 use crate::peer::{
     CallContext, CancelSignal, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError,
     PeerSink,
 };
 use crate::server::{Execution, HandlerErased, Router};
-use crate::server_request::{Resolution, dispatch, resolve};
+use crate::server_request::{RouteOutcome, dispatch, dispatch_view, route};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use std::future::Future;
@@ -994,10 +997,10 @@ where
             None => break,
         };
 
-        let request = match decode_request_frame(frame)? {
-            FrameAction::Message(message) => message,
-            FrameAction::Continue => continue,
-            FrameAction::Close => break,
+        let request = match decode_request_payload(frame)? {
+            FramePayload::Bytes(payload) => Message::from_slice_exact(&payload)?,
+            FramePayload::Continue => continue,
+            FramePayload::Close => break,
         };
 
         if let Some(response) = upstream.forward_message(&request).await? {
@@ -1187,39 +1190,53 @@ async fn reader_task(
             None => break,
         };
 
-        let request = match decode_request_frame(frame)? {
-            FrameAction::Message(message) => message,
-            FrameAction::Continue => continue,
-            FrameAction::Close => break,
+        let payload = match decode_request_payload(frame)? {
+            FramePayload::Bytes(payload) => payload,
+            FramePayload::Continue => continue,
+            FramePayload::Close => break,
         };
+        // Borrow the frame rather than copying its query and body into an owned
+        // Message; only the off-reader path (whose spawned task outlives
+        // `payload`) materializes one.
+        let view = MessageView::from_slice_exact(&payload)?;
 
-        // Resolve the route (version/query validation + handler lookup)
-        // here, on the reader, so the early error responses and the
-        // execution mode are computed identically for the inline and
-        // off-reader paths; only where dispatch runs differs.
-        match resolve(router, &request) {
-            Resolution::Respond(maybe_response) => {
-                if let Some(response) = maybe_response {
+        // Validate + look up the handler here, on the reader, so early error
+        // responses and the execution mode are computed identically for the
+        // inline and off-reader paths; only where dispatch runs differs.
+        match route(router, &view.header, view.query) {
+            RouteOutcome::Reject {
+                notify,
+                code,
+                message,
+            } => {
+                if !notify {
+                    let mut response = create_error_response_unstamped_view(&view, code, message);
+                    // The outbound channel carries owned messages written later
+                    // by the writer task, so copy the borrowed query in.
+                    stamp_response_query(&mut response, view.query.to_vec());
                     if conn.outbound_tx.send(response).await.is_err() {
                         break;
                     }
                 }
             }
-            Resolution::Dispatch { handler, notify } => match handler.execution() {
+            RouteOutcome::Dispatch {
+                handler,
+                notify,
+                path,
+            } => match handler.execution() {
                 Execution::Inline => {
                     // Thread the calling peer and the connection's
                     // cancellation signal to handlers so `with_json_ctx` /
                     // `with_typed_ctx` (and registry-backed callables) can
                     // push notifies back through this connection during
                     // request handling and observe disconnect/shutdown.
-                    let path = request.query_str().unwrap_or("");
                     let ctx = CallContext::with_cancel(path, &conn.peer, &inline_signal);
-                    let maybe_response = dispatch(handler.as_ref(), &request, &ctx, notify);
-                    // `ctx`'s borrow of `request` ends with the dispatch call
-                    // above, so the request query can now be moved into the
-                    // response instead of cloned by the handler.
-                    if let Some(mut response) = maybe_response {
-                        stamp_response_query(&mut response, request.query);
+                    if let Some(mut response) = dispatch_view(handler.as_ref(), &view, &ctx, notify)
+                    {
+                        // The response is query-less and the writer task frames
+                        // it later, so copy the borrowed query into it rather
+                        // than referencing `payload`.
+                        stamp_response_query(&mut response, view.query.to_vec());
                         if conn.outbound_tx.send(response).await.is_err() {
                             // Writer task exited (likely wire error);
                             // abandon reader. The disconnect guard still
@@ -1229,6 +1246,9 @@ async fn reader_task(
                     }
                 }
                 Execution::OffReader => {
+                    // The spawned blocking task outlives `payload`, so it needs
+                    // an owned request.
+                    let request = view.to_message();
                     if !spawn_off_reader(&offreader_sem, &conn, handler, request, notify).await {
                         break;
                     }
@@ -1439,17 +1459,19 @@ impl Drop for DisconnectGuard {
     }
 }
 
-enum FrameAction {
-    Message(Message),
+enum FramePayload {
+    /// A binary frame's raw bytes, to be parsed as a [`MessageView`] (reader) or
+    /// an owned [`Message`] (proxy) by the caller.
+    Bytes(Vec<u8>),
     Continue,
     Close,
 }
 
-fn decode_request_frame(frame: WsMessage) -> Result<FrameAction, RepeError> {
+fn decode_request_payload(frame: WsMessage) -> Result<FramePayload, RepeError> {
     match frame {
-        WsMessage::Binary(payload) => Message::from_slice_exact(&payload).map(FrameAction::Message),
-        WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => Ok(FrameAction::Continue),
-        WsMessage::Close(_) => Ok(FrameAction::Close),
+        WsMessage::Binary(payload) => Ok(FramePayload::Bytes(payload)),
+        WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => Ok(FramePayload::Continue),
+        WsMessage::Close(_) => Ok(FramePayload::Close),
         WsMessage::Text(_) => Err(websocket_invalid_data_error(
             "websocket transport requires binary messages",
         )),

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1,7 +1,7 @@
 use crate::async_client::AsyncClient;
 use crate::constants::{ErrorCode, QueryFormat};
 use crate::error::RepeError;
-use crate::message::{Message, create_error_response_like};
+use crate::message::{Message, create_error_response_like, stamp_response_query};
 use crate::peer::{
     CallContext, CancelSignal, NotifyBody, PeerHandle, PeerId, PeerRegistry, PeerSendError,
     PeerSink,
@@ -1214,7 +1214,12 @@ async fn reader_task(
                     // request handling and observe disconnect/shutdown.
                     let path = request.query_str().unwrap_or("");
                     let ctx = CallContext::with_cancel(path, &conn.peer, &inline_signal);
-                    if let Some(response) = dispatch(handler.as_ref(), &request, &ctx, notify) {
+                    let maybe_response = dispatch(handler.as_ref(), &request, &ctx, notify);
+                    // `ctx`'s borrow of `request` ends with the dispatch call
+                    // above, so the request query can now be moved into the
+                    // response instead of cloned by the handler.
+                    if let Some(mut response) = maybe_response {
+                        stamp_response_query(&mut response, request.query);
                         if conn.outbound_tx.send(response).await.is_err() {
                             // Writer task exited (likely wire error);
                             // abandon reader. The disconnect guard still
@@ -1321,7 +1326,11 @@ async fn spawn_off_reader(
                 })
             }
         };
-        if let Some(response) = response {
+        if let Some(mut response) = response {
+            // Echo the request query by moving its buffer into the response
+            // (handlers leave it empty); a panic error response already carries
+            // its own query, so the stamp is a no-op there.
+            stamp_response_query(&mut response, request.query);
             // Best-effort: the writer may already be gone if the
             // connection closed while this handler ran.
             let _ = outbound_tx.blocking_send(response);

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -13,6 +13,7 @@ use crate::server::{Execution, HandlerErased, Router};
 use crate::server_request::{RouteOutcome, dispatch, dispatch_view, route};
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
+use std::borrow::Cow;
 use std::future::Future;
 use std::io::ErrorKind;
 use std::pin::Pin;
@@ -1211,9 +1212,10 @@ async fn reader_task(
             } => {
                 if !notify {
                     let mut response = create_error_response_unstamped_view(&view, code, message);
-                    // The outbound channel carries owned messages written later
-                    // by the writer task, so copy the borrowed query in.
-                    stamp_response_query(&mut response, view.query.to_vec());
+                    // The outbound channel carries owned messages framed later by
+                    // the writer task, so stamp the borrowed query in (an error
+                    // response is always query-less, so it is copied here).
+                    stamp_response_query(&mut response, Cow::Borrowed(view.query));
                     if conn.outbound_tx.send(response).await.is_err() {
                         break;
                     }
@@ -1234,9 +1236,10 @@ async fn reader_task(
                     if let Some(mut response) = dispatch_view(handler.as_ref(), &view, &ctx, notify)
                     {
                         // The response is query-less and the writer task frames
-                        // it later, so copy the borrowed query into it rather
-                        // than referencing `payload`.
-                        stamp_response_query(&mut response, view.query.to_vec());
+                        // it later, so stamp the borrowed query in rather than
+                        // referencing `payload`. A handler that set its own
+                        // response query keeps it and pays no copy.
+                        stamp_response_query(&mut response, Cow::Borrowed(view.query));
                         if conn.outbound_tx.send(response).await.is_err() {
                             // Writer task exited (likely wire error);
                             // abandon reader. The disconnect guard still
@@ -1347,10 +1350,10 @@ async fn spawn_off_reader(
             }
         };
         if let Some(mut response) = response {
-            // Echo the request query by moving its buffer into the response
-            // (handlers leave it empty); a panic error response already carries
-            // its own query, so the stamp is a no-op there.
-            stamp_response_query(&mut response, request.query);
+            // Echo the request query by moving its owned buffer into the response
+            // (`Cow::Owned`, no copy -- handlers leave it empty); a panic error
+            // response already carries its own query, so the stamp is a no-op.
+            stamp_response_query(&mut response, Cow::Owned(request.query));
             // Best-effort: the writer may already be gone if the
             // connection closed while this handler ran.
             let _ = outbound_tx.blocking_send(response);

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -1,0 +1,159 @@
+//! Per-request allocation budget for the server hot path.
+//!
+//! These tests pin the number of heap allocations on the inbound→outbound
+//! request path so that a regression (an extra per-request allocation) fails
+//! loudly, and a deliberate reduction shows up as a test that must be updated
+//! downward. They are the regression guard behind the ongoing effort to drive
+//! repe toward fewer per-request allocations.
+//!
+//! A thread-local counting [`GlobalAlloc`] wraps the system allocator. The
+//! counter is per-thread, so the measured closure (which runs entirely on the
+//! test thread) is unaffected by allocations on other threads in the test
+//! binary. `dealloc` is intentionally not counted; we budget *allocation
+//! events* (`alloc` + `realloc`), which is what scales with request volume.
+//!
+//! The dispatch path is composed from public APIs because the internal
+//! `route_request` is `pub(crate)`. The query-echo move the servers perform at
+//! the dispatch boundary is replicated here via the public `Message`/`Header`
+//! fields so the budget matches what a real server pays.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::hint::black_box;
+use std::io::Cursor;
+
+use repe::server::Router;
+use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use serde_json::json;
+
+thread_local! {
+    static ALLOCS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct CountingAllocator;
+
+// SAFETY: each method forwards to the system allocator unchanged and only
+// additionally bumps a thread-local `Cell<usize>`, whose access allocates
+// nothing (a `const`-initialized thread-local is a plain static read), so no
+// reentrancy into the allocator is introduced.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.with(|c| c.set(c.get() + 1));
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.with(|c| c.set(c.get() + 1));
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+/// Run `f` and return its result alongside the number of allocation events it
+/// made on the current thread.
+fn count_allocs<R>(f: impl FnOnce() -> R) -> (R, usize) {
+    let start = ALLOCS.with(Cell::get);
+    let out = f();
+    let end = ALLOCS.with(Cell::get);
+    (out, end - start)
+}
+
+fn request(path: &str, body: serde_json::Value) -> Vec<u8> {
+    Message::builder()
+        .id(1)
+        .query_str(path)
+        .query_format(QueryFormat::JsonPointer)
+        .body_json(&body)
+        .unwrap()
+        .build()
+        .to_vec()
+}
+
+/// Replicates the read → dispatch → query-echo-move → write cycle a server runs
+/// per request, using only public APIs. `out` is reused across calls so its
+/// allocation is paid once (at warm-up), matching a per-connection writer.
+fn dispatch_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
+    let mut reader = Cursor::new(wire);
+    let req = read_message(&mut reader).expect("read");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let mut resp = handler.handle_with_ctx(&req, &ctx).expect("dispatch");
+    // The server moves the request query into the (query-less) handler response
+    // at the dispatch boundary; replicate that here.
+    resp.query = req.query;
+    resp.header.query_length = resp.query.len() as u64;
+    resp.header.length =
+        HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
+    out.clear();
+    write_message(out, &resp).expect("write");
+}
+
+#[test]
+fn framing_round_trip_allocates_only_query_and_body() {
+    // The pure framing path, no dispatch: `read_message` allocates exactly one
+    // `Vec` for the query and one for the body; the header is a stack array, and
+    // `write_message` reuses the warmed `out` buffer. This is the framing budget
+    // the zero-copy/borrowed-read work would later drive toward zero.
+    let wire = request("/echo", json!({"x": 1}));
+    let mut out = Vec::new();
+
+    // Warm up `out` so its growth isn't charged to the measured call.
+    {
+        let mut reader = Cursor::new(&wire);
+        let req = read_message(&mut reader).unwrap();
+        write_message(&mut out, &req).unwrap();
+    }
+
+    let (_, allocs) = count_allocs(|| {
+        let mut reader = Cursor::new(&wire);
+        let req = read_message(&mut reader).unwrap();
+        out.clear();
+        write_message(&mut out, &req).unwrap();
+        black_box(&out);
+    });
+
+    assert_eq!(
+        allocs, 2,
+        "read_message should allocate exactly the query + body Vecs; write reuses `out`"
+    );
+}
+
+#[test]
+fn json_dispatch_allocation_budget() {
+    // Full read → dispatch → write for a small JSON echo (`{"x":1}`). Budget:
+    //
+    //   2  read_message: the query Vec + the body Vec
+    //   2  serde_json decode of `{"x":1}` to Value: the map node + the "x" key
+    //   1  serde_json encode of the response body to a Vec
+    //   0  query echo (moved from the request, not cloned — PR #20)
+    //   0  write_message (reuses the warmed `out` buffer)
+    //   ----
+    //   5
+    //
+    // The count includes serde_json's payload (de)serialization, so it is
+    // payload-shaped and may shift if serde_json's allocation behavior changes;
+    // what this guards is that repe's *framework* contribution does not grow. If
+    // this fails after a serde_json update, re-baseline EXPECTED; if it fails
+    // after a repe change, investigate the new (or removed) allocation.
+    const EXPECTED: usize = 5;
+    let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+    let wire = request("/echo", json!({"x": 1}));
+    let mut out = Vec::new();
+
+    // Warm up the reused writer buffer.
+    dispatch_cycle(&router, &wire, "/echo", &mut out);
+
+    let (_, allocs) = count_allocs(|| dispatch_cycle(&router, &wire, "/echo", &mut out));
+
+    assert_eq!(
+        allocs, EXPECTED,
+        "per-request allocation budget changed (was {EXPECTED}, now {allocs}); \
+         a reduction is good news — update EXPECTED; an increase is a regression"
+    );
+}

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -91,8 +91,7 @@ fn dispatch_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
     // at the dispatch boundary; replicate that here.
     resp.query = req.query;
     resp.header.query_length = resp.query.len() as u64;
-    resp.header.length =
-        HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
+    resp.header.length = HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
     out.clear();
     write_message(out, &resp).expect("write");
 }
@@ -135,8 +134,7 @@ fn dispatch_cycle_ws_inline(router: &Router, wire: &[u8], path: &str) -> Message
     let mut resp = handler.handle_view(&view, &ctx).expect("dispatch");
     resp.query = view.query.to_vec();
     resp.header.query_length = resp.query.len() as u64;
-    resp.header.length =
-        HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
+    resp.header.length = HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
     resp
 }
 

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -20,10 +20,13 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::hint::black_box;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 use repe::server::Router;
-use repe::{CallContext, HEADER_SIZE, Message, QueryFormat, read_message, write_message};
+use repe::{
+    CallContext, HEADER_SIZE, Message, MessageView, QueryFormat, read_message, read_message_into,
+    write_message, write_message_streaming,
+};
 use serde_json::json;
 
 thread_local! {
@@ -94,6 +97,32 @@ fn dispatch_cycle(router: &Router, wire: &[u8], path: &str, out: &mut Vec<u8>) {
     write_message(out, &resp).expect("write");
 }
 
+/// The borrowing path: read into a reused buffer, parse a `MessageView`,
+/// dispatch via `handle_view`, and write the response framing the query as a
+/// borrowed slice of the read buffer (`write_message_streaming`). No owned
+/// request `Message`, so the read query/body `Vec`s never exist.
+fn dispatch_cycle_view(
+    router: &Router,
+    wire: &[u8],
+    path: &str,
+    buf: &mut Vec<u8>,
+    out: &mut Vec<u8>,
+) {
+    let mut reader = Cursor::new(wire);
+    read_message_into(&mut reader, buf).expect("read");
+    let view = MessageView::from_slice(buf).expect("view");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let resp = handler.handle_view(&view, &ctx).expect("dispatch");
+    out.clear();
+    // The response is query-less; echo the query straight from the borrowed
+    // view, so no query buffer is allocated on the response side either.
+    write_message_streaming(out, resp.header, view.query, resp.body.len() as u64, |w| {
+        w.write_all(&resp.body)
+    })
+    .expect("write");
+}
+
 #[test]
 fn framing_round_trip_allocates_only_query_and_body() {
     // The pure framing path, no dispatch: `read_message` allocates exactly one
@@ -155,5 +184,37 @@ fn json_dispatch_allocation_budget() {
         allocs, EXPECTED,
         "per-request allocation budget changed (was {EXPECTED}, now {allocs}); \
          a reduction is good news — update EXPECTED; an increase is a regression"
+    );
+}
+
+#[test]
+fn json_dispatch_view_allocation_budget() {
+    // The borrowing read path for the same `{"x":1}` echo. The two read-side
+    // Vecs (query + body) are gone — the read buffer is reused and the response
+    // echoes the query as a borrowed slice — leaving only serde_json's payload
+    // work:
+    //
+    //   0  read_message_into (reuses `buf`) + MessageView (borrows)
+    //   2  serde_json decode of `{"x":1}` to Value
+    //   1  serde_json encode of the response body
+    //   0  query echo (borrowed from the view by the writer)
+    //   0  write_message_streaming (reuses `out`)
+    //   ----
+    //   3   (down from 5 on the owned path)
+    const EXPECTED: usize = 3;
+    let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+    let wire = request("/echo", json!({"x": 1}));
+    let mut buf = Vec::new();
+    let mut out = Vec::new();
+
+    // Warm up both reused buffers.
+    dispatch_cycle_view(&router, &wire, "/echo", &mut buf, &mut out);
+
+    let (_, allocs) =
+        count_allocs(|| dispatch_cycle_view(&router, &wire, "/echo", &mut buf, &mut out));
+
+    assert_eq!(
+        allocs, EXPECTED,
+        "borrowing-path allocation budget changed (was {EXPECTED}, now {allocs})"
     );
 }

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -201,6 +201,12 @@ fn json_dispatch_view_allocation_budget() {
     //   0  write_message_streaming (reuses `out`)
     //   ----
     //   3   (down from 5 on the owned path)
+    //
+    // NOTE: this 5→3 win applies to `with_json`/`with_typed` routes, which
+    // override `handle_view` to decode from the borrowed body. Context-aware,
+    // struct, registry, and middleware-wrapped routes use the owning
+    // `handle_view` default (`MessageView::to_message`) and keep the owned
+    // path's 2 read allocations until they too are overridden.
     const EXPECTED: usize = 3;
     let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
     let wire = request("/echo", json!({"x": 1}));

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -123,6 +123,23 @@ fn dispatch_cycle_view(
     .expect("write");
 }
 
+/// The WebSocket inline pattern: parse a borrowed `MessageView` from the
+/// tungstenite payload, dispatch via `handle_view`, then copy the borrowed query
+/// into the response because the outbound channel carries owned messages written
+/// later by the writer task. Replicates the (pub(crate)) `stamp_response_query`
+/// step via the public `Message`/`Header` fields.
+fn dispatch_cycle_ws_inline(router: &Router, wire: &[u8], path: &str) -> Message {
+    let view = MessageView::from_slice_exact(wire).expect("view");
+    let handler = router.get(path).expect("handler");
+    let ctx = CallContext::detached(path);
+    let mut resp = handler.handle_view(&view, &ctx).expect("dispatch");
+    resp.query = view.query.to_vec();
+    resp.header.query_length = resp.query.len() as u64;
+    resp.header.length =
+        HEADER_SIZE as u64 + resp.header.query_length + resp.header.body_length;
+    resp
+}
+
 #[test]
 fn framing_round_trip_allocates_only_query_and_body() {
     // The pure framing path, no dispatch: `read_message` allocates exactly one
@@ -222,5 +239,38 @@ fn json_dispatch_view_allocation_budget() {
     assert_eq!(
         allocs, EXPECTED,
         "borrowing-path allocation budget changed (was {EXPECTED}, now {allocs})"
+    );
+}
+
+#[test]
+fn websocket_inline_dispatch_allocation_budget() {
+    // The WebSocket inline path borrows the request body (no read-side body Vec),
+    // but unlike the TCP/async path it must copy the query into the response
+    // because the outbound channel carries owned messages framed later. So:
+    //
+    //   0  MessageView::from_slice_exact (borrows the payload)
+    //   2  serde_json decode of `{"x":1}`
+    //   1  serde_json encode of the response body
+    //   1  query copy for the owned response (outbound channel)
+    //   ----
+    //   4   (down from 5 on the owned WebSocket path — the read-side body Vec)
+    //
+    // As with the TCP path, this applies to with_json/with_typed routes; other
+    // handlers use the owning handle_view fallback.
+    const EXPECTED: usize = 4;
+    let router = Router::new().with_json("/echo", |v: serde_json::Value| Ok(v));
+    let wire = request("/echo", json!({"x": 1}));
+
+    // Warm up (router.get + handler internals touch no per-call statics here,
+    // but keep the shape identical to the other budgets).
+    let _ = dispatch_cycle_ws_inline(&router, &wire, "/echo");
+
+    let (_, allocs) = count_allocs(|| {
+        black_box(dispatch_cycle_ws_inline(&router, &wire, "/echo"));
+    });
+
+    assert_eq!(
+        allocs, EXPECTED,
+        "websocket-inline allocation budget changed (was {EXPECTED}, now {allocs})"
     );
 }


### PR DESCRIPTION
Drives the server hot path toward fewer per-request allocations — fully measured, regression-guarded, and reviewed. Consolidates what were PRs #20–#23 into one branch.

## What it does

| Path | Per-request allocations | Notes |
|---|---|---|
| Registry pointer resolution | `O(N)` → **0** on the walk | read −33%, write −22% |
| TCP / async dispatch (`with_json`/`with_typed`) | 5 → **3** | zero framing allocations; `json_echo` 341→316 ns, `typed_sum` 176→137 ns |
| WebSocket inline (`with_json`/`with_typed`) | 5 → **4** | drops the request body copy; response query still copied for the outbound channel |
| Per-response query echo | clone → **move/borrow** | |

## How it's structured (8 commits, reviewable in order)

1. **Registry resolution** — `Cow`-borrowed pointer tokens, lazy error-path strings.
2. **Query echo: clone → move** — built-in handlers return a query-less response; the dispatch layer supplies the query.
3. **Measurement foundation** — `tests/allocations.rs` (counting `#[global_allocator]`, `assert_eq` budgets) + `benches/server_lifecycle.rs`.
4. **Borrowing primitives** — `read_message_into` / `_async`, `HandlerErased::handle_view`, `MessageView::to_message` / `from_slice_exact`.
5. **TCP + async wiring** — reusable read buffer + `MessageView` dispatch + framing the response from the borrowed query; shared `route()` validation core.
6–7. **Review fixes** — from a 3-agent review (see below) + two clean nits (UTF-8 `from_slice` alignment, `route()` returns the validated path).
8. **WebSocket inline** — reader borrows the tungstenite payload; off-reader stays owned (its task outlives the buffer); proxy stays owned.

## Honest scoping
- The 5→3 / "framing allocates nothing" win is for `with_json`/`with_typed` routes (which override `handle_view`). Context-aware, struct, registry, and middleware-wrapped routes use the owning `handle_view` default — a correct owned copy — and keep the owned count until overridden. Middleware-wrapped routes are structurally bound to the owned path (the `Middleware` trait takes `&Message`).
- This is the conservative slice of the perf space: the data shows **serde_json dominates** (typed handlers are ~2.2× faster than `Value`), so framing was the cheap win, not the big one.

## Behavior change (documented on `HandlerErased`)
Built-in handlers' `handle` / `handle_with_ctx` now return a response whose `query` is **empty** — the dispatch layer fills it. A direct caller (e.g. via `Router::get`) that needs a complete, query-echoing response should use `create_response`, which echoes the query itself. Error and success frames over the wire are byte-identical to `main` (verified live by a review agent). No existing test/example relied on the old behavior. (Edge improvement: an invalid-UTF-8 `Utf8`-framed body is now rejected strictly rather than lossily substituted.)

## What to review (risk areas)
- **`src/websocket_server.rs` `reader_task`** — the borrow/lifetime reasoning (a `view` borrows the payload `Vec`; only owned data crosses the `.await`s and into the spawned off-reader task). This is the most delicate change.
- **`src/server_request.rs`** — the shared `route()` core and the owned-vs-borrowing split (`resolve`/`Resolution` removed; owned `dispatch` kept for off-reader).
- **`src/message.rs`** — the response-builder family (`create_response` echoes; the `*_unstamped` / `*_view` builders are query-less) and `stamp_response_query` / `response_echo_query`.

## Verification
Default + all-features builds, `clippy --all-targets --all-features`, `rustdoc -D broken_intra_doc_links`, and the full suite (incl. the WebSocket inline/off-reader/cancellation/peer/cohosting/proxy tests and the allocation budgets) are all green. Reviewed by three agents on the bulk of the change and a fourth focused on the WebSocket-inline commit; all findings addressed. CHANGELOG updated.

**Recommend squash-merge** — the history contains one add-then-remove of a `create_response_owned` helper across the review-fix commit.
