### PR TITLE
Add write_message_complex_slice: zero-buffer complex body framing (v3.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.5.0] - 2026-06-09
+
+### Added
+- `write_message_complex_slice`, the complex counterpart of `write_message_typed_slice`: it frames a REPE message whose entire body is a complex numeric array (`&[Complex<T>]`) straight to a sink with no intermediate body buffer, sizing it in closed form (`beve::complex_slice_size`, O(1)) and writing the interleaved `(re, im)` payload in one bulk write. The wire bytes are identical to a `MessageBuilder::body_complex_slice` message framed with `write_message`; decode with `Message::decode_complex_slice`. This closes the streaming-framing gap left in 3.4.0, where complex bodies had no zero-buffer path and had to be built and allocated whole via `body_complex_slice`.
+
+### Changed
+- Depend on `beve = "2.1"` (raised from `"2"`), which adds the `to_writer_complex_slice` / `complex_slice_size` streaming primitives backing the new framing helper.
+
 ## [3.4.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7f737013edb35b09159f6845b0a6acee54521857279d36e5d5bb8668aa36c"
+checksum = "1172527f0f50aedb1a656406adb4fc50071f70fea7012e9baa71580a939bbbc3"
 dependencies = [
  "half",
  "serde",
@@ -898,7 +898,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repe"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "beve",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repe"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust implementation of the REPE RPC protocol (JSON-focused)"
@@ -56,12 +56,14 @@ name = "websocket_cohosting"
 required-features = ["websocket"]
 
 [dependencies]
-# beve 2.0's default feature set is already lean (core ser/de + streaming +
+# beve's default feature set is already lean (core ser/de + streaming +
 # typed/complex bulk slice helpers); the heavy MATLAB/HDF5 `mat` interop is opt-in
-# there, so repe no longer needs `default-features = false`. 2.0 is the floor for
-# `read_typed_slice` / `read_complex_slice`, the bulk decoders behind the
-# typed-numeric body fast path.
-beve = "2"
+# there, so repe no longer needs `default-features = false`. 2.1 is the floor for
+# `to_writer_complex_slice` / `complex_slice_size`, the streaming complex
+# primitives behind `write_message_complex_slice` (and carries the
+# `read_typed_slice` / `read_complex_slice` bulk decoders behind the
+# typed-numeric body fast path).
+beve = "2.1"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/dev/typed-numeric-body-fast-path.md
+++ b/dev/typed-numeric-body-fast-path.md
@@ -8,11 +8,9 @@ This file now tracks only what was deliberately left out, with the context neede
 
 ## Future work
 
-### Complex streaming writer (`write_message_typed_slice` for complex)
+### Complex streaming writer — shipped in 3.5.0
 
-`write_message_typed_slice` is zero-buffer for numeric slices, but there is **no streaming complex equivalent** because beve has no `to_writer_complex_slice` — only `to_vec_complex_slice` (which allocates the whole body). A complex body must therefore be built as a `Message` (`body_complex_slice`) and framed with `write_message`.
-
-- **Blocked on beve.** Land `to_writer_complex_slice<W, T>` in beve (the streaming counterpart of `to_vec_complex_slice`, mirroring `to_writer_typed_slice`), plus a `complex_slice_size` for the O(1) length. Then add `write_message_complex_slice` to `src/io.rs`, sized by `complex_slice_size` and written by `to_writer_complex_slice` — symmetric with the numeric path.
+`write_message_typed_slice` was zero-buffer for numeric slices but had no streaming complex equivalent, because beve had only `to_vec_complex_slice` (allocates the whole body) and no streaming writer. Closed: beve 2.1.0 added `to_writer_complex_slice<W, T>` + `complex_slice_size` (the streaming counterpart of `to_vec_complex_slice`, mirroring `to_writer_typed_slice` / `typed_slice_size`), and repe 3.5.0 added `write_message_complex_slice` in `src/io.rs`, sized by `complex_slice_size` and written by `to_writer_complex_slice` — symmetric with the numeric path. Retained here as the record of the gap.
 
 ### `with_typed_slice` handler route
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -152,8 +152,8 @@ where
 /// [`MessageBuilder::body_typed_slice`] message written with [`write_message`];
 /// decode them with [`Message::decode_typed_slice`].
 ///
-/// For an owned message, or for a complex body (beve has no streaming complex
-/// writer yet), build a [`Message`] with
+/// For a complex body use the sibling [`write_message_complex_slice`]. For an
+/// owned message, build a [`Message`] with
 /// [`body_typed_slice`](crate::message::MessageBuilder::body_typed_slice) /
 /// [`body_complex_slice`](crate::message::MessageBuilder::body_complex_slice) and
 /// frame it with [`write_message`].
@@ -175,6 +175,44 @@ where
     let body_len = beve::typed_slice_size(slice);
     write_message_streaming(w, header, query, body_len, |w| {
         beve::to_writer_typed_slice(w, slice)
+    })
+}
+
+/// Frame a REPE message whose entire body is a complex numeric array, writing the
+/// BEVE complex extension array straight to the sink with no intermediate body
+/// buffer — the complex counterpart of [`write_message_typed_slice`].
+///
+/// The body length is computed in closed form with [`beve::complex_slice_size`]
+/// (O(1), no traversal) and the payload is written by
+/// [`beve::to_writer_complex_slice`] (a single `write_all` of the interleaved
+/// `(re, im)` bytes on little-endian targets). So framing a large
+/// `&[Complex<f64>]` costs a header write plus one bulk write, versus building and
+/// allocating the whole body up front via
+/// [`body_complex_slice`](crate::message::MessageBuilder::body_complex_slice).
+///
+/// `header.body_format` is set to [`BodyFormat::Beve`]; `query_length`,
+/// `body_length`, and `length` are filled in from `query` and the slice (as in
+/// [`write_message_streaming`]). The bytes on the wire are identical to a
+/// [`MessageBuilder::body_complex_slice`] message written with [`write_message`];
+/// decode them with [`Message::decode_complex_slice`].
+///
+/// [`BodyFormat::Beve`]: crate::constants::BodyFormat::Beve
+/// [`MessageBuilder::body_complex_slice`]: crate::message::MessageBuilder::body_complex_slice
+/// [`Message::decode_complex_slice`]: crate::message::Message::decode_complex_slice
+pub fn write_message_complex_slice<W, T>(
+    w: &mut W,
+    mut header: Header,
+    query: &[u8],
+    slice: &[beve::Complex<T>],
+) -> Result<(), RepeError>
+where
+    W: Write,
+    T: beve::BeveTypedSlice,
+{
+    header.body_format = crate::constants::BodyFormat::Beve as u16;
+    let body_len = beve::complex_slice_size(slice);
+    write_message_streaming(w, header, query, body_len, |w| {
+        beve::to_writer_complex_slice(w, slice)
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,8 @@ pub use fleet::{
 pub use header::Header;
 #[cfg(not(target_arch = "wasm32"))]
 pub use io::{
-    read_message, read_message_into, write_message, write_message_streaming,
-    write_message_typed_slice,
+    read_message, read_message_into, write_message, write_message_complex_slice,
+    write_message_streaming, write_message_typed_slice,
 };
 pub use json_pointer::{evaluate as eval_json_pointer, parse as parse_json_pointer};
 

--- a/tests/allocations.rs
+++ b/tests/allocations.rs
@@ -24,8 +24,9 @@ use std::io::{Cursor, Write};
 
 use repe::server::Router;
 use repe::{
-    CallContext, HEADER_SIZE, Header, Message, MessageView, QueryFormat, read_message,
-    read_message_into, write_message, write_message_streaming, write_message_typed_slice,
+    CallContext, Complex, HEADER_SIZE, Header, Message, MessageView, QueryFormat, read_message,
+    read_message_into, write_message, write_message_complex_slice, write_message_streaming,
+    write_message_typed_slice,
 };
 use serde_json::json;
 
@@ -290,6 +291,38 @@ fn write_message_typed_slice_uses_no_body_buffer() {
     assert_eq!(
         allocs, 0,
         "streaming a typed-slice body should allocate no intermediate buffer"
+    );
+}
+
+#[test]
+fn write_message_complex_slice_uses_no_body_buffer() {
+    // The complex counterpart of `write_message_typed_slice_uses_no_body_buffer`:
+    // streaming a complex-slice body frames it with no intermediate body `Vec`.
+    // The interleaved (re, im) payload is the slice reinterpreted as bytes
+    // (little-endian) written straight to the sink, so once the reused sink is
+    // warmed, framing allocates nothing. (On big-endian targets beve uses one small
+    // reused scratch buffer; this budget is the little-endian path CI runs on.)
+    let data: Vec<Complex<f64>> = (0..4096)
+        .map(|i| Complex {
+            re: i as f64,
+            im: -(i as f64),
+        })
+        .collect();
+    let query = b"/spectra/iq";
+    let mut out = Vec::new();
+
+    // Warm the sink so its growth isn't charged to the measured call.
+    write_message_complex_slice(&mut out, Header::new(), query, &data).unwrap();
+
+    let (_, allocs) = count_allocs(|| {
+        out.clear();
+        write_message_complex_slice(&mut out, Header::new(), query, &data).unwrap();
+        black_box(&out);
+    });
+
+    assert_eq!(
+        allocs, 0,
+        "streaming a complex-slice body should allocate no intermediate buffer"
     );
 }
 

--- a/tests/typed_numeric_body.rs
+++ b/tests/typed_numeric_body.rs
@@ -1,13 +1,16 @@
 //! End-to-end tests for the typed-numeric body fast path: the bulk
 //! `body_typed_slice` / `body_complex_slice` encoders, the `decode_typed_slice` /
-//! `decode_complex_slice` decoders, and the `write_message_typed_slice` framing
-//! convenience. The central guarantees are that the bulk path is byte-for-byte
-//! interchangeable with the serde (`body_beve`) path and that it round-trips.
+//! `decode_complex_slice` decoders, and the `write_message_typed_slice` /
+//! `write_message_complex_slice` framing convenience. The central guarantees are
+//! that the bulk path is byte-for-byte interchangeable with the serde
+//! (`body_beve`) path and that it round-trips.
 
 use half::{bf16, f16};
 use repe::constants::BodyFormat;
 use repe::message::Message;
-use repe::{Complex, Header, write_message, write_message_typed_slice};
+use repe::{
+    Complex, Header, write_message, write_message_complex_slice, write_message_typed_slice,
+};
 
 #[test]
 fn typed_slice_roundtrips_and_sets_beve_format() {
@@ -123,6 +126,39 @@ fn write_message_typed_slice_frames_identically_to_owned() {
     let parsed = Message::from_slice(&streamed).unwrap();
     assert_eq!(parsed.query, query);
     let back: Vec<f64> = parsed.decode_typed_slice().unwrap();
+    assert_eq!(back, data);
+}
+
+#[test]
+fn write_message_complex_slice_frames_identically_to_owned() {
+    // The streaming complex framing helper must emit byte-for-byte the same wire
+    // frame as building a `body_complex_slice` message and writing it with
+    // `write_message`.
+    let data: Vec<Complex<f64>> = (0..1000)
+        .map(|i| Complex {
+            re: i as f64 * 0.5,
+            im: -(i as f64),
+        })
+        .collect();
+    let query = b"/spectra/iq";
+
+    let mut streamed = Vec::new();
+    write_message_complex_slice(&mut streamed, Header::new(), query, &data).unwrap();
+
+    let owned = Message::builder()
+        .query_bytes(query.to_vec())
+        .body_complex_slice(&data)
+        .build();
+    let mut framed = Vec::new();
+    write_message(&mut framed, &owned).unwrap();
+
+    assert_eq!(streamed, framed);
+
+    // ...and the streamed frame parses back to the original values.
+    let parsed = Message::from_slice(&streamed).unwrap();
+    assert_eq!(parsed.query, query);
+    assert_eq!(parsed.header.body_format, BodyFormat::Beve as u16);
+    let back: Vec<Complex<f64>> = parsed.decode_complex_slice().unwrap();
     assert_eq!(back, data);
 }
 


### PR DESCRIPTION
## Summary

Adds `write_message_complex_slice`, the complex counterpart of `write_message_typed_slice`. It frames a REPE message whose entire body is a complex numeric array (`&[Complex<T>]`) straight to a sink with **no intermediate body buffer**: the body length is computed in closed form with `beve::complex_slice_size` (O(1), no traversal) and the interleaved `(re, im)` payload is written by `beve::to_writer_complex_slice` (a single bulk `write_all` on little-endian targets).

The wire bytes are identical to a `MessageBuilder::body_complex_slice` message framed with `write_message`; decode them with `Message::decode_complex_slice`.

## Why

This closes the streaming-framing gap left in 3.4.0. Numeric bodies already had a zero-buffer streaming path (`write_message_typed_slice`); complex bodies did not, and had to be built and allocated whole via `body_complex_slice` before framing. With beve 2.1.0's new `to_writer_complex_slice` / `complex_slice_size` primitives, complex bodies now get the same zero-allocation framing as numeric ones, completing the typed-body story for the high-throughput complex-array / matrix use case.

## Testing

- `write_message_complex_slice_frames_identically_to_owned` — asserts byte-for-byte equality with the owned `body_complex_slice` + `write_message` path, plus a round-trip through `decode_complex_slice`.
- `write_message_complex_slice_uses_no_body_buffer` — pins the zero-allocation framing budget (0 allocations into a warmed sink).

Full suite + clippy + fmt pass against the published beve 2.1.0.

## Dependency

Raises the beve floor from `"2"` to `"2.1"` for `to_writer_complex_slice` / `complex_slice_size` (published in beve 2.1.0).

## Semver

Additive public API → minor bump to **3.5.0**.