### PR TITLE
Zero-copy borrowing route for bulk numeric requests (with_typed_slice_ref / call_typed_slice_aligned)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.7.0] - 2026-06-09
+
+### Added
+- A zero-copy borrowing route for bulk numeric requests, realizing the aligned-typed-array path noted as future work in 3.6.0 (now that `beve = "2.2"` implements it). `Router::with_typed_slice_ref::<T, R, _>(path, |&[T]| -> Result<Vec<R>, _>)` hands its handler a `&[T]` borrowed straight out of the connection's receive buffer, with no allocation and no element copy on decode, when the request arrives in BEVE's *aligned* typed-array wire form and the buffer base is aligned to `align_of::<T>()` (the common case for the reused per-connection buffer on little-endian targets). The client opts into that wire form with `AsyncClient::call_typed_slice_aligned` / `Client::call_typed_slice_aligned` (with `_with_timeout` variants), which frame the request in place so the padding run places the payload on a `T` boundary within the frame. The aligned body is a distinct BEVE type from the regular typed array, so it pairs specifically with a `with_typed_slice_ref` route; a plain `with_typed_slice` / serde route rejects it with `ErrorCode::InvalidBody` rather than misreading. Conversely a `with_typed_slice_ref` route is a drop-in *superset* of `with_typed_slice`: it transparently accepts the regular (unaligned) typed array sent by `call_typed_slice` and the serde (`call_typed_beve`) path, bulk-copying those into the borrowed `&[T]`, and it falls back to a bulk copy for an aligned body whenever the buffer is not aligned, so correctness never depends on the alignment landing. The response is framed exactly as `with_typed_slice` frames it (a regular typed array), so it interoperates with every client on the way back out. A wrong element class/width surfaces as `RepeError::Beve` rather than being misread. See `tests/typed_slice_zero_copy.rs`.
+
+### Changed
+- Depend on `beve = "2.2"` (raised from `"2.1"`), which adds the aligned typed-array primitives (`write_aligned_typed_slice` / `aligned_typed_slice_size` / `read_aligned_typed_slice` / `read_aligned_typed_slice_ref`) backing the new borrowing route.
+
 ## [3.6.0] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1172527f0f50aedb1a656406adb4fc50071f70fea7012e9baa71580a939bbbc3"
+checksum = "c2b7bcce9a3b058d77a9c93d5168b28e4dc4ca5a2d0f41b51bae5ec50c7f5153"
 dependencies = [
  "half",
  "serde",
@@ -898,7 +898,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repe"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "beve",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repe"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust implementation of the REPE RPC protocol (JSON-focused)"
@@ -58,12 +58,15 @@ required-features = ["websocket"]
 [dependencies]
 # beve's default feature set is already lean (core ser/de + streaming +
 # typed/complex bulk slice helpers); the heavy MATLAB/HDF5 `mat` interop is opt-in
-# there, so repe no longer needs `default-features = false`. 2.1 is the floor for
-# `to_writer_complex_slice` / `complex_slice_size`, the streaming complex
-# primitives behind `write_message_complex_slice` (and carries the
-# `read_typed_slice` / `read_complex_slice` bulk decoders behind the
-# typed-numeric body fast path).
-beve = "2.1"
+# there, so repe no longer needs `default-features = false`. 2.2 is the floor for
+# the aligned typed-array primitives (`write_aligned_typed_slice` /
+# `aligned_typed_slice_size` / `read_aligned_typed_slice` /
+# `read_aligned_typed_slice_ref`) behind the zero-copy borrowing route
+# (`Router::with_typed_slice_ref` / `*::call_typed_slice_aligned`); it also carries
+# `to_writer_complex_slice` / `complex_slice_size` (the streaming complex
+# primitives behind `write_message_complex_slice`) and the `read_typed_slice` /
+# `read_complex_slice` bulk decoders behind the typed-numeric body fast path.
+beve = "2.2"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,26 @@ assert_eq!(out, vec![2.0, 4.0, 6.0]);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+For the request decode, `Router::with_typed_slice_ref` goes one step further and hands the handler a `&[T]` borrowed straight out of the receive buffer, with no allocation or element copy, when the client sends the *aligned* wire form via `call_typed_slice_aligned`:
+
+```rust
+use repe::{Client, Router, Server};
+
+let router = Router::new()
+    .with_typed_slice_ref::<f64, f64, _>("/sum", |xs| Ok(vec![xs.iter().sum()]));
+let server = Server::new(router);
+let listener = server.listen("127.0.0.1:0")?;
+let addr = listener.local_addr()?;
+std::thread::spawn(move || { let _ = server.serve(listener); });
+
+let client = Client::connect(addr)?;
+let out: Vec<f64> = client.call_typed_slice_aligned("/sum", &[1.0, 2.0, 3.0])?;
+assert_eq!(out, vec![6.0]);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+A `with_typed_slice_ref` route is a drop-in superset of `with_typed_slice`: it still accepts the regular `call_typed_slice` / serde clients (bulk-copying those), and falls back to a bulk copy whenever a borrow isn't possible, so correctness never depends on the alignment landing.
+
 ## Feature Flags
 
 | Flag | Effect |

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,7 +1,7 @@
 use crate::async_io::{read_message_async, write_message_async};
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
-use crate::message::{Message, MessageBuilder};
+use crate::message::{Message, MessageBuilder, build_aligned_typed_slice_frame};
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -224,6 +224,56 @@ impl AsyncClient {
         R: beve::BeveTypedSlice,
     {
         self.call_typed_slice_with_optional_timeout(path, body, Some(timeout_duration))
+            .await
+    }
+
+    /// Send a contiguous numeric slice through the *aligned* wire form, enabling a
+    /// zero-copy borrow of the request on a [`Router::with_typed_slice_ref`] server.
+    ///
+    /// Identical in result to [`call_typed_slice`](Self::call_typed_slice) (send
+    /// `&[T]`, decode a `Vec<R>` response), but the request body is framed as a
+    /// BEVE *aligned* typed array: an explicit padding run places the element block
+    /// on an `align_of::<T>()` boundary within the frame, so a `with_typed_slice_ref`
+    /// server reading the frame into an aligned buffer can hand its handler a
+    /// `&[T]` borrowed straight out of that buffer, with no allocation and no
+    /// element copy on decode. The server transparently falls back to a bulk copy
+    /// when its buffer is not aligned, so correctness never depends on the
+    /// alignment landing.
+    ///
+    /// The aligned body is a distinct BEVE type from the regular typed array, so
+    /// this pairs specifically with a `with_typed_slice_ref` route. A plain
+    /// [`with_typed_slice`](crate::server::Router::with_typed_slice) or serde route
+    /// does not understand the aligned form and rejects it; use
+    /// [`call_typed_slice`](Self::call_typed_slice) for those.
+    ///
+    /// [`Router::with_typed_slice_ref`]: crate::server::Router::with_typed_slice_ref
+    pub async fn call_typed_slice_aligned<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        self.call_typed_slice_aligned_with_optional_timeout(path, body, None)
+            .await
+    }
+
+    /// Timeout-bearing twin of [`call_typed_slice_aligned`](Self::call_typed_slice_aligned).
+    pub async fn call_typed_slice_aligned_with_timeout<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+        timeout_duration: Duration,
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        self.call_typed_slice_aligned_with_optional_timeout(path, body, Some(timeout_duration))
             .await
     }
 
@@ -541,6 +591,60 @@ impl AsyncClient {
             )
             .await?;
         resp.decode_typed_slice()
+    }
+
+    async fn call_typed_slice_aligned_with_optional_timeout<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+        timeout_duration: Option<Duration>,
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        let id = self.next_request_id();
+        let frame = build_aligned_typed_slice_frame(id, path.as_ref(), body);
+        let resp = self.dispatch_raw_frame(id, frame, timeout_duration).await?;
+        resp.decode_typed_slice()
+    }
+
+    /// Send a fully-built request frame (header + query + body already serialized)
+    /// under request id `id`, correlate the response, and validate it. The raw-frame
+    /// twin of [`call_with_body_and_timeout`](Self::call_with_body_and_timeout) for
+    /// the in-place aligned framing path, which cannot go through [`MessageBuilder`]
+    /// because its padding depends on the payload's absolute offset in the frame.
+    async fn dispatch_raw_frame(
+        &self,
+        id: u64,
+        frame: Vec<u8>,
+        timeout_duration: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        let (sender, receiver) = oneshot::channel();
+        let mut pending_guard = PendingRequestGuard::register(&self.inner, id, sender)?;
+
+        {
+            let mut writer = self.inner.writer.lock().await;
+            writer.write_all(&frame).await?;
+            writer.flush().await?;
+        }
+
+        let received = match timeout_duration {
+            Some(duration) => match timeout(duration, receiver).await {
+                Ok(Ok(value)) => value,
+                Ok(Err(_)) => return Err(response_channel_closed_error(id)),
+                Err(_) => return Err(request_timeout_error(id, duration)),
+            },
+            None => match receiver.await {
+                Ok(value) => value,
+                Err(_) => return Err(response_channel_closed_error(id)),
+            },
+        };
+
+        let resp = received?;
+        pending_guard.disarm();
+        Self::validate_response(id, resp)
     }
 
     async fn call_with_body_and_timeout<P, F>(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
 use crate::io::{read_message, write_message};
-use crate::message::{Message, MessageBuilder};
+use crate::message::{Message, MessageBuilder, build_aligned_typed_slice_frame};
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -178,6 +178,43 @@ impl Client {
         R: beve::BeveTypedSlice,
     {
         self.call_typed_slice_with_optional_timeout(path, body, Some(timeout))
+    }
+
+    /// Send a contiguous numeric slice through the *aligned* wire form, enabling a
+    /// zero-copy borrow of the request on a [`Router::with_typed_slice_ref`] server.
+    /// The synchronous twin of
+    /// [`AsyncClient::call_typed_slice_aligned`](crate::AsyncClient::call_typed_slice_aligned);
+    /// see it for the full contract. Pairs specifically with a
+    /// [`Router::with_typed_slice_ref`] route (a plain `with_typed_slice` / serde
+    /// route does not understand the aligned form).
+    ///
+    /// [`Router::with_typed_slice_ref`]: crate::server::Router::with_typed_slice_ref
+    pub fn call_typed_slice_aligned<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        self.call_typed_slice_aligned_with_optional_timeout(path, body, None)
+    }
+
+    /// Timeout-bearing twin of [`call_typed_slice_aligned`](Self::call_typed_slice_aligned).
+    pub fn call_typed_slice_aligned_with_timeout<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+        timeout: Duration,
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        self.call_typed_slice_aligned_with_optional_timeout(path, body, Some(timeout))
     }
 
     /// Send a JSON-pointer request with an empty body and return the full response message.
@@ -493,6 +530,64 @@ impl Client {
             |builder| Ok(builder.body_typed_slice(body)),
         )?;
         resp.decode_typed_slice()
+    }
+
+    fn call_typed_slice_aligned_with_optional_timeout<P, T, R>(
+        &self,
+        path: P,
+        body: &[T],
+        timeout: Option<Duration>,
+    ) -> Result<Vec<R>, RepeError>
+    where
+        P: AsRef<str>,
+        T: beve::BeveTypedSlice,
+        R: beve::BeveTypedSlice,
+    {
+        let id = self.next_request_id();
+        let frame = build_aligned_typed_slice_frame(id, path.as_ref(), body);
+        let resp = self.dispatch_raw_frame(id, frame, timeout)?;
+        resp.decode_typed_slice()
+    }
+
+    /// Send a fully-built request frame under request id `id`, correlate the
+    /// response, and validate it. The raw-frame twin of
+    /// [`call_with_body_and_timeout`](Self::call_with_body_and_timeout) for the
+    /// in-place aligned framing path (whose padding depends on the payload's
+    /// absolute frame offset, so it cannot go through [`MessageBuilder`]).
+    fn dispatch_raw_frame(
+        &self,
+        id: u64,
+        frame: Vec<u8>,
+        timeout: Option<Duration>,
+    ) -> Result<Message, RepeError> {
+        let (sender, receiver) = mpsc::channel();
+        {
+            let mut pending = self
+                .inner
+                .pending
+                .lock()
+                .map_err(|_| poisoned_lock_error("client pending map"))?;
+            pending.insert(id, sender);
+        }
+
+        if let Err(err) = self.write_raw_frame(&frame) {
+            self.remove_pending(id);
+            return Err(err);
+        }
+
+        let resp = self.wait_for_response(id, receiver, timeout)?;
+        Self::validate_response(id, resp)
+    }
+
+    fn write_raw_frame(&self, frame: &[u8]) -> Result<(), RepeError> {
+        let mut writer = self
+            .inner
+            .writer
+            .lock()
+            .map_err(|_| poisoned_lock_error("client writer"))?;
+        writer.write_all(frame)?;
+        writer.flush()?;
+        Ok(())
     }
 
     fn call_with_body_and_timeout<P, F>(

--- a/src/message.rs
+++ b/src/message.rs
@@ -839,6 +839,48 @@ mod tests {
         assert_eq!(msg.header.query_format, 0x7777);
         assert_eq!(msg.header.body_format, 0x8888);
     }
+
+    #[test]
+    fn aligned_frame_header_and_payload_round_trip() {
+        let data: Vec<f64> = (0..300).map(|i| i as f64 * 0.5).collect();
+        let frame = build_aligned_typed_slice_frame(42, "/scale", &data);
+
+        // The header parses, the lengths add up, and the body is a valid aligned
+        // typed array that decodes (owned, always works) back to the input.
+        let view = MessageView::from_slice(&frame).expect("frame parses");
+        assert_eq!(view.header.id, 42);
+        assert_eq!(view.header.query_format, QueryFormat::JsonPointer as u16);
+        assert_eq!(view.header.body_format, BodyFormat::Beve as u16);
+        assert_eq!(view.query, b"/scale");
+        assert_eq!(view.header.length as usize, frame.len());
+        let back = beve::read_aligned_typed_slice::<f64>(view.body).expect("owned decode");
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn aligned_frame_payload_is_borrowable_when_buffer_is_aligned() {
+        // Validate the padding math end to end: when the whole frame sits at an
+        // 8-aligned base address, the f64 payload is aligned in memory and the
+        // zero-copy borrow succeeds. We force an 8-aligned backing buffer via a
+        // `Vec<u64>` and copy the frame in at offset 0.
+        let data: Vec<f64> = (0..257).map(|i| 1.0 / (i as f64 + 1.0)).collect();
+        // A 7-byte query makes the unpadded payload offset odd, so a correct
+        // borrow can only come from the inserted alignment padding.
+        let frame = build_aligned_typed_slice_frame(1, "/abcdef", &data);
+
+        let words = frame.len() / 8 + 1;
+        let mut backing: Vec<u64> = vec![0; words];
+        // SAFETY: `backing` is 8-aligned and large enough to hold `frame`.
+        let bytes =
+            unsafe { std::slice::from_raw_parts_mut(backing.as_mut_ptr() as *mut u8, words * 8) };
+        bytes[..frame.len()].copy_from_slice(&frame);
+        let aligned_frame = &bytes[..frame.len()];
+
+        let view = MessageView::from_slice(aligned_frame).expect("frame parses");
+        let borrowed: &[f64] =
+            beve::read_aligned_typed_slice_ref::<f64>(view.body).expect("zero-copy borrow");
+        assert_eq!(borrowed, data.as_slice());
+    }
 }
 
 #[derive(Default)]
@@ -1114,6 +1156,55 @@ pub(crate) fn create_typed_slice_response_unstamped_view<T: beve::BeveTypedSlice
     response_header_builder(view.header.id, view.header.query_format)
         .body_typed_slice(result)
         .build()
+}
+
+/// Build a complete request frame whose body is a BEVE *aligned* typed numeric
+/// array, padded so the element block (`DATA`) lands on an `align_of::<T>()`
+/// boundary measured from the start of the frame.
+///
+/// This is the wire form that enables a zero-copy borrow on the receiving server
+/// ([`Router::with_typed_slice_ref`]): the server reads the whole frame into one
+/// buffer and, when that buffer's base address is aligned, hands the handler a
+/// `&[T]` borrowed straight out of it with no element copy. The regular
+/// [`MessageBuilder::body_typed_slice`] path cannot offer this because its payload
+/// sits at an arbitrary offset; the aligned form inserts an explicit padding run
+/// to fix that.
+///
+/// The padding depends on the payload's absolute offset within the frame, which is
+/// why this frames in place rather than going through [`MessageBuilder`]: the
+/// aligned body is appended directly after the `HEADER_SIZE + query` prefix, so
+/// [`beve::write_aligned_typed_slice`] (which pads relative to the current buffer
+/// length) sees the true offset. The header is written last, once the body length
+/// is known. The bytes are otherwise an ordinary REPE request:
+/// [`QueryFormat::JsonPointer`] query, [`BodyFormat::Beve`] body.
+///
+/// [`Router::with_typed_slice_ref`]: crate::server::Router::with_typed_slice_ref
+pub(crate) fn build_aligned_typed_slice_frame<T: beve::BeveTypedSlice>(
+    id: u64,
+    path: &str,
+    slice: &[T],
+) -> Vec<u8> {
+    let query = path.as_bytes();
+    let prefix = HEADER_SIZE + query.len();
+    let mut frame = Vec::with_capacity(prefix + beve::aligned_typed_slice_size(slice, prefix));
+
+    // Reserve the header (backfilled below), then the query, so that the aligned
+    // body is appended at absolute offset `prefix` and padded for that offset.
+    frame.resize(HEADER_SIZE, 0);
+    frame.extend_from_slice(query);
+    debug_assert_eq!(frame.len(), prefix);
+    beve::write_aligned_typed_slice(&mut frame, slice);
+
+    let body_length = (frame.len() - prefix) as u64;
+    let mut header = Header::new();
+    header.id = id;
+    header.query_format = QueryFormat::JsonPointer as u16;
+    header.body_format = BodyFormat::Beve as u16;
+    header.query_length = query.len() as u64;
+    header.body_length = body_length;
+    header.length = frame.len() as u64;
+    frame[..HEADER_SIZE].copy_from_slice(&header.encode());
+    frame
 }
 
 /// Borrowing twin of [`create_response_unstamped`]: builds the same query-less

--- a/src/server.rs
+++ b/src/server.rs
@@ -571,6 +571,140 @@ where
     }
 }
 
+/// BEVE aligned-typed-array marker byte (`0x5C`): a typed array (type 4) in the
+/// bool/string/aligned sub-category (3) with the aligned discriminator (2), per
+/// BEVE spec §4. It opens the aligned wire form that
+/// [`crate::message::build_aligned_typed_slice_frame`] emits and the borrowing
+/// route decodes. Kept as a local constant rather than reaching into BEVE's
+/// header internals; [`aligned_marker_matches_beve`] pins it to BEVE's actual
+/// output so a future BEVE change cannot drift past us silently.
+const BEVE_ALIGNED_TYPED_ARRAY_MARKER: u8 = 0x5C;
+
+/// A decoded typed-slice request body: either borrowed straight from the receive
+/// buffer (the zero-copy win) or owned after a bulk copy (the fallback). Both
+/// expose the payload as `&[T]`, so the handler closure is oblivious to which
+/// path produced it.
+enum SliceInput<'a, T> {
+    Borrowed(&'a [T]),
+    Owned(Vec<T>),
+}
+
+impl<T> SliceInput<'_, T> {
+    #[inline]
+    fn as_slice(&self) -> &[T] {
+        match self {
+            SliceInput::Borrowed(s) => s,
+            SliceInput::Owned(v) => v,
+        }
+    }
+}
+
+/// Decode a typed-slice request body for the borrowing route, preferring a
+/// zero-copy borrow and degrading gracefully.
+///
+/// Accepts both wire forms so a [`Router::with_typed_slice_ref`] route is a
+/// drop-in superset of [`Router::with_typed_slice`]:
+///
+/// * An *aligned* typed array (marker `0x5C`, what `call_typed_slice_aligned`
+///   sends) is borrowed as `&[T]` when the buffer permits, else bulk-copied (the
+///   aligned payload is unaligned in this particular buffer). A genuine
+///   element-type mismatch or truncation surfaces as an error from the owned
+///   re-read.
+/// * A *regular* typed array (what `call_typed_slice` / the serde path send) has
+///   no padding to borrow through, so it is always bulk-copied via
+///   [`beve::read_typed_slice`].
+fn decode_typed_slice_ref_body<T>(body: &[u8]) -> Result<SliceInput<'_, T>, RepeError>
+where
+    T: beve::BeveTypedSlice,
+{
+    if body.first() == Some(&BEVE_ALIGNED_TYPED_ARRAY_MARKER) {
+        match beve::read_aligned_typed_slice_ref::<T>(body) {
+            Ok(slice) => Ok(SliceInput::Borrowed(slice)),
+            // Borrow refused (buffer base not aligned, or big-endian target) or a
+            // real decode error: re-read owned, which copies and either succeeds
+            // or reports the definitive error.
+            Err(_) => Ok(SliceInput::Owned(beve::read_aligned_typed_slice::<T>(
+                body,
+            )?)),
+        }
+    } else {
+        Ok(SliceInput::Owned(beve::read_typed_slice::<T>(body)?))
+    }
+}
+
+/// Body-format gate shared by the borrowing handler's owned and view paths: a
+/// typed numeric array is only ever [`BodyFormat::Beve`], so any other format is
+/// a client error rather than something to coerce (mirrors
+/// [`decode_typed_slice_param`]). On the happy path it returns the decoded
+/// [`SliceInput`]; on a wrong format it returns the prebuilt error `Message`.
+fn decode_typed_slice_ref_param<'a, T>(
+    body_format: u16,
+    body: &'a [u8],
+    on_bad_format: impl FnOnce() -> Message,
+) -> Result<Result<SliceInput<'a, T>, Message>, RepeError>
+where
+    T: beve::BeveTypedSlice,
+{
+    match BodyFormat::try_from(body_format) {
+        Ok(BodyFormat::Beve) => Ok(Ok(decode_typed_slice_ref_body::<T>(body)?)),
+        _ => Ok(Err(on_bad_format())),
+    }
+}
+
+/// Borrowing bulk numeric handler registered by [`Router::with_typed_slice_ref`].
+/// Identical to [`TypedSliceHandler`] except the closure receives a borrowed
+/// `&[T]` request, which on the view (server) path comes straight out of the
+/// connection's receive buffer with no element copy when the aligned wire form
+/// and buffer alignment allow it.
+struct TypedSliceRefHandler<T, R, F>(F, std::marker::PhantomData<(T, R)>)
+where
+    T: beve::BeveTypedSlice + Send + Sync + 'static,
+    R: beve::BeveTypedSlice + Send + Sync + 'static,
+    F: Fn(&[T]) -> Result<Vec<R>, (ErrorCode, String)> + Send + Sync + 'static;
+
+impl<T, R, F> HandlerErased for TypedSliceRefHandler<T, R, F>
+where
+    T: beve::BeveTypedSlice + Send + Sync + 'static,
+    R: beve::BeveTypedSlice + Send + Sync + 'static,
+    F: Fn(&[T]) -> Result<Vec<R>, (ErrorCode, String)> + Send + Sync + 'static,
+{
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let input =
+            match decode_typed_slice_ref_param::<T>(req.header.body_format, &req.body, || {
+                create_error_response_like(
+                    req,
+                    ErrorCode::InvalidBody,
+                    "Expected BEVE typed-numeric body",
+                )
+            })? {
+                Ok(v) => v,
+                Err(err) => return Ok(err),
+            };
+        match (self.0)(input.as_slice()) {
+            Ok(out) => Ok(create_typed_slice_response_unstamped(req, &out)),
+            Err((code, msg)) => Ok(create_error_response_like(req, code, msg)),
+        }
+    }
+
+    fn handle_view(&self, view: &MessageView, _ctx: &CallContext) -> Result<Message, RepeError> {
+        let input =
+            match decode_typed_slice_ref_param::<T>(view.header.body_format, view.body, || {
+                create_error_response_unstamped_view(
+                    view,
+                    ErrorCode::InvalidBody,
+                    "Expected BEVE typed-numeric body",
+                )
+            })? {
+                Ok(v) => v,
+                Err(err) => return Ok(err),
+            };
+        match (self.0)(input.as_slice()) {
+            Ok(out) => Ok(create_typed_slice_response_unstamped_view(view, &out)),
+            Err((code, msg)) => Ok(create_error_response_unstamped_view(view, code, msg)),
+        }
+    }
+}
+
 /// Trait shape mirroring [`TypedHandlerFn`] for context-aware typed
 /// handlers. Implemented by closures of the form
 /// `Fn(&CallContext, T) -> Result<R, (ErrorCode, String)>`.
@@ -1003,6 +1137,49 @@ impl Router {
         self.insert_route(
             path,
             Arc::new(TypedSliceHandler::<T, R, F>(f, std::marker::PhantomData)),
+        );
+        self
+    }
+
+    /// Add a bulk numeric handler whose closure *borrows* its request as `&[T]`,
+    /// the zero-copy counterpart of [`with_typed_slice`](Self::with_typed_slice).
+    ///
+    /// When the client sends the request through the aligned wire form
+    /// ([`AsyncClient::call_typed_slice_aligned`] / [`Client::call_typed_slice_aligned`])
+    /// and the connection's receive buffer happens to be aligned to
+    /// `align_of::<T>()` (the common case for the reused per-connection buffer on
+    /// little-endian targets), the handler receives a `&[T]` pointing straight
+    /// into that buffer: no allocation and no element copy on the way in. When the
+    /// buffer is not aligned, or the client used the regular
+    /// [`call_typed_slice`](crate::AsyncClient::call_typed_slice) / serde path, the
+    /// body is bulk-copied into an owned buffer first and the handler sees a `&[T]`
+    /// over that. Either way the closure is identical, so a `with_typed_slice_ref`
+    /// route is a drop-in superset of `with_typed_slice`: it accepts every client
+    /// the latter does, and additionally borrows when it can.
+    ///
+    /// The response is framed exactly as [`with_typed_slice`](Self::with_typed_slice)
+    /// frames it (a regular typed array), so it interoperates with every client on
+    /// the way back out.
+    ///
+    /// ```ignore
+    /// use repe::server::Router;
+    /// // Sum each request without ever copying it into a `Vec<f64>`.
+    /// let router = Router::new()
+    ///     .with_typed_slice_ref::<f64, f64, _>("/stats", |xs| Ok(vec![xs.iter().sum()]));
+    /// ```
+    ///
+    /// [`with_typed_slice`]: Self::with_typed_slice
+    /// [`AsyncClient::call_typed_slice_aligned`]: crate::AsyncClient::call_typed_slice_aligned
+    /// [`Client::call_typed_slice_aligned`]: crate::Client::call_typed_slice_aligned
+    pub fn with_typed_slice_ref<T, R, F>(mut self, path: &str, f: F) -> Self
+    where
+        T: beve::BeveTypedSlice + Send + Sync + 'static,
+        R: beve::BeveTypedSlice + Send + Sync + 'static,
+        F: Fn(&[T]) -> Result<Vec<R>, (ErrorCode, String)> + Send + Sync + 'static,
+    {
+        self.insert_route(
+            path,
+            Arc::new(TypedSliceRefHandler::<T, R, F>(f, std::marker::PhantomData)),
         );
         self
     }
@@ -1665,6 +1842,15 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use std::io::Read;
     use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+    /// Pin [`BEVE_ALIGNED_TYPED_ARRAY_MARKER`] to BEVE's actual aligned-array
+    /// output, so the borrowing route's marker dispatch can never silently drift
+    /// from the format BEVE emits.
+    #[test]
+    fn aligned_marker_matches_beve() {
+        let encoded = beve::to_vec_aligned_typed_slice(&[1.0_f64]);
+        assert_eq!(encoded.first(), Some(&BEVE_ALIGNED_TYPED_ARRAY_MARKER));
+    }
 
     #[test]
     fn middleware_runs_for_registered_handlers() {

--- a/tests/typed_slice_zero_copy.rs
+++ b/tests/typed_slice_zero_copy.rs
@@ -1,0 +1,146 @@
+//! End-to-end coverage for the zero-copy borrowing route: `Router::with_typed_slice_ref`
+//! paired with `*::call_typed_slice_aligned` (the aligned wire form), plus the
+//! interop guarantees that make a `_ref` route a drop-in superset of
+//! `with_typed_slice`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use repe::server::Router;
+use repe::{AsyncClient, AsyncServer, Client, Server};
+use std::time::Duration;
+
+async fn spawn(router: Router) -> String {
+    let listener = AsyncServer::listen("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr").to_string();
+    tokio::spawn(async move { AsyncServer::new(router).serve(listener).await });
+    addr
+}
+
+fn spawn_sync(router: Router) -> String {
+    let server = Server::new(router);
+    let listener = server.listen("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr").to_string();
+    std::thread::spawn(move || server.serve(listener));
+    addr
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aligned_call_roundtrips_against_ref_route() {
+    let router = Router::new()
+        .with_typed_slice_ref::<f64, f64, _>("/scale2", |xs| {
+            Ok(xs.iter().map(|x| x * 2.0).collect())
+        })
+        .with_typed_slice_ref::<f32, f32, _>("/negate", |xs| Ok(xs.iter().map(|x| -x).collect()));
+    let addr = spawn(router).await;
+    let client = AsyncClient::connect(&addr).await.expect("connect");
+
+    // A large body spans multiple TCP segments, exercising the borrow path on the
+    // server's reused, (in practice) aligned receive buffer.
+    let xs: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.25).collect();
+    let out: Vec<f64> = client
+        .call_typed_slice_aligned("/scale2", &xs)
+        .await
+        .expect("aligned f64");
+    assert_eq!(out, xs.iter().map(|x| x * 2.0).collect::<Vec<_>>());
+
+    let fs: Vec<f32> = (0..1024).map(|i| i as f32 - 7.5).collect();
+    let neg: Vec<f32> = client
+        .call_typed_slice_aligned("/negate", &fs)
+        .await
+        .expect("aligned f32");
+    assert_eq!(neg, fs.iter().map(|x| -x).collect::<Vec<_>>());
+
+    // Empty slice must round-trip cleanly through the aligned form too.
+    let empty: Vec<f64> = Vec::new();
+    let back: Vec<f64> = client
+        .call_typed_slice_aligned("/scale2", &empty)
+        .await
+        .expect("empty");
+    assert!(back.is_empty());
+
+    // Timeout-bearing variant succeeds on the happy path.
+    let xs2: Vec<f64> = vec![1.0, 2.0, 3.0];
+    let out2: Vec<f64> = client
+        .call_typed_slice_aligned_with_timeout("/scale2", &xs2, Duration::from_secs(5))
+        .await
+        .expect("aligned with timeout");
+    assert_eq!(out2, vec![2.0, 4.0, 6.0]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ref_route_accepts_regular_typed_slice_client() {
+    // A `_ref` route is a superset: a plain `call_typed_slice` (regular, unaligned
+    // wire form) is bulk-copied into the borrowed `&[T]` and works unchanged.
+    let router = Router::new().with_typed_slice_ref::<f64, f64, _>("/echo", |xs| Ok(xs.to_vec()));
+    let addr = spawn(router).await;
+    let client = AsyncClient::connect(&addr).await.expect("connect");
+
+    let xs: Vec<f64> = (0..256).map(|i| i as f64 * 1.5).collect();
+    let out: Vec<f64> = client
+        .call_typed_slice("/echo", &xs)
+        .await
+        .expect("regular -> ref");
+    assert_eq!(out, xs);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ref_route_accepts_serde_client() {
+    // The serde path (`call_typed_beve` over `Vec<f64>`) also reaches a `_ref`
+    // route, since its body is the regular typed array the superset decoder reads.
+    let router = Router::new().with_typed_slice_ref::<f64, f64, _>("/echo", |xs| Ok(xs.to_vec()));
+    let addr = spawn(router).await;
+    let client = AsyncClient::connect(&addr).await.expect("connect");
+
+    let xs: Vec<f64> = vec![1.0, -2.5, 3.25, 4.0e9];
+    let out: Vec<f64> = client
+        .call_typed_beve("/echo", &xs)
+        .await
+        .expect("serde -> ref");
+    assert_eq!(out, xs);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aligned_call_against_regular_route_is_an_error() {
+    // The aligned body is a distinct BEVE type; a plain `with_typed_slice` route
+    // does not understand it and rejects rather than misreading.
+    let router = Router::new().with_typed_slice::<f64, f64, _>("/echo", Ok);
+    let addr = spawn(router).await;
+    let client = AsyncClient::connect(&addr).await.expect("connect");
+
+    let xs: Vec<f64> = vec![1.0, 2.0, 3.0];
+    let res: Result<Vec<f64>, _> = client.call_typed_slice_aligned("/echo", &xs).await;
+    assert!(res.is_err(), "aligned body into a regular route must error");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_element_type_is_an_error() {
+    // Server expects f64; client sends an aligned f32 array. The element
+    // class/width disagree, so the borrowing decoder rejects.
+    let router = Router::new().with_typed_slice_ref::<f64, f64, _>("/echo", |xs| Ok(xs.to_vec()));
+    let addr = spawn(router).await;
+    let client = AsyncClient::connect(&addr).await.expect("connect");
+
+    let fs: Vec<f32> = vec![1.0, 2.0, 3.0];
+    let res: Result<Vec<f32>, _> = client.call_typed_slice_aligned("/echo", &fs).await;
+    assert!(res.is_err(), "aligned f32 into an f64 route must error");
+}
+
+#[test]
+fn sync_aligned_call_roundtrips_against_ref_route() {
+    let router = Router::new().with_typed_slice_ref::<f64, f64, _>("/scale2", |xs| {
+        Ok(xs.iter().map(|x| x * 2.0).collect())
+    });
+    let addr = spawn_sync(router);
+
+    let client = Client::connect(&addr).expect("connect");
+    let xs: Vec<f64> = (0..2048).map(|i| i as f64 * 0.5).collect();
+    let out: Vec<f64> = client
+        .call_typed_slice_aligned("/scale2", &xs)
+        .expect("sync aligned");
+    assert_eq!(out, xs.iter().map(|x| x * 2.0).collect::<Vec<_>>());
+
+    let out2: Vec<f64> = client
+        .call_typed_slice_aligned_with_timeout("/scale2", &xs, Duration::from_secs(5))
+        .expect("sync aligned with timeout");
+    assert_eq!(out2, xs.iter().map(|x| x * 2.0).collect::<Vec<_>>());
+}


### PR DESCRIPTION
## What

Adds a **zero-copy borrowing route** for bulk numeric requests, realizing the aligned-typed-array path that the 3.6.0 changelog flagged as future work (now that `beve = "2.2"` implements the aligned primitives).

- **`Router::with_typed_slice_ref::<T, R, _>(path, |&[T]| -> Result<Vec<R>, _>)`** hands its handler a `&[T]` borrowed straight out of the connection's receive buffer — no allocation, no element copy on decode — when the request arrives in BEVE's *aligned* typed-array wire form and the buffer base is aligned to `align_of::<T>()` (the common case for the reused per-connection buffer on little-endian targets).
- **`AsyncClient::call_typed_slice_aligned` / `Client::call_typed_slice_aligned`** (plus `_with_timeout` variants) opt into that wire form. They frame the request *in place* (header + query + aligned body in one buffer) so the padding run places the payload on a `T` boundary measured from the frame start — which cannot be done through `MessageBuilder`, whose padding would be offset-blind.

## Why it's safe to adopt

A `with_typed_slice_ref` route is a **drop-in superset** of `with_typed_slice`:

- It still accepts the regular (unaligned) typed array sent by `call_typed_slice` and the serde `call_typed_beve` path, bulk-copying those into the borrowed `&[T]`.
- It falls back to a bulk copy for an aligned body whenever the buffer base isn't aligned (or on a big-endian target), so **correctness never depends on the alignment landing**.
- The response is framed exactly as `with_typed_slice` frames it (a regular typed array), so it interoperates with every client on the way back out.

The aligned body is a *distinct* BEVE type from the regular typed array, so `call_typed_slice_aligned` pairs specifically with a `_ref` route; a plain `with_typed_slice` / serde route rejects it with `ErrorCode::InvalidBody` rather than misreading. A wrong element class/width surfaces as `RepeError::Beve`.

## Measurement

The borrow eliminates the request-side decode allocation + memcpy. Timing the three server-side decode paths in isolation for an f64 body (`bench/` scratch, release):

| elements | regular (owned) | aligned (owned) | **borrow** |
|---|---|---|---|
| 1,024 | 257 ns | 235 ns | **8 ns** |
| 16,384 | 2.65 µs | 2.46 µs | **7 ns** |
| 262,144 | 57.3 µs | 45.4 µs | **7 ns** |
| 1,000,000 | 234 µs | 213 µs | **7 ns** |

The borrow is constant-time regardless of array size; the owned copy scales linearly. End-to-end RPC gains are smaller and array-size-dependent (the response framing and the handler's own output `Vec<R>` are unaffected) — this PR claims only the structural decode-side win, not an end-to-end multiplier.

## Soundness

The unsafe is all in `beve` (`read_aligned_typed_slice_ref` runtime-checks the payload pointer alignment and refuses, returning `Unsupported`, rather than risk an unaligned read). repe only frames bytes and dispatches on the marker. The marker constant is pinned to BEVE's actual output by a test (`aligned_marker_matches_beve`) so a future BEVE change can't drift past us silently.

## Tests

- `tests/typed_slice_zero_copy.rs` — aligned round-trip (f64/f32/empty/large/timeout, sync + async); `_ref` accepts regular + serde clients; aligned-into-regular-route errors; wrong-element-type errors.
- `src/message.rs` unit tests — frame header/payload round-trip, and an end-to-end borrow against an 8-aligned backing buffer validating the padding math.

## Wire compatibility

No change to existing wire formats. `call_typed_slice` and the serde path are byte-for-byte unchanged; the Glaze/C++ interop fixtures are unaffected. The aligned form is strictly additive and opt-in.

Closes the "future work" note in the 3.6.0 changelog. Version bump 3.6.0 → 3.7.0.