### PR TITLE
Unify aligned client framing through MessageBuilder::body_aligned_typed_slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.8.0] - 2026-06-09
+
+### Added
+- `MessageBuilder::body_aligned_typed_slice(&[T])`, the zero-copy counterpart of `body_typed_slice`: it encodes a contiguous numeric slice as BEVE's *aligned* typed array, padded (via `beve::write_aligned_typed_slice_at`) so the payload lands on an `align_of::<T>()` boundary at its eventual `HEADER_SIZE + query.len()` frame offset. This makes the body borrowable as `&[T]` by a `Router::with_typed_slice_ref` server. The query must be set before this is called (so the offset is known); if it is set afterward the padding is for the wrong offset and the server falls back to a bulk copy (still correct, just not zero-copy). The body carries the same `into_wire_bytes` wire-prefix headroom as `body_typed_slice`, and the alignment survives that shift.
+
+### Changed
+- `AsyncClient::call_typed_slice_aligned` / `Client::call_typed_slice_aligned` now frame their request through `MessageBuilder::body_aligned_typed_slice` and the ordinary `call_with_body_and_timeout` path, replacing the dedicated in-place frame builder and raw-frame dispatch helpers introduced in 3.7.0. The wire bytes are byte-for-byte identical, so this is an internal simplification with no observable behavior change; it removes the parallel send path now that `beve = "2.3"` can pad a standalone body for an arbitrary frame offset.
+- Depend on `beve = "2.3"` (raised from `"2.2"`), the floor for `write_aligned_typed_slice_at` (the offset-aware aligned writer).
+
 ## [3.7.0] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b7bcce9a3b058d77a9c93d5168b28e4dc4ca5a2d0f41b51bae5ec50c7f5153"
+checksum = "ac470faa8d03fa0331336217fc92245b7eaca6e05c52b364f5c181eed9d3fcf7"
 dependencies = [
  "half",
  "serde",
@@ -898,7 +898,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repe"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "beve",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repe"
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust implementation of the REPE RPC protocol (JSON-focused)"
@@ -58,15 +58,17 @@ required-features = ["websocket"]
 [dependencies]
 # beve's default feature set is already lean (core ser/de + streaming +
 # typed/complex bulk slice helpers); the heavy MATLAB/HDF5 `mat` interop is opt-in
-# there, so repe no longer needs `default-features = false`. 2.2 is the floor for
-# the aligned typed-array primitives (`write_aligned_typed_slice` /
-# `aligned_typed_slice_size` / `read_aligned_typed_slice` /
+# there, so repe no longer needs `default-features = false`. 2.3 is the floor for
+# `write_aligned_typed_slice_at`, the offset-aware aligned writer that
+# `MessageBuilder::body_aligned_typed_slice` uses to pad a standalone body for its
+# eventual frame offset; 2.2 added the rest of the aligned typed-array primitives
+# (`aligned_typed_slice_size` / `read_aligned_typed_slice` /
 # `read_aligned_typed_slice_ref`) behind the zero-copy borrowing route
-# (`Router::with_typed_slice_ref` / `*::call_typed_slice_aligned`); it also carries
+# (`Router::with_typed_slice_ref` / `*::call_typed_slice_aligned`). beve also carries
 # `to_writer_complex_slice` / `complex_slice_size` (the streaming complex
 # primitives behind `write_message_complex_slice`) and the `read_typed_slice` /
 # `read_complex_slice` bulk decoders behind the typed-numeric body fast path.
-beve = "2.2"
+beve = "2.3"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,7 +1,7 @@
 use crate::async_io::{read_message_async, write_message_async};
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
-use crate::message::{Message, MessageBuilder, build_aligned_typed_slice_frame};
+use crate::message::{Message, MessageBuilder};
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -604,47 +604,15 @@ impl AsyncClient {
         T: beve::BeveTypedSlice,
         R: beve::BeveTypedSlice,
     {
-        let id = self.next_request_id();
-        let frame = build_aligned_typed_slice_frame(id, path.as_ref(), body);
-        let resp = self.dispatch_raw_frame(id, frame, timeout_duration).await?;
+        let resp = self
+            .call_with_body_and_timeout(
+                path,
+                QueryFormat::JsonPointer as u16,
+                timeout_duration,
+                |builder| Ok(builder.body_aligned_typed_slice(body)),
+            )
+            .await?;
         resp.decode_typed_slice()
-    }
-
-    /// Send a fully-built request frame (header + query + body already serialized)
-    /// under request id `id`, correlate the response, and validate it. The raw-frame
-    /// twin of [`call_with_body_and_timeout`](Self::call_with_body_and_timeout) for
-    /// the in-place aligned framing path, which cannot go through [`MessageBuilder`]
-    /// because its padding depends on the payload's absolute offset in the frame.
-    async fn dispatch_raw_frame(
-        &self,
-        id: u64,
-        frame: Vec<u8>,
-        timeout_duration: Option<Duration>,
-    ) -> Result<Message, RepeError> {
-        let (sender, receiver) = oneshot::channel();
-        let mut pending_guard = PendingRequestGuard::register(&self.inner, id, sender)?;
-
-        {
-            let mut writer = self.inner.writer.lock().await;
-            writer.write_all(&frame).await?;
-            writer.flush().await?;
-        }
-
-        let received = match timeout_duration {
-            Some(duration) => match timeout(duration, receiver).await {
-                Ok(Ok(value)) => value,
-                Ok(Err(_)) => return Err(response_channel_closed_error(id)),
-                Err(_) => return Err(request_timeout_error(id, duration)),
-            },
-            None => match receiver.await {
-                Ok(value) => value,
-                Err(_) => return Err(response_channel_closed_error(id)),
-            },
-        };
-
-        let resp = received?;
-        pending_guard.disarm();
-        Self::validate_response(id, resp)
     }
 
     async fn call_with_body_and_timeout<P, F>(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
 use crate::error::RepeError;
 use crate::io::{read_message, write_message};
-use crate::message::{Message, MessageBuilder, build_aligned_typed_slice_frame};
+use crate::message::{Message, MessageBuilder};
 use beve::from_slice as beve_from_slice;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -543,51 +543,13 @@ impl Client {
         T: beve::BeveTypedSlice,
         R: beve::BeveTypedSlice,
     {
-        let id = self.next_request_id();
-        let frame = build_aligned_typed_slice_frame(id, path.as_ref(), body);
-        let resp = self.dispatch_raw_frame(id, frame, timeout)?;
+        let resp = self.call_with_body_and_timeout(
+            path,
+            QueryFormat::JsonPointer as u16,
+            timeout,
+            |builder| Ok(builder.body_aligned_typed_slice(body)),
+        )?;
         resp.decode_typed_slice()
-    }
-
-    /// Send a fully-built request frame under request id `id`, correlate the
-    /// response, and validate it. The raw-frame twin of
-    /// [`call_with_body_and_timeout`](Self::call_with_body_and_timeout) for the
-    /// in-place aligned framing path (whose padding depends on the payload's
-    /// absolute frame offset, so it cannot go through [`MessageBuilder`]).
-    fn dispatch_raw_frame(
-        &self,
-        id: u64,
-        frame: Vec<u8>,
-        timeout: Option<Duration>,
-    ) -> Result<Message, RepeError> {
-        let (sender, receiver) = mpsc::channel();
-        {
-            let mut pending = self
-                .inner
-                .pending
-                .lock()
-                .map_err(|_| poisoned_lock_error("client pending map"))?;
-            pending.insert(id, sender);
-        }
-
-        if let Err(err) = self.write_raw_frame(&frame) {
-            self.remove_pending(id);
-            return Err(err);
-        }
-
-        let resp = self.wait_for_response(id, receiver, timeout)?;
-        Self::validate_response(id, resp)
-    }
-
-    fn write_raw_frame(&self, frame: &[u8]) -> Result<(), RepeError> {
-        let mut writer = self
-            .inner
-            .writer
-            .lock()
-            .map_err(|_| poisoned_lock_error("client writer"))?;
-        writer.write_all(frame)?;
-        writer.flush()?;
-        Ok(())
     }
 
     fn call_with_body_and_timeout<P, F>(

--- a/src/message.rs
+++ b/src/message.rs
@@ -840,10 +840,32 @@ mod tests {
         assert_eq!(msg.header.body_format, 0x8888);
     }
 
+    /// Copy `frame` into a genuinely 8-aligned backing buffer (via `Vec<u64>`) and
+    /// return it, so a test can validate the zero-copy borrow at a known-aligned
+    /// base address.
+    fn into_aligned_buffer(frame: &[u8]) -> Vec<u64> {
+        let words = frame.len() / 8 + 1;
+        let mut backing: Vec<u64> = vec![0; words];
+        // SAFETY: `backing` is 8-aligned and large enough to hold `frame`.
+        let bytes =
+            unsafe { std::slice::from_raw_parts_mut(backing.as_mut_ptr() as *mut u8, words * 8) };
+        bytes[..frame.len()].copy_from_slice(frame);
+        backing
+    }
+
+    fn aligned_request(id: u64, path: &str, data: &[f64]) -> Message {
+        Message::builder()
+            .id(id)
+            .query_str(path)
+            .query_format(QueryFormat::JsonPointer)
+            .body_aligned_typed_slice(data)
+            .build()
+    }
+
     #[test]
-    fn aligned_frame_header_and_payload_round_trip() {
+    fn aligned_body_builder_header_and_payload_round_trip() {
         let data: Vec<f64> = (0..300).map(|i| i as f64 * 0.5).collect();
-        let frame = build_aligned_typed_slice_frame(42, "/scale", &data);
+        let frame = aligned_request(42, "/scale", &data).to_vec();
 
         // The header parses, the lengths add up, and the body is a valid aligned
         // typed array that decodes (owned, always works) back to the input.
@@ -858,25 +880,41 @@ mod tests {
     }
 
     #[test]
-    fn aligned_frame_payload_is_borrowable_when_buffer_is_aligned() {
+    fn aligned_body_payload_is_borrowable_when_buffer_is_aligned() {
         // Validate the padding math end to end: when the whole frame sits at an
         // 8-aligned base address, the f64 payload is aligned in memory and the
-        // zero-copy borrow succeeds. We force an 8-aligned backing buffer via a
-        // `Vec<u64>` and copy the frame in at offset 0.
+        // zero-copy borrow succeeds. A 7-byte query makes the unpadded payload
+        // offset odd, so a correct borrow can only come from the inserted padding.
         let data: Vec<f64> = (0..257).map(|i| 1.0 / (i as f64 + 1.0)).collect();
-        // A 7-byte query makes the unpadded payload offset odd, so a correct
-        // borrow can only come from the inserted alignment padding.
-        let frame = build_aligned_typed_slice_frame(1, "/abcdef", &data);
+        let frame = aligned_request(1, "/abcdef", &data).to_vec();
 
-        let words = frame.len() / 8 + 1;
-        let mut backing: Vec<u64> = vec![0; words];
-        // SAFETY: `backing` is 8-aligned and large enough to hold `frame`.
+        let backing = into_aligned_buffer(&frame);
         let bytes =
-            unsafe { std::slice::from_raw_parts_mut(backing.as_mut_ptr() as *mut u8, words * 8) };
-        bytes[..frame.len()].copy_from_slice(&frame);
-        let aligned_frame = &bytes[..frame.len()];
+            unsafe { std::slice::from_raw_parts(backing.as_ptr() as *const u8, frame.len()) };
 
-        let view = MessageView::from_slice(aligned_frame).expect("frame parses");
+        let view = MessageView::from_slice(bytes).expect("frame parses");
+        let borrowed: &[f64] =
+            beve::read_aligned_typed_slice_ref::<f64>(view.body).expect("zero-copy borrow");
+        assert_eq!(borrowed, data.as_slice());
+    }
+
+    #[test]
+    fn aligned_body_survives_into_wire_bytes() {
+        // `into_wire_bytes` shifts the body to `HEADER_SIZE + query.len()`, which is
+        // exactly the offset `body_aligned_typed_slice` padded for, so the alignment
+        // is preserved through that outbound path too (not just `to_vec`).
+        let data: Vec<f64> = (0..130).map(|i| i as f64 - 64.0).collect();
+        let frame = aligned_request(7, "/abcdef", &data).into_wire_bytes();
+        assert_eq!(
+            beve::read_aligned_typed_slice::<f64>(MessageView::from_slice(&frame).unwrap().body)
+                .unwrap(),
+            data
+        );
+
+        let backing = into_aligned_buffer(&frame);
+        let bytes =
+            unsafe { std::slice::from_raw_parts(backing.as_ptr() as *const u8, frame.len()) };
+        let view = MessageView::from_slice(bytes).expect("frame parses");
         let borrowed: &[f64] =
             beve::read_aligned_typed_slice_ref::<f64>(view.body).expect("zero-copy borrow");
         assert_eq!(borrowed, data.as_slice());
@@ -1002,6 +1040,48 @@ impl MessageBuilder {
         let mut body = Vec::with_capacity(body_len + HEADER_SIZE + self.query.len());
         beve::to_writer_complex_slice(&mut body, slice)
             .expect("writing a complex slice into a Vec is infallible");
+        self.body = body;
+        self.body_format = BodyFormat::Beve as u16;
+        self
+    }
+
+    /// Encode a contiguous numeric slice as a BEVE *aligned* typed array, padded so
+    /// the element block lands on an `align_of::<T>()` boundary within the final
+    /// wire frame, and set [`BodyFormat::Beve`].
+    ///
+    /// The zero-copy counterpart of [`body_typed_slice`]: it emits BEVE's aligned
+    /// typed-array form (an explicit padding run before the payload) so a
+    /// [`Router::with_typed_slice_ref`] server reading the frame into an aligned
+    /// buffer can borrow the body as `&[T]` with no element copy. Decode the owned
+    /// view with [`Message::decode_typed_slice`] as usual; the borrow happens
+    /// server-side.
+    ///
+    /// The padding is sized for the payload's absolute offset in the frame
+    /// (`HEADER_SIZE + query.len()`), so **the query must already be set** when this
+    /// is called (the common `.query_*(..).body_aligned_typed_slice(..)` order, and
+    /// what the `call_typed_slice_aligned` client helpers do). If the query is set
+    /// *after* the body, the padding is computed for the wrong offset and the
+    /// payload will not be borrowable in the frame — the server then falls back to a
+    /// bulk copy, so the result is still correct, just not zero-copy. The body
+    /// buffer carries the same `HEADER_SIZE + query.len()` wire-prefix headroom as
+    /// [`body_typed_slice`], and [`Message::into_wire_bytes`] shifts the body to
+    /// exactly that offset, so the alignment is preserved through that path too.
+    ///
+    /// Unlike [`body_typed_slice`], the bytes are a distinct BEVE type and are *not*
+    /// interchangeable with the serde / regular typed-array path; they pair
+    /// specifically with a `with_typed_slice_ref` route.
+    ///
+    /// [`body_typed_slice`]: Self::body_typed_slice
+    /// [`Router::with_typed_slice_ref`]: crate::server::Router::with_typed_slice_ref
+    pub fn body_aligned_typed_slice<T: beve::BeveTypedSlice>(mut self, slice: &[T]) -> Self {
+        let base_offset = HEADER_SIZE + self.query.len();
+        let body_len = beve::aligned_typed_slice_size(slice, base_offset);
+        // Reserve the `HEADER_SIZE + query.len()` wire-prefix headroom (== base_offset)
+        // so `into_wire_bytes` reuses this allocation; its body shift lands the
+        // payload at exactly `base_offset`, which is what the padding was sized for.
+        let mut body = Vec::with_capacity(body_len + base_offset);
+        beve::write_aligned_typed_slice_at(&mut body, slice, base_offset);
+        debug_assert_eq!(body.len(), body_len);
         self.body = body;
         self.body_format = BodyFormat::Beve as u16;
         self
@@ -1156,55 +1236,6 @@ pub(crate) fn create_typed_slice_response_unstamped_view<T: beve::BeveTypedSlice
     response_header_builder(view.header.id, view.header.query_format)
         .body_typed_slice(result)
         .build()
-}
-
-/// Build a complete request frame whose body is a BEVE *aligned* typed numeric
-/// array, padded so the element block (`DATA`) lands on an `align_of::<T>()`
-/// boundary measured from the start of the frame.
-///
-/// This is the wire form that enables a zero-copy borrow on the receiving server
-/// ([`Router::with_typed_slice_ref`]): the server reads the whole frame into one
-/// buffer and, when that buffer's base address is aligned, hands the handler a
-/// `&[T]` borrowed straight out of it with no element copy. The regular
-/// [`MessageBuilder::body_typed_slice`] path cannot offer this because its payload
-/// sits at an arbitrary offset; the aligned form inserts an explicit padding run
-/// to fix that.
-///
-/// The padding depends on the payload's absolute offset within the frame, which is
-/// why this frames in place rather than going through [`MessageBuilder`]: the
-/// aligned body is appended directly after the `HEADER_SIZE + query` prefix, so
-/// [`beve::write_aligned_typed_slice`] (which pads relative to the current buffer
-/// length) sees the true offset. The header is written last, once the body length
-/// is known. The bytes are otherwise an ordinary REPE request:
-/// [`QueryFormat::JsonPointer`] query, [`BodyFormat::Beve`] body.
-///
-/// [`Router::with_typed_slice_ref`]: crate::server::Router::with_typed_slice_ref
-pub(crate) fn build_aligned_typed_slice_frame<T: beve::BeveTypedSlice>(
-    id: u64,
-    path: &str,
-    slice: &[T],
-) -> Vec<u8> {
-    let query = path.as_bytes();
-    let prefix = HEADER_SIZE + query.len();
-    let mut frame = Vec::with_capacity(prefix + beve::aligned_typed_slice_size(slice, prefix));
-
-    // Reserve the header (backfilled below), then the query, so that the aligned
-    // body is appended at absolute offset `prefix` and padded for that offset.
-    frame.resize(HEADER_SIZE, 0);
-    frame.extend_from_slice(query);
-    debug_assert_eq!(frame.len(), prefix);
-    beve::write_aligned_typed_slice(&mut frame, slice);
-
-    let body_length = (frame.len() - prefix) as u64;
-    let mut header = Header::new();
-    header.id = id;
-    header.query_format = QueryFormat::JsonPointer as u16;
-    header.body_format = BodyFormat::Beve as u16;
-    header.query_length = query.len() as u64;
-    header.body_length = body_length;
-    header.length = frame.len() as u64;
-    frame[..HEADER_SIZE].copy_from_slice(&header.encode());
-    frame
 }
 
 /// Borrowing twin of [`create_response_unstamped`]: builds the same query-less

--- a/src/message.rs
+++ b/src/message.rs
@@ -844,6 +844,8 @@ mod tests {
     /// return it, so a test can validate the zero-copy borrow at a known-aligned
     /// base address.
     fn into_aligned_buffer(frame: &[u8]) -> Vec<u64> {
+        // `+ 1` word guarantees room even when `frame.len()` is a multiple of 8
+        // (then `words * 8 == frame.len() + 8`), so the byte view always fits.
         let words = frame.len() / 8 + 1;
         let mut backing: Vec<u64> = vec![0; words];
         // SAFETY: `backing` is 8-aligned and large enough to hold `frame`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -574,8 +574,8 @@ where
 /// BEVE aligned-typed-array marker byte (`0x5C`): a typed array (type 4) in the
 /// bool/string/aligned sub-category (3) with the aligned discriminator (2), per
 /// BEVE spec §4. It opens the aligned wire form that
-/// [`crate::message::build_aligned_typed_slice_frame`] emits and the borrowing
-/// route decodes. Kept as a local constant rather than reaching into BEVE's
+/// [`MessageBuilder::body_aligned_typed_slice`](crate::message::MessageBuilder::body_aligned_typed_slice)
+/// emits and the borrowing route decodes. Kept as a local constant rather than reaching into BEVE's
 /// header internals; [`aligned_marker_matches_beve`] pins it to BEVE's actual
 /// output so a future BEVE change cannot drift past us silently.
 const BEVE_ALIGNED_TYPED_ARRAY_MARKER: u8 = 0x5C;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1852,6 +1852,41 @@ mod tests {
         assert_eq!(encoded.first(), Some(&BEVE_ALIGNED_TYPED_ARRAY_MARKER));
     }
 
+    /// The borrowing decoder's owned fallback: a well-formed aligned body whose
+    /// payload is not aligned in this buffer (here, forced by placing it at an odd
+    /// offset) must refuse the zero-copy borrow and bulk-copy instead, still
+    /// returning the correct data. This is the path a `body_aligned_typed_slice`
+    /// body padded for the wrong frame offset (e.g. query set after the body) takes
+    /// on the server, so the documented graceful degradation is correctness-safe.
+    #[test]
+    fn ref_decode_falls_back_to_owned_when_payload_unaligned() {
+        let data: Vec<f64> = (0..16).map(|i| i as f64 * 3.0).collect();
+        let aligned = beve::to_vec_aligned_typed_slice(&data);
+
+        // Place the aligned body at offset 1 in a genuinely 8-aligned backing
+        // buffer (`Vec<u64>`), so its DATA pointer is deterministically odd and the
+        // zero-copy borrow must refuse regardless of allocator behavior.
+        let words = aligned.len() / 8 + 2;
+        let mut backing: Vec<u64> = vec![0; words];
+        // SAFETY: `backing` is 8-aligned and large enough to hold `aligned` at +1.
+        let bytes =
+            unsafe { std::slice::from_raw_parts_mut(backing.as_mut_ptr() as *mut u8, words * 8) };
+        bytes[1..1 + aligned.len()].copy_from_slice(&aligned);
+        let body = &bytes[1..1 + aligned.len()];
+
+        let decoded = decode_typed_slice_ref_body::<f64>(body).expect("decode");
+        assert!(
+            matches!(decoded, SliceInput::Owned(_)),
+            "unaligned aligned body must take the owned fallback"
+        );
+        assert_eq!(decoded.as_slice(), data.as_slice());
+
+        // And the regular (unaligned wire) typed array always decodes owned too.
+        let regular = beve::to_vec_typed_slice(&data);
+        let decoded = decode_typed_slice_ref_body::<f64>(&regular).expect("decode regular");
+        assert_eq!(decoded.as_slice(), data.as_slice());
+    }
+
     #[test]
     fn middleware_runs_for_registered_handlers() {
         let hits = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## What

Follow-up to the zero-copy route (#30), now that beve 2.3.0 ships `write_aligned_typed_slice_at` (the offset-aware aligned writer). Replaces the dedicated in-place framing path with a normal `MessageBuilder` body method.

- **Adds `MessageBuilder::body_aligned_typed_slice(&[T])`** — the zero-copy counterpart of `body_typed_slice`. It encodes BEVE's aligned typed array padded (via `write_aligned_typed_slice_at`) for the body's eventual `HEADER_SIZE + query.len()` frame offset, so a `with_typed_slice_ref` server can borrow it as `&[T]`. Carries the same `into_wire_bytes` wire-prefix headroom as `body_typed_slice`, and the alignment survives that shift (new test `aligned_body_survives_into_wire_bytes`).
- **Routes `call_typed_slice_aligned`** (sync + async, all timeout variants) through the ordinary `call_with_body_and_timeout` path, **removing** `build_aligned_typed_slice_frame` (message.rs), `dispatch_raw_frame` (both clients), and `write_raw_frame` (sync client).
- **Bumps `beve = "2.2" → "2.3"`.**

## Why

3.7.0 shipped the zero-copy route against beve 2.2, which could only pad relative to `out.len()`. That forced the client to frame the whole request in place (a parallel send path bypassing `MessageBuilder`) so the padding saw the true frame offset. beve 2.3's `write_aligned_typed_slice_at` takes the frame offset explicitly, so the body can be built standalone with correct padding and flow through the same `body_*` → `build` → `write_message` path as every other request. One body-builder family instead of two send paths.

## Wire compatibility

**Byte-for-byte identical.** The aligned body bytes and the framed request are unchanged; this is purely an internal restructuring of how the client produces them. The 6 end-to-end tests in `tests/typed_slice_zero_copy.rs` (unchanged) still pass, now exercising the `body_aligned_typed_slice` path.

## Note on `body_aligned_typed_slice` ordering

The padding is sized for `HEADER_SIZE + query.len()`, so the query must be set **before** this call (the `.query_*(..).body_aligned_typed_slice(..)` order, which the client helpers use). If set afterward, the padding is for the wrong offset and the server falls back to a bulk copy — still correct, just not zero-copy. Documented on the method, matching the existing `body_typed_slice` headroom caveat.

Net **-28 lines**. Version 3.7.0 → 3.8.0.