### PR TITLE
Bump beve 1.4.0 -> 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c20046081d97b1be27be3a64150ef6982487bcbe3005ebb05e45ff5169814b"
+checksum = "b44e159c2f21e26710d447d86d373fc711408c2fc51ed010e2f92957a03f4b4a"
 dependencies = [
  "half",
  "serde",


### PR DESCRIPTION
## Summary

Updates the `beve` dependency in `Cargo.lock` from 1.4.0 to 1.5.0 (the latest published version). The `Cargo.toml` requirement (`beve = "1.4"`, i.e. `^1.4`) already permitted this, so only the lockfile changes.

## What's in beve 1.5.0

A purely additive release. The only API change is a new `read_complex_slice::<T>()` — a bulk, bounds-checked decoder for BEVE complex-number arrays (the read counterpart to the existing `write_complex_slice`/`to_vec_complex_slice` writers, single `copy_nonoverlapping` on little-endian).

The streaming/zero-buffer framing APIs repe pins beve for (`to_writer_streaming`, `serialized_size`, `to_vec_into`) are unchanged and intact.

## Verification

- `cargo build --all-targets` — clean
- `cargo test` — all green (including the `write_message_streaming` doctest and BEVE roundtrip tests)