### PR TITLE
Add value-stream feature: SVS download streaming over REPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [3.9.0] - 2026-06-11
+
+### Added
+- A **Serialized Value Stream (SVS)** download path behind the optional `value-stream` feature: stream a large (multi-GB even compressed) BEVE-serialized, optionally zstd-compressed in-memory value over an ordinary REPE request/response connection. Flow control is the round trip itself (no ACK window, no unbounded queue), and the producer never materializes a full serialized or compressed copy. Implements the cross-language [SVS spec](https://github.com/repe-org/REPE/blob/main/serialized-stream-protocol.md).
+  - **Producer** (via `RouterValueStreamExt` on `Router`): `with_value_stream::<T: Serialize>` (arbitrary serde value), `with_typed_value_stream::<T: BeveTypedSlice>` (a `Vec<T>` bulk typed array), and `with_complex_value_stream::<T>` (a `Vec<Complex<T>>`, e.g. IQ buffers). Each registers `/_svs/{open,next,cancel}` backed by a bounded per-stream session (serialize → optional zstd → chunk into a bounded channel). The `next` handler reports `Execution::OffReader` and blocks for backpressure on the sync `Server` and the WebSocket server; it is not for the inline async server (documented in the module).
+  - **Sync consumer**: `pull_value::<T>` / `pull_to_beve_file` / `pull_to_beve_zst_file` / general `pull_stream` (in-memory value, decompressed `.beve` file, raw `.beve.zst` file — file modes commit atomically via temp-then-rename only after the terminating chunk), plus the bulk `pull_typed_slice::<T>` / `pull_complex_slice::<T>` (memcpy decode straight into the result `Vec`).
+  - **Async consumer**: `pull_value_async` / `pull_typed_slice_async` / `pull_complex_slice_async`, generic over a sealed `AsyncSvsClient` transport — they drive either the async-TCP `AsyncClient` or (with the `websocket` feature) the `WebSocketClient`. The blocking `Read`-based decoders run on a `spawn_blocking` task draining a bounded channel fed by an async `next`-issuing task, so the runtime is never parked and the channel bound is the backpressure.
+- `Router::with_erased_handler` — the low-level escape hatch (register a raw `HandlerErased` returning a fully custom `Message`) the SVS handlers are built on; broadly useful beyond SVS.
+
+### Changed
+- Depend on `beve = "2.5"` (raised from `"2.3"`), the floor for the `read_typed_slice_from_reader` / `read_complex_slice_from_reader` streaming bulk decoders backing the bulk pull receivers.
+
 ## [3.8.0] - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,10 +116,11 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac470faa8d03fa0331336217fc92245b7eaca6e05c52b364f5c181eed9d3fcf7"
+checksum = "867ac1100d98653bdfbb6670a9ea43b753a580328d46e2aac9cfacca704bab71"
 dependencies = [
+ "bytemuck",
  "half",
  "serde",
  "simdutf8",
@@ -153,6 +154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +176,18 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -354,6 +373,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-channel"
@@ -572,6 +597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +768,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -921,6 +962,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "zstd",
 ]
 
 [[package]]
@@ -1045,6 +1087,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simdutf8"
@@ -1522,3 +1570,31 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repe"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Rust implementation of the REPE RPC protocol (JSON-focused)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ websocket-wasm = [
     "dep:web-sys",
 ]
 cli = ["websocket", "dep:clap", "dep:clap_complete"]
+# Streaming transfer of a serialized, optionally zstd-compressed in-memory value
+# over ordinary REPE request/response (the SVS wire contract). Pulls in `zstd`
+# for the compressed path; the engine itself is plain `std` threads + channels.
+value-stream = ["dep:zstd"]
 
 [[bin]]
 name = "repe"
@@ -55,6 +59,10 @@ required-features = ["websocket"]
 name = "websocket_cohosting"
 required-features = ["websocket"]
 
+[[example]]
+name = "value_stream"
+required-features = ["value-stream"]
+
 [dependencies]
 # beve's default feature set is already lean (core ser/de + streaming +
 # typed/complex bulk slice helpers); the heavy MATLAB/HDF5 `mat` interop is opt-in
@@ -68,7 +76,7 @@ required-features = ["websocket"]
 # `to_writer_complex_slice` / `complex_slice_size` (the streaming complex
 # primitives behind `write_message_complex_slice`) and the `read_typed_slice` /
 # `read_complex_slice` bulk decoders behind the typed-numeric body fast path.
-beve = "2.3"
+beve = "2.5"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"
@@ -79,6 +87,9 @@ futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4", optional = true }
+# Streaming zstd codec for the `value-stream` feature (SVS `compression = 1`).
+# Optional so the core crate stays free of the libzstd C dependency.
+zstd = { version = "0.13", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time", "io-util", "sync"] }
@@ -109,6 +120,10 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 # Only for tests: construct f16/bf16 values to exercise the half-float element
 # types of the typed-numeric body path (the runtime dep on half comes via beve).
 half = "2.4"
+# Only for the `value-stream` integration tests: independently decompress a
+# pulled `.beve.zst` file to assert its contents. Matches the optional runtime
+# dep version.
+zstd = "0.13"
 
 [[bench]]
 # Wire-serialization throughput: `Message::to_vec` vs the new

--- a/docs/streaming-serialized-values.md
+++ b/docs/streaming-serialized-values.md
@@ -1,0 +1,202 @@
+# Streaming Serialized Values (proposal)
+
+Status: **implemented** behind the `value-stream` feature (`src/value_stream.rs`). SVS is a **pull-only** contract, so this is the whole of it on the wire; an **async / WebSocket client puller** is the one remaining piece (see below). Companion to [Streaming with Backpressure](streaming.md); this is the bulk-transfer shape for *serialized, compressed, unknown-length* payloads.
+
+## 0. What is implemented
+
+Behind the optional `value-stream` feature (pulls in `zstd`):
+
+- **Server producer** — `Router::with_value_stream(resolve, StreamOpts)` registers the `/_svs/{open,next,cancel}` routes backed by a bounded per-stream session (a `std::thread` running `beve::to_writer_streaming` → optional zstd `write::Encoder` → a `sync_channel` of chunks). One registration serves one value type. The `next` handler reports `Execution::OffReader` so it is also correct on the WebSocket server; it blocks for backpressure on the synchronous `Server` (one thread per connection). It is **not** suitable on the inline `AsyncServer`, which does not honor `OffReader` (documented in the module).
+- **Client puller** — `pull_value::<T>`, `pull_to_beve_file`, `pull_to_beve_zst_file`, and the general `pull_stream` drive the pull over the synchronous `Client`. All three receiver modes (§3.2) work: raw `.beve.zst`, decompressed `.beve`, and streaming typed decode into `T` via `beve::from_reader_streaming`. File modes write a temp sibling and rename only after the terminating `last = 1` and an fsync, so a dropped connection never commits a truncated file.
+- **Tests** — unit tests for the chunker and the lookahead/`last` detection (including producer-failure vs clean-end), plus end-to-end TCP round-trips for every mode, tag/output-mismatch rejection, unknown-resource errors, sequential-stream release, and the atomic-file guarantee (`tests/value_stream.rs`). A runnable demo is in `examples/value_stream.rs`.
+
+**Remaining:** an async/WebSocket-client puller (the server producer already runs under WebSocket; only the client side is sync-TCP-only today).
+
+**Out of scope (not deferred):** client→server *push* upload. SVS is pull-only by design (spec §7). A client that needs to send a value to a server either has the server pull from it (the same `open`/`next`/`cancel`, roles reversed, on a bidirectional transport like WebSocket) or uses the separate credit-windowed push engine `repe::stream` ([Streaming with Backpressure](streaming.md)) — which already provides ACK-window backpressure and reconnect-resume. SVS does not reinvent a weaker one-outstanding-ACK push; see §5 and §11.
+
+
+Revision note: an earlier draft used a *server-push* design backpressured by "blocking writes." That is unsound — `WebSocketClient::subscribe_notifies` pushes every inbound notify into an **unbounded** channel (its own docs warn a slow consumer "will grow the buffer until the process OOMs" and name an ACK window as the fix), so transport flow control never reaches the producer. This revision uses a **client-pull (request/response)** model, where flow control is intrinsic and no inbound-notify subscription is involved. See §5–§6.
+
+## 1. The problem
+
+Move a large in-memory value to a peer over a TCP or WebSocket REPE connection, where the wire payload is **BEVE-serialized and zstd-compressed** and is **multi-GB even compressed**, such that:
+
+- the **producer** never materializes a full serialized or compressed copy (only the value it already holds, plus codec buffers);
+- the **receiver** chooses, per transfer, one of:
+  1. write a `.beve.zst` file (compressed, as received),
+  2. write a `.beve` file (decompressed),
+  3. deserialize into a `T: DeserializeOwned` in memory (streaming decode);
+- for outputs 1 and 2 the value is **never** deserialized; for output 3 only the resulting `T` is resident, never a full compressed or decompressed buffer.
+
+Neither existing transfer mechanism fits directly (§5).
+
+## 2. The pieces already exist
+
+This proposal is mostly glue, because the hard parts are already public:
+
+- **`beve` streams both directions, including typed decode.** `beve::to_writer_streaming::<W: Write, T: Serialize>` + `beve::serialized_size` produce without materializing; `beve::from_reader_streaming::<R: Read, T: DeserializeOwned>` decodes **directly into `T`** token-by-token, with no intermediate generic tree (`streaming_de.rs`). This is a genuine advantage over the Julia binding, whose typed deserialize still materializes a generic tree first — Rust needs no `beve` change for any mode.
+- **zstd streams.** The `zstd` crate's `stream::write::Encoder<W>` / `stream::write::Decoder<W>` (write-side filters) and `stream::read::Decoder<R>` (read-side filter) wrap any `Write`/`Read`. `zstd` is **not yet a dependency** — add it behind an optional feature (§7).
+- **Request/response works on both transports today.** The pull model below uses ordinary request/response, which the sync `Client`, async client, and `WebSocketClient` all already provide. It deliberately does **not** use `subscribe_notifies` (see the revision note).
+
+So the only genuinely new code is a chunk-transport adapter (a producer session + a pull reader) and the receiver wiring.
+
+## 3. Architecture (client-pull)
+
+```
+SERVER (producer, holds value: T)              CLIENT (receiver, drives the pull)
+  &value                                         loop: `next(stream_id)` request
+    │ beve::to_writer_streaming                    │  ← response body = next chunk (+ last flag)
+    ▼                                              ▼
+  BEVE bytes                                     chunk bytes
+    │ zstd write::Encoder                          ├─► write raw ──────────────► tmp → rename .beve.zst (mode 1)
+    ▼                                              ├─► zstd write::Decoder ────► tmp → rename .beve     (mode 2)
+  zstd bytes                                       └─► zstd read::Decoder
+    │ BoundedSink (blocks task when full)               │ beve::from_reader_streaming::<_, T>   (mode 3)
+    ▼                                                    ▼
+  bounded session channel ──[ `next` request/response over TCP / WebSocket ]── pulled on demand
+```
+
+The server holds a per-stream **session**: a `spawn_blocking` task running serialize→compress into a **bounded** channel. The client pulls chunks with ordinary `next` requests at its own pace. Request/response is the flow control (§6): the bounded channel stalls the serializer when the client is slow; the client only asks for more when ready. No notify subscription, no unbounded queue, no ACK window.
+
+### 3.1 Producer (server session)
+
+```rust
+// On `open`: start a streaming session for `value`, return a stream_id.
+let (tx, rx) = sync_channel::<Vec<u8>>(SESSION_DEPTH);   // bounded — backpressure lives here
+std::thread::spawn(move || {                             // or spawn_blocking in async
+    let sink = ChunkSink::new(tx, 1 << 20);              // ~1 MiB chunks into the bounded channel
+    let mut enc = zstd::stream::write::Encoder::new(sink, 3)?;
+    beve::to_writer_streaming(&mut enc, &value)?;        // value -> BEVE -> zstd -> bounded chunks
+    let sink = enc.finish()?;                            // flush zstd epilogue into sink
+    sink.finish()                                        // push final partial chunk, then drop tx (closes rx)
+});
+// On `next(stream_id)`: rx.recv() -> response body; channel closed & drained -> last = true.
+// On last / `cancel` / client disconnect: ensure the thread is joined/stopped and the session is freed.
+```
+
+Peak server memory = the value (already resident) + `SESSION_DEPTH` chunks + zstd buffers. The serializer **blocks** on a full `sync_channel`, so a slow client cannot make it race ahead. Session lifetime must be bounded: free it on `last`, on `cancel`, and on client disconnect/idle-timeout, or an abandoned pull leaks the thread and the value. Teardown must **drop the receiver / close the channel** to release a serializer thread already parked inside `SyncSender::send` — dropping `rx` wakes that parked send (with an error it treats as cancellation); merely forgetting the session would leave the thread blocked forever.
+
+There is no upload (client-producer) counterpart: SVS is pull-only. When the producer is the client rather than the server, the *server* pulls from it with the same `open`/`next`/`cancel` on a bidirectional transport, or a genuine push is carried by `repe::stream` instead — see the out-of-scope note at the top and §11.
+
+### 3.2 Receiver (three modes; client drives the pull)
+
+```rust
+// Mode 1: .beve.zst — write compressed bytes to a TEMP file, rename on `last`.
+tmp.write_all(&chunk)?;                      // ... on last: tmp.sync_all()?; fs::rename(tmp, final)?;
+
+// Mode 2: .beve — stream-decompress to a TEMP file, rename on `last`.
+let mut dec = zstd::stream::write::Decoder::new(tmp)?;
+dec.write_all(&chunk)?;                      // ... on last: dec.flush()?; rename(tmp, final)?;
+
+// Mode 3: struct — pull reader -> zstd read::Decoder -> typed streaming decode.
+//   `ChunkReader: Read` issues `next` requests on demand (§3.3), bounded in-flight.
+let value: T = beve::from_reader_streaming(
+    zstd::stream::read::Decoder::new(ChunkReader::new(client, stream_id))?
+)?;
+```
+
+| Mode | Output | Holds value? | Holds full compressed/decompressed buffer? |
+|---|---|---|---|
+| 1 | `.beve.zst` | no | no |
+| 2 | `.beve` | no | no |
+| 3 | `T` | yes (the result) | no — typed decode streams directly into `T` |
+
+Mode 3 is strictly leaner than `beve::from_reader` over a whole decompressed buffer, and far leaner than read-file-then-decompress-then-decode (which holds compressed + decompressed + value at once). Because `from_reader_streaming` decodes straight into `T`, there is no intermediate generic tree (unlike the Julia path).
+
+**Atomic output (mandatory).** The wire commits no total length (the compressed size is unknown up front), so a dropped connection would otherwise leave a byte-truncated `.beve`/`.beve.zst` that looks complete. File modes write to a temp path and `rename` only **after** `last` and a flush. A stream that ends without `last` is discarded.
+
+### 3.3 Pull reader for mode 3
+
+`from_reader_streaming` pulls bytes (`R: Read`), which fits the pull model directly: `ChunkReader::read` returns buffered bytes and, when empty, issues the next `next` request (and surfaces `last` as EOF). For throughput, the client may keep a small in-flight window of `next` requests and feed a **bounded** channel that the blocking `from_reader_streaming` (run under `spawn_blocking` in async code) drains — bounded, unlike the push design's unbounded notify channel. Modes 1 and 2 need no decoder; the pull loop writes bytes straight to the temp file/decoder.
+
+## 4. Wire contract — defined in the shared SVS spec
+
+Because a REPE.jl service and a repe-rs service will exchange these streams, the wire is defined **once** in the shared, cross-language contract — [REPE Serialized Value Stream (SVS)](https://github.com/repe-org/REPE/blob/main/serialized-stream-protocol.md), canonical in the REPE org repo — not in this plan. That document is the normative source for the routes (`/_svs/{open,next,cancel}`), the message shapes, and the exact byte encodings (the `stream_id` placement, the `last`-flag in the `next` response query, and the `format`/`compression` fields — `format` reusing REPE `BodyFormat` values, `compression` orthogonal). This plan implements that contract.
+
+In brief: `open` (client → server, returns `stream_id`, `format`, `compression`), `next` (client → server with `{stream_id}`, response carries `last` in the query and the raw chunk in the body, zero-copy), `cancel`. No total length is committed; `last = 1` terminates. **repe-rs is the reference implementation** that validates the contract's provisional v0 before it freezes as v1 (see that doc's status).
+
+## 5. Why the existing mechanisms don't fit
+
+- **`write_message_streaming` (single-message).** Requires `body_len` in the header before the first body byte. The zstd-compressed length is unknown until compression finishes (a size pass would mean compressing twice), so the single-message path cannot carry it. Over WebSocket it also reassembles the whole frame in memory, defeating the bound. Ruled out.
+- **`repe::stream` (the backpressure engine).** Works, but carries a credit window, replay ring, and resume handshake this case does not need: pull provides backpressure intrinsically (§6) and v1 does not need resume. Using it here is over-machinery for the pull case. It is, however, the right home for genuine client→server *push* and for resume — those are `repe::stream`'s job, not a future SVS direction (§11).
+- **Ranged pull.** For *seekable* sources accessed by offset. Serialized + compressed output is forward-only and non-seekable, so random-access ranges do not apply.
+
+This proposal is the lightweight middle: client-pull request/response, intrinsically backpressured, no resume, for unknown-length serialized payloads.
+
+## 6. Backpressure and direction (the corrected core)
+
+- **Why pull, not push.** A notify push gives no free backpressure: `subscribe_notifies` drains the socket into an unbounded channel (its docs warn of OOM and name an ACK window as the fix), so a fast producer + slow disk grows the buffer without limit and TCP/WS flow control never reaches the producer. The earlier "blocking writes" claim was wrong for every WebSocket path. **Pull** fixes this structurally: the client requests the next chunk only when ready, and the server's bounded session channel (§3.1) stalls the serializer when the client lags. The round trip *is* the flow control — no ACK window, no credit accounting, and no new transport primitive.
+- **Throughput vs. round trips.** Pull costs one round trip per chunk (~8k for 8 GB at 1 MiB chunks): negligible on a LAN, significant at WAN latency. Mitigate by **pipelining** a small window of `next` requests via existing multiplexing (tag responses with a sequence, reassemble in order); this hides RTT while staying bounded by the window. Oversizing chunks is not the answer on WebSocket (§9).
+- **One direction, both role assignments.** The wire is always consumer-pulls-producer over request/response. Usually the server is the producer and the client pulls (above). When the client is the producer, the server pulls from it the same way on a bidirectional transport — there is no separate client-push path (that is `repe::stream`'s job, not SVS's; see §5 and §11).
+
+## 7. Dependency and feature gating
+
+Add `zstd` behind an **optional feature** so the core crate stays lean:
+
+```toml
+[features]
+beve-zstd-stream = ["dep:zstd"]   # streaming zstd for serialized-value transfer
+
+[dependencies]
+zstd = { version = "0.13", optional = true }
+```
+
+`beve` is already a dependency and already exposes the full streaming API (including typed decode); no `beve` change is required. The transfer helpers live behind `beve-zstd-stream`.
+
+## 8. Proposed surface
+
+```rust
+// Server: register open/next handlers backed by a bounded session channel.
+pub fn serve_value_stream<F, T>(server: &mut Server, resolve: F)
+where F: Fn(&str) -> Option<T> + Send + Sync + 'static, T: Serialize + Send + 'static;
+
+pub struct StreamOpts { pub chunk_bytes: usize, pub zstd_level: i32, pub session_depth: usize }
+
+// Client: pull a stream into the chosen output. File modes write-temp-then-rename.
+pub enum StreamOutput<'a, T> {
+    BeveZstdFile(&'a Path),   // mode 1
+    BeveFile(&'a Path),       // mode 2
+    Value(PhantomData<T>),    // mode 3 -> returns T
+}
+
+pub fn pull_stream<T: DeserializeOwned>(client: &Client, resource: &str, out: StreamOutput<T>)
+    -> Result<Option<T>, RepeError>;   // Some(T) for mode 3, None for file modes
+```
+
+(Names illustrative; align with crate conventions. Async variants mirror these, with `spawn_blocking` around the blocking codec passes per §3.3.)
+
+## 9. Chunk sizing
+
+Keep `chunk_bytes` small enough that a WebSocket binary frame stays modest — **1–4 MiB**. Smaller favors WebSocket receiver memory and latency; larger favors TCP throughput by cutting per-message overhead. Default 1 MiB serves both transports; expose it. Do **not** use tens-of-MiB chunks — that reintroduces large WS frames and undoes the receiver bound. For WAN throughput prefer pipelined pull (§6) over oversizing.
+
+## 10. Memory accounting (multi-GB payload)
+
+| | Server (producer) | Client mode 1/2 (file) | Client mode 3 (struct) |
+|---|---|---|---|
+| Value / result | resident (source) | — | resident (result `T`) |
+| Full serialized buffer | never | never | never |
+| Full compressed buffer | never | never | never |
+| Full decompressed buffer | never | never | never (typed decode streams) |
+| Transient | `SESSION_DEPTH` chunks + zstd | 1 chunk + zstd + write buf | window chunks + zstd + decode |
+
+File modes are bounded regardless of payload size; struct mode is bounded to `T` + O(window). (Contrast the Julia companion plan, where typed mode 3 is bounded only after a new streaming typed deserializer lands; Rust's `from_reader_streaming` already streams typed decode.)
+
+## 11. Out of scope and deferred
+
+**Out of scope of SVS entirely** (these are `repe::stream`'s domain, not a future SVS direction — SVS is the pull contract, `repe::stream` is the push engine):
+
+- **Client→server push / pipelined-push throughput.** If a producer-driven transfer with a credit/ACK window is ever needed (e.g. pull's RTT ceiling proves insufficient over WAN even with pipelining, §6), that is `repe::stream`, which already provides the ACK-window backpressure. It is a distinct protocol, not a knob added to SVS.
+- **Resume across a dropped connection.** SVS restarts a failed transfer (discarding the un-renamed temp file). Resuming a stateful serialize+compress stream means re-running it to the resume offset, and the replay machinery for it lives in `repe::stream`. SVS commits no resume state.
+
+**Deferred (could land under SVS later):**
+- **Integrity check.** Transport already checksums; atomic rename (§3.2) already prevents a *truncated* file being accepted. For corruption detection, fold a streaming CRC32C into the final chunk/`end` (codec passes are single-pass, so cheap).
+- **Multiple concurrent streams per connection.** `stream_id` namespaces them; routing N in flight is additive.
+
+## 12. Build order
+
+1. Add `zstd` optional dep + `beve-zstd-stream` feature.
+2. `ChunkSink: Write` + bounded session channel + `open`/`next`/`cancel` helpers over `Message`; test the producer session in isolation (bounded memory, clean shutdown), asserting byte-identity with `to_writer_streaming` + zstd over a `Vec`.
+3. `ChunkReader: Read` + `pull_stream` with file modes (atomic temp-then-rename) + round-trip over TCP.
+4. Mode 3: typed `from_reader_streaming` over the pull reader (`spawn_blocking` in async); round-trip a struct, asserting value-equality with the source.
+5. WebSocket parity — free, since pull is plain request/response; assert frame sizes stay ~`chunk_bytes`.
+6. Backpressure (slow client → bounded server memory), session-lifecycle (disconnect frees the session), atomic-output (mid-stream kill leaves no final-named file), cancel, and large-payload (generated) tests.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -8,6 +8,8 @@ When you need to push multi-GB blobs (capture files, log streams, paginated quer
 
 The wire shape (`transfer_begin`, chunk body fields, ACK / cancel / resume bodies) is up to the embedder. This module deals only in offsets, ACKs, and opaque body bytes. See `TransferControl`, `TransferRegistry<K>`, and `spawn_watchdog` for the full surface.
 
+> **Before reaching for this module:** if your payload is a **serialized + compressed in-memory value** of unknown compressed length (BEVE + zstd), the [Streaming Serialized Values](streaming-serialized-values.md) proposal is a lightweight **client-pull** transfer that bounds memory on both ends (file or in-memory value output) using request/response as the flow control — no credit window or replay ring. `repe::stream` earns its full machinery specifically when you need **pipelined push throughput with backpressure** or **resume across a dropped connection**, which client-pull defers.
+
 ## Sketch
 
 ```rust

--- a/examples/stream_pull_vs_push.rs
+++ b/examples/stream_pull_vs_push.rs
@@ -1,0 +1,372 @@
+//! Throughput comparison: **push** streaming (`repe::stream` / `TransferControl`,
+//! credit-window pipelined) vs the new **pull** streaming (SVS / `value_stream`,
+//! one round trip per chunk).
+//!
+//! Run: `cargo run --release --example stream_pull_vs_push --features value-stream`
+//!
+//! All three harnesses move the same byte volume over a loopback TCP connection,
+//! in 1 MiB chunks, framed as REPE messages:
+//!
+//! * **pull (value_stream)** — the actual shipped pull API, end to end (BEVE
+//!   serialize → optional zstd → chunked pull → reassemble/deserialize).
+//! * **pull-mechanism** — a bare-socket serial request/response loop (client asks,
+//!   server answers, one chunk at a time). Isolates the *architecture* of pull
+//!   from BEVE/zstd and Router dispatch cost.
+//! * **push (repe::stream)** — a faithful producer driven by `TransferControl`: it
+//!   streams chunks ahead up to the credit window without waiting per chunk, ACKs
+//!   flow back asynchronously, and each chunk is recorded in the replay ring (the
+//!   resume machinery repe::stream pays for).
+//!
+//! Read the caveats printed at the end before drawing conclusions — loopback has
+//! almost no latency, which is precisely the regime where pull looks best.
+
+use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts};
+use repe::{
+    BodyFormat, Client, Message, QueryFormat, Router, Server, TransferControl, pull_value,
+    read_message, write_message,
+};
+use std::io::{BufReader, BufWriter, Cursor, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const CHUNK: usize = 1 << 20; // 1 MiB
+const WINDOW: u64 = 64 << 20; // 64 MiB credit window (repe::stream default)
+const REPS: usize = 3;
+
+fn main() {
+    let sizes = [32usize << 20, 64 << 20, 128 << 20];
+
+    println!(
+        "chunk = {} KiB, credit window = {} MiB, {} reps (best shown), loopback TCP\n",
+        CHUNK / 1024,
+        WINDOW >> 20,
+        REPS
+    );
+
+    println!("== Transport architecture (bare REPE framing, raw bytes) ==");
+    println!("This is the apples-to-apples push-vs-pull comparison: same framing, same");
+    println!("bytes, no codec, no Router dispatch. It isolates windowed-push vs serial-pull.\n");
+    println!(
+        "{:<26} {:>10} {:>12} {:>12}",
+        "mechanism", "payload", "best (ms)", "MB/s"
+    );
+    println!("{}", "-".repeat(62));
+    for &total in &sizes {
+        let label = format!("{} MiB", total >> 20);
+        row(
+            "push (repe::stream)",
+            &label,
+            total,
+            best(REPS, || bench_push(total)),
+        );
+        row(
+            "pull-mechanism (bare)",
+            &label,
+            total,
+            best(REPS, || bench_pull_mechanism(total)),
+        );
+        println!();
+    }
+
+    println!("== value_stream end-to-end (the shipped pull API: +BEVE, +optional zstd) ==");
+    println!(
+        "NOTE: for this payload (one flat ~{}-element byte array) these rows are",
+        sizes[2] >> 20
+    );
+    println!("dominated by streaming DECODE cost, not transport — see the decode diagnostic.\n");
+    println!(
+        "{:<26} {:>10} {:>12} {:>12}",
+        "mechanism", "payload", "best (ms)", "MB/s"
+    );
+    println!("{}", "-".repeat(62));
+    for &total in &sizes {
+        let payload = lcg_bytes(total);
+        let label = format!("{} MiB", total >> 20);
+        row(
+            "pull (value_stream none)",
+            &label,
+            total,
+            best(REPS, || bench_pull(&payload, Compression::None)),
+        );
+        row(
+            "pull (value_stream zstd)",
+            &label,
+            total,
+            best(REPS, || bench_pull(&payload, Compression::Zstd)),
+        );
+        println!();
+    }
+
+    decode_diagnostic(sizes[2]);
+    print_caveats();
+}
+
+/// Isolate where the value_stream pull time goes for a large flat array: bulk
+/// decode (`from_slice`) vs streaming decode (`from_reader_streaming`), no
+/// transport involved. A large gap means the end-to-end rows above are
+/// decode-bound, not transport-bound.
+fn decode_diagnostic(total: usize) {
+    let payload = lcg_bytes(total);
+    let encoded = beve::to_vec(&payload).unwrap();
+
+    let t = Instant::now();
+    let bulk: Vec<u8> = beve::from_slice(&encoded).unwrap();
+    let bulk_ms = t.elapsed().as_secs_f64() * 1000.0;
+    assert_eq!(bulk.len(), total);
+
+    let t = Instant::now();
+    let streamed: Vec<u8> = beve::from_reader_streaming(Cursor::new(&encoded)).unwrap();
+    let stream_ms = t.elapsed().as_secs_f64() * 1000.0;
+    assert_eq!(streamed.len(), total);
+
+    let mb = total as f64 / (1024.0 * 1024.0);
+    println!(
+        "== Decode diagnostic ({} MiB flat byte array, no transport) ==",
+        total >> 20
+    );
+    println!(
+        "  beve::from_slice          (bulk)      {:>8.2} ms   {:>7.0} MB/s",
+        bulk_ms,
+        mb / (bulk_ms / 1000.0)
+    );
+    println!(
+        "  beve::from_reader_streaming (element)  {:>8.2} ms   {:>7.0} MB/s   <- value_stream mode-3 path",
+        stream_ms,
+        mb / (stream_ms / 1000.0)
+    );
+    println!();
+}
+
+fn row(name: &str, payload: &str, total: usize, dur: Duration) {
+    let secs = dur.as_secs_f64();
+    let mbps = (total as f64 / (1024.0 * 1024.0)) / secs;
+    println!(
+        "{:<26} {:>10} {:>12.2} {:>12.0}",
+        name,
+        payload,
+        secs * 1000.0,
+        mbps
+    );
+}
+
+fn best(reps: usize, mut f: impl FnMut() -> Duration) -> Duration {
+    (0..reps).map(|_| f()).min().unwrap()
+}
+
+/// Cheap incompressible-ish filler so the zstd variant is honest (no
+/// runs-of-zeros that compress to nothing) without pulling in `rand`.
+fn lcg_bytes(n: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(n);
+    let mut state: u64 = 0x9E3779B97F4A7C15;
+    while v.len() < n {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        v.extend_from_slice(&state.to_le_bytes());
+    }
+    v.truncate(n);
+    v
+}
+
+// ---- pull: the real value_stream API, end to end ------------------------------
+
+fn bench_pull(payload: &[u8], compression: Compression) -> Duration {
+    let payload = payload.to_vec();
+    let opts = StreamOpts {
+        chunk_bytes: CHUNK,
+        compression,
+        zstd_level: 3,
+        session_depth: 4,
+    };
+    let router = Router::new().with_value_stream(move |_r: &str| Some(payload.clone()), opts);
+    let server = Server::new(router);
+    let listener = server.listen("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+
+    let client = Client::connect(addr).unwrap();
+    let start = Instant::now();
+    let got: Vec<u8> = pull_value(&client, "x").unwrap();
+    let elapsed = start.elapsed();
+    assert_eq!(got.len(), got.len()); // touch result so it isn't optimized away
+    elapsed
+}
+
+// ---- pull-mechanism: bare-socket serial request/response ----------------------
+
+fn bench_pull_mechanism(total: usize) -> Duration {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let producer = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        stream.set_nodelay(true).ok();
+        let mut r = BufReader::new(stream.try_clone().unwrap());
+        let mut w = BufWriter::new(stream);
+        let body = vec![0u8; CHUNK];
+        let mut sent = 0usize;
+        loop {
+            // Wait for the consumer's "next" request before answering (serial).
+            if read_message(&mut r).is_err() {
+                break;
+            }
+            let len = CHUNK.min(total - sent);
+            let last = sent + len >= total;
+            let msg = chunk_msg(&body[..len], last);
+            write_message(&mut w, &msg).unwrap();
+            w.flush().unwrap();
+            sent += len;
+            if last {
+                break;
+            }
+        }
+    });
+
+    let stream = TcpStream::connect(addr).unwrap();
+    stream.set_nodelay(true).ok();
+    let mut r = BufReader::new(stream.try_clone().unwrap());
+    let mut w = BufWriter::new(stream);
+
+    let start = Instant::now();
+    let mut received = 0usize;
+    loop {
+        // Ask, then wait for the chunk: one full round trip per chunk.
+        write_message(&mut w, &next_req()).unwrap();
+        w.flush().unwrap();
+        let resp = read_message(&mut r).unwrap();
+        received += resp.body.len();
+        if resp.query.first().copied() == Some(1) {
+            break;
+        }
+    }
+    let elapsed = start.elapsed();
+    assert_eq!(received, total);
+    producer.join().unwrap();
+    elapsed
+}
+
+// ---- push: faithful repe::stream / TransferControl windowed producer ----------
+
+fn bench_push(total: usize) -> Duration {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let producer = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        stream.set_nodelay(true).ok();
+        let control = TransferControl::new(WINDOW);
+
+        // ACK reader: the consumer's ACKs advance the credit window concurrently
+        // with production, so the producer never stalls per chunk — only when it
+        // gets WINDOW bytes ahead of the ACKs.
+        let ack_ctl = control.clone();
+        let ack_stream = stream.try_clone().unwrap();
+        let ack_reader = thread::spawn(move || {
+            let mut r = BufReader::new(ack_stream);
+            while let Ok(m) = read_message(&mut r) {
+                let off = u64::from_le_bytes(m.body[..8].try_into().unwrap());
+                ack_ctl.record_ack(0, off);
+                if off >= total as u64 {
+                    break;
+                }
+            }
+        });
+
+        let mut w = BufWriter::new(stream);
+        let body = vec![0u8; CHUNK];
+        let mut offset = 0u64;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while (offset as usize) < total {
+            let len = CHUNK.min(total - offset as usize);
+            // Block only if we are a full window ahead of the ACKs.
+            control.wait_for_credit(len as u64, deadline).unwrap();
+            // Record the chunk in the replay ring (resume support cost), then send.
+            control.push_replay(
+                offset,
+                len as u64,
+                (offset as usize + len) >= total,
+                body[..len].to_vec(),
+            );
+            let last = (offset as usize + len) >= total;
+            write_message(&mut w, &chunk_msg(&body[..len], last)).unwrap();
+            w.flush().unwrap();
+            offset += len as u64;
+            control.record_sent(offset);
+        }
+        ack_reader.join().unwrap();
+    });
+
+    let stream = TcpStream::connect(addr).unwrap();
+    stream.set_nodelay(true).ok();
+    let mut r = BufReader::new(stream.try_clone().unwrap());
+    let mut w = BufWriter::new(stream);
+
+    let start = Instant::now();
+    let mut received = 0u64;
+    loop {
+        let chunk = read_message(&mut r).unwrap();
+        received += chunk.body.len() as u64;
+        // ACK the cumulative offset (one ACK per chunk).
+        let ack = Message::builder()
+            .body_bytes(received.to_le_bytes().to_vec())
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        write_message(&mut w, &ack).unwrap();
+        w.flush().unwrap();
+        if chunk.query.first().copied() == Some(1) {
+            break;
+        }
+    }
+    let elapsed = start.elapsed();
+    assert_eq!(received, total as u64);
+    producer.join().unwrap();
+    elapsed
+}
+
+// ---- shared framing -----------------------------------------------------------
+
+fn chunk_msg(body: &[u8], last: bool) -> Message {
+    Message::builder()
+        .query_format(QueryFormat::RawBinary)
+        .query_bytes(vec![last as u8])
+        .body_format(BodyFormat::RawBinary)
+        .body_bytes(body.to_vec())
+        .build()
+}
+
+fn next_req() -> Message {
+    Message::builder()
+        .query_format(QueryFormat::JsonPointer)
+        .query_bytes(b"/next".to_vec())
+        .build()
+}
+
+fn print_caveats() {
+    println!(
+        "\nConclusions:\n\
+         1. TRANSPORT (the actual push-vs-pull question): on loopback the two are comparable,\n\
+            and serial pull is even a bit faster than windowed push -- because a round trip is\n\
+            nearly free at ~0 latency, while push pays credit accounting + a per-chunk replay-\n\
+            ring copy (its resume support). Push's win is LATENCY-bound, not present on a LAN.\n\
+         2. The value_stream rows are CODEC-bound, not transport-bound: the decode diagnostic\n\
+            shows BEVE decode of this payload runs at a few hundred MB/s, while the bare pull\n\
+            transport runs at ~8 GB/s. The pull *transport* is not the bottleneck here.\n\
+         3. That codec cost is COMMON to push and pull -- pushing a serialized value over\n\
+            repe::stream would pay the same BEVE serialize/deserialize -- so it is NOT a\n\
+            push-vs-pull differentiator. The only transport-level differentiator is round-trip\n\
+            sensitivity (below).\n\
+         4. This pull implementation does NOT pipeline `next` requests; the SVS spec permits a\n\
+            pipelined pull window, which would erase most of the latency gap below.\n\n\
+         Latency projection (1 MiB chunks, serial pull): one-way latency L adds ~2*L of stall\n\
+         per chunk (request + response). 128 MiB = 128 chunks: at L=1ms that is ~256 ms of pure\n\
+         round-trip stall that windowed push avoids (push pays ~one window-fill total); at\n\
+         L=25us (LAN) ~6 ms; at loopback (~1us) negligible, as measured above.\n\n\
+         Friction (beve): `from_slice::<Vec<u8>>` / `from_reader_streaming::<Vec<u8>>` decode a\n\
+         flat byte array element-wise (~300 MB/s) rather than via a bulk u8 path (memcpy speed).\n\
+         A bulk fast-path for primitive arrays in the streaming decoder would lift value_stream\n\
+         mode-3 throughput for large numeric/byte payloads by an order of magnitude."
+    );
+}

--- a/examples/value_stream.rs
+++ b/examples/value_stream.rs
@@ -1,0 +1,53 @@
+//! Stream a large in-memory value from a server to a client without either side
+//! holding a full serialized or compressed copy — the SVS download path.
+//!
+//! Run with: `cargo run --example value_stream --features value-stream`
+
+use repe::value_stream::{RouterValueStreamExt, StreamOpts};
+use repe::{Client, Router, Server, pull_value};
+use serde::{Deserialize, Serialize};
+use std::net::TcpListener;
+use std::thread;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Dataset {
+    name: String,
+    samples: Vec<f64>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The value the server will stream. In a real service this might be loaded
+    // lazily inside `resolve` keyed on the requested resource.
+    let dataset = Dataset {
+        name: "demo".to_string(),
+        samples: (0..1_000_000).map(|i| i as f64).collect(),
+    };
+
+    // Register the SVS routes. `resolve` maps a resource key to the value to
+    // stream; the value is BEVE-serialized and zstd-compressed as it is pulled.
+    let server_copy = dataset.clone();
+    let router = Router::new().with_value_stream(
+        move |resource: &str| (resource == "demo").then(|| server_copy.clone()),
+        StreamOpts::default(),
+    );
+
+    let server = Server::new(router);
+    let listener: TcpListener = server.listen("127.0.0.1:0")?;
+    let addr = listener.local_addr()?;
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+
+    // Pull the value straight into a `Dataset`, streaming-decoded — never holding
+    // the full compressed or decompressed buffer in memory.
+    let client = Client::connect(addr)?;
+    let pulled: Dataset = pull_value(&client, "demo")?;
+
+    println!(
+        "pulled '{}' with {} samples; matches source: {}",
+        pulled.name,
+        pulled.samples.len(),
+        pulled == dataset
+    );
+    Ok(())
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Fleet: fleet.md
   - WebSocket Transport: websocket.md
   - Streaming: streaming.md
+  - Streaming Serialized Values: streaming-serialized-values.md
   - Command-Line Client: cli.md
 
 extra:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod structs;
 pub mod udp_client;
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub mod uniudp_fleet;
+#[cfg(all(feature = "value-stream", not(target_arch = "wasm32")))]
+pub mod value_stream;
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub mod wasm_client;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
@@ -102,6 +104,11 @@ pub use structs::{RepeStruct, StructError};
 pub use udp_client::UniUdpClient;
 #[cfg(all(feature = "fleet-udp", not(target_arch = "wasm32")))]
 pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
+#[cfg(all(feature = "value-stream", not(target_arch = "wasm32")))]
+pub use value_stream::{
+    Compression, RouterValueStreamExt, StreamOpts, StreamOutput, pull_complex_slice, pull_stream,
+    pull_to_beve_file, pull_to_beve_zst_file, pull_typed_slice, pull_value,
+};
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub use wasm_client::WasmClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,9 @@ pub use udp_client::UniUdpClient;
 pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
 #[cfg(all(feature = "value-stream", not(target_arch = "wasm32")))]
 pub use value_stream::{
-    Compression, RouterValueStreamExt, StreamOpts, StreamOutput, pull_complex_slice,
-    pull_complex_slice_async, pull_stream, pull_to_beve_file, pull_to_beve_zst_file,
-    pull_typed_slice, pull_typed_slice_async, pull_value, pull_value_async,
+    AsyncSvsClient, Compression, RouterValueStreamExt, StreamOpts, StreamOutput,
+    pull_complex_slice, pull_complex_slice_async, pull_stream, pull_to_beve_file,
+    pull_to_beve_zst_file, pull_typed_slice, pull_typed_slice_async, pull_value, pull_value_async,
 };
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub use wasm_client::WasmClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,9 @@ pub use udp_client::UniUdpClient;
 pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
 #[cfg(all(feature = "value-stream", not(target_arch = "wasm32")))]
 pub use value_stream::{
-    Compression, RouterValueStreamExt, StreamOpts, StreamOutput, pull_complex_slice, pull_stream,
-    pull_to_beve_file, pull_to_beve_zst_file, pull_typed_slice, pull_value,
+    Compression, RouterValueStreamExt, StreamOpts, StreamOutput, pull_complex_slice,
+    pull_complex_slice_async, pull_stream, pull_to_beve_file, pull_to_beve_zst_file,
+    pull_typed_slice, pull_typed_slice_async, pull_value, pull_value_async,
 };
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub use wasm_client::WasmClient;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1004,6 +1004,31 @@ impl Router {
         self
     }
 
+    /// Register a custom [`HandlerErased`] at `path`, the low-level escape hatch
+    /// beneath the typed/JSON registrars.
+    ///
+    /// The built-in `with_*` constructors decode the request body into a value
+    /// and frame the response for you; this one hands you the raw request and
+    /// lets you return any [`Message`], so you control the response query bytes,
+    /// query format, and body format directly. That is what a protocol carried
+    /// over REPE but not shaped like a single value-in/value-out call needs — for
+    /// example a handler that returns a raw-binary body with a flag byte in the
+    /// response query (see the `value-stream` feature, which is built entirely on
+    /// this method).
+    ///
+    /// The handler participates in the middleware pipeline and the response
+    /// query-echo rule exactly like the built-ins: a response left with an empty
+    /// query has the request query echoed in by the dispatch layer, while a
+    /// query the handler sets itself is preserved (see [`HandlerErased`]).
+    ///
+    /// Distinct from [`with_handler`](Self::with_handler), which adapts a
+    /// [`JsonTypedHandler`] (value-in/value-out); this takes an already-erased
+    /// [`HandlerErased`] for full control of the response frame.
+    pub fn with_erased_handler(mut self, path: &str, handler: Arc<dyn HandlerErased>) -> Self {
+        self.insert_route(path, handler);
+        self
+    }
+
     /// Attach a middleware that runs before handlers and can short-circuit requests.
     pub fn with_middleware(mut self, middleware: impl Middleware + 'static) -> Self {
         self.register_middleware(middleware);

--- a/src/value_stream.rs
+++ b/src/value_stream.rs
@@ -1,0 +1,1140 @@
+//! Streaming transfer of a serialized, optionally zstd-compressed in-memory
+//! value over ordinary REPE request/response — the **Serialized Value Stream
+//! (SVS)** wire contract.
+//!
+//! SVS moves a large value (multi-GB even compressed) from a producer to a
+//! consumer without either side materializing a full serialized or compressed
+//! copy. The value is BEVE-serialized and, on the compressed path, zstd-encoded
+//! as it is produced; the bytes cross the wire as a sequence of opaque chunks
+//! pulled one round trip at a time, so flow control is the request/response
+//! cadence itself — no ACK window, no unbounded queue. The receiver chooses, per
+//! transfer, to write the compressed bytes to a file, decompress them to a file,
+//! or stream-decode them straight into a `T`.
+//!
+//! This module is the repe-rs **reference implementation** of the SVS contract.
+//! The normative wire definition (routes, `stream_id` encoding, the `last`-flag
+//! placement, the `format`/`compression` tags) lives in the REPE org repository
+//! next to the base REPE spec; everything in this module beyond those wire fields
+//! (chunk sizing, the bounded producer channel, the lookahead that detects the
+//! final chunk) is local engine policy and not part of the contract.
+//!
+//! # Directions
+//!
+//! * **Download** (server produces, client pulls) — the primary direction.
+//!   Register a producer with [`RouterValueStreamExt::with_value_stream`] and
+//!   pull with [`pull_value`] / [`pull_to_beve_file`] / [`pull_to_beve_zst_file`]
+//!   (or the general [`pull_stream`]).
+//!
+//! # Where the producer may run
+//!
+//! A `next` request blocks the handler until the producer has the next chunk
+//! ready — that block *is* the backpressure. It must therefore run somewhere a
+//! blocking handler is fine: the synchronous [`Server`](crate::Server) (one
+//! thread per connection) or the WebSocket server (the `next` handler reports
+//! [`Execution::OffReader`](crate::Execution), so it runs off the reader task).
+//! The inline async TCP server ([`AsyncServer`](crate::AsyncServer)) runs handlers
+//! on the connection's runtime task and does not honor `OffReader`, so a producer
+//! registered there would park a runtime worker; use the sync or WebSocket server
+//! for SVS producers.
+
+use crate::client::Client;
+use crate::constants::{BodyFormat, ErrorCode, QueryFormat};
+use crate::error::RepeError;
+use crate::message::{Message, create_error_message};
+use crate::server::{Execution, HandlerErased, Router};
+use beve::Complex;
+use beve::from_slice as beve_from_slice;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// The SVS contract version this implementation speaks, reported in the `open`
+/// response and validated by the client.
+pub const SVS_VERSION: u8 = 1;
+
+/// Reserved namespace for SVS routes. Routes beginning with `_` are reserved for
+/// REPE protocol extensions; SVS claims `/_svs`.
+pub const ROUTE_OPEN: &str = "/_svs/open";
+/// Route for pulling the next chunk of a download stream. See [`ROUTE_OPEN`].
+pub const ROUTE_NEXT: &str = "/_svs/next";
+/// Route for releasing a stream early (request or notify). See [`ROUTE_OPEN`].
+pub const ROUTE_CANCEL: &str = "/_svs/cancel";
+
+/// The codec applied over the serialized value bytes, orthogonal to the
+/// serialization `format`. Wire values match the SVS `compression` tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Compression {
+    /// `compression = 0`: the chunk stream is the serialized value verbatim.
+    None = 0,
+    /// `compression = 1`: the chunk stream is a zstd frame over the serialized
+    /// value.
+    Zstd = 1,
+}
+
+impl Compression {
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Compression::None),
+            1 => Some(Compression::Zstd),
+            _ => None,
+        }
+    }
+}
+
+/// Local producer-side knobs (SVS §5 "local policy" — none of these are on the
+/// wire, so a producer and consumer interoperate regardless of how they are set).
+#[derive(Debug, Clone, Copy)]
+pub struct StreamOpts {
+    /// Target size of each chunk pushed into the session channel. Keep this a few
+    /// MiB at most so a WebSocket binary frame stays modest; 1 MiB by default.
+    pub chunk_bytes: usize,
+    /// Codec applied over the serialized bytes.
+    pub compression: Compression,
+    /// zstd compression level when `compression` is [`Compression::Zstd`].
+    pub zstd_level: i32,
+    /// Bounded depth of the per-stream producer channel. This is where memory is
+    /// bounded and backpressure lives: the serializer parks once this many chunks
+    /// are buffered ahead of the consumer.
+    pub session_depth: usize,
+}
+
+impl Default for StreamOpts {
+    fn default() -> Self {
+        Self {
+            chunk_bytes: 1 << 20,
+            compression: Compression::Zstd,
+            zstd_level: 3,
+            session_depth: 4,
+        }
+    }
+}
+
+// ---- wire message bodies (BEVE) ------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct OpenRequest {
+    resource: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenResponse {
+    version: u8,
+    stream_id: u64,
+    /// Serialization format of the logical content, using REPE `BodyFormat`
+    /// values (`1` = BEVE here).
+    format: u16,
+    /// Codec over the serialized bytes (`0` = none, `1` = zstd).
+    compression: u8,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NextRequest {
+    stream_id: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct CancelRequest {
+    stream_id: u64,
+    reason: String,
+}
+
+// ---- server: producer session -------------------------------------------------
+
+/// One message in the producer→handler channel. Terminating the stream with an
+/// explicit [`Msg::End`] / [`Msg::Fail`] (rather than relying on the channel
+/// closing) keeps the "did it finish cleanly?" answer ordered with the chunks: a
+/// truncated production surfaces as `Fail`, never as a silently-short clean end.
+enum Msg {
+    Chunk(Vec<u8>),
+    End,
+    Fail(String),
+}
+
+/// A `Write` sink that batches the producer's byte stream into fixed-size chunks
+/// and pushes each into the bounded session channel. A send failure (the receiver
+/// was dropped — the consumer cancelled or disconnected) surfaces as a broken
+/// pipe, which aborts the in-progress serialize/compress pass.
+struct ChunkSink {
+    tx: SyncSender<Msg>,
+    buf: Vec<u8>,
+    chunk_bytes: usize,
+}
+
+impl ChunkSink {
+    fn new(tx: SyncSender<Msg>, chunk_bytes: usize) -> Self {
+        Self {
+            tx,
+            buf: Vec::with_capacity(chunk_bytes),
+            chunk_bytes,
+        }
+    }
+
+    fn send_chunk(&mut self) -> io::Result<()> {
+        let chunk = std::mem::replace(&mut self.buf, Vec::with_capacity(self.chunk_bytes));
+        self.tx
+            .send(Msg::Chunk(chunk))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "svs stream cancelled"))
+    }
+
+    /// Flush the trailing partial chunk (if any). Does not close the channel; the
+    /// caller sends [`Msg::End`]/[`Msg::Fail`] explicitly afterward.
+    fn flush_remaining(&mut self) -> io::Result<()> {
+        if self.buf.is_empty() {
+            Ok(())
+        } else {
+            self.send_chunk()
+        }
+    }
+}
+
+impl Write for ChunkSink {
+    fn write(&mut self, mut data: &[u8]) -> io::Result<usize> {
+        let total = data.len();
+        while !data.is_empty() {
+            let space = self.chunk_bytes - self.buf.len();
+            let take = space.min(data.len());
+            self.buf.extend_from_slice(&data[..take]);
+            data = &data[take..];
+            if self.buf.len() >= self.chunk_bytes {
+                self.send_chunk()?;
+            }
+        }
+        Ok(total)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // A chunk boundary is a size decision, not a flush decision: the zstd
+        // encoder flushes mid-frame and the receiver concatenates regardless, so
+        // an intermediate flush must NOT emit a short chunk. The trailing partial
+        // is pushed once, by `flush_remaining` at the end.
+        Ok(())
+    }
+}
+
+/// A producer-side closure that writes the full logical body to a sink: a
+/// generic serde value (`to_writer_streaming`), a bulk typed numeric array
+/// (`to_writer_typed_slice`), or a bulk complex array (`to_writer_complex_slice`).
+/// Boxed so one producer engine serves every body shape.
+type BodyWriter = Box<dyn FnOnce(&mut dyn Write) -> io::Result<()> + Send>;
+
+/// Map a beve encode error to an `io::Error` for the producer pipeline.
+fn beve_to_io(e: beve::Error) -> io::Error {
+    io::Error::other(e.to_string())
+}
+
+/// Run the (write→compress→chunk) pipeline to completion, reporting the outcome
+/// through the channel. Always ends with exactly one `End` or `Fail` before the
+/// channel closes.
+fn produce(body: BodyWriter, tx: SyncSender<Msg>, opts: StreamOpts) {
+    let mut sink = ChunkSink::new(tx.clone(), opts.chunk_bytes);
+    let result = (|| -> io::Result<()> {
+        match opts.compression {
+            Compression::None => body(&mut sink)?,
+            Compression::Zstd => {
+                let mut enc = zstd::stream::write::Encoder::new(&mut sink, opts.zstd_level)?;
+                body(&mut enc)?;
+                enc.finish()?;
+            }
+        }
+        sink.flush_remaining()
+    })();
+    // Send the terminal marker before `sink` (and its channel handle) drop, so the
+    // consumer observes End/Fail in order rather than a bare channel close.
+    let _ = match result {
+        Ok(()) => tx.send(Msg::End),
+        Err(e) => tx.send(Msg::Fail(e.to_string())),
+    };
+}
+
+/// Per-stream consumer-facing state: the receiving end of the producer channel
+/// plus the one-chunk lookahead used to mark the final chunk with `last = 1`.
+struct Session {
+    rx: Receiver<Msg>,
+    lookahead: Option<Vec<u8>>,
+    done: bool,
+}
+
+impl Session {
+    fn recv(&self) -> Msg {
+        self.rx.recv().unwrap_or_else(|_| {
+            // The producer always sends End/Fail before dropping the sender, so a
+            // bare close means the producer thread vanished (panic).
+            Msg::Fail("svs producer ended without completing".to_string())
+        })
+    }
+
+    /// Return the next chunk and whether it is the last. Blocks until the
+    /// producer has the *following* chunk (or its terminal marker) ready — that
+    /// block is the backpressure. Returns `Err` if the producer failed, so a
+    /// truncated production never masquerades as a clean `last`.
+    fn pull(&mut self) -> Result<(Vec<u8>, bool), String> {
+        let current = match self.lookahead.take() {
+            Some(c) => c,
+            None => match self.recv() {
+                Msg::Chunk(c) => c,
+                Msg::End => return Ok((Vec::new(), true)),
+                Msg::Fail(e) => return Err(e),
+            },
+        };
+        match self.recv() {
+            Msg::Chunk(next) => {
+                self.lookahead = Some(next);
+                Ok((current, false))
+            }
+            Msg::End => Ok((current, true)),
+            Msg::Fail(e) => Err(e),
+        }
+    }
+}
+
+/// Server-side table of live download sessions, shared by the `open`/`next`/
+/// `cancel` handlers. Each session is behind its own lock so a `next` can block
+/// on production without holding the table lock.
+struct SessionTable {
+    next_id: AtomicU64,
+    sessions: Mutex<HashMap<u64, Arc<Mutex<Session>>>>,
+}
+
+impl SessionTable {
+    fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn get(&self, stream_id: u64) -> Option<Arc<Mutex<Session>>> {
+        self.sessions.lock().unwrap().get(&stream_id).cloned()
+    }
+
+    fn remove(&self, stream_id: u64) {
+        self.sessions.lock().unwrap().remove(&stream_id);
+    }
+}
+
+struct OpenHandler<F> {
+    table: Arc<SessionTable>,
+    make_body: F,
+    opts: StreamOpts,
+}
+
+impl<F> HandlerErased for OpenHandler<F>
+where
+    F: Fn(&str) -> Option<BodyWriter> + Send + Sync + 'static,
+{
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let open: OpenRequest = match beve_from_slice(&req.body) {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(error_like(
+                    req,
+                    ErrorCode::InvalidBody,
+                    "svs open: expected BEVE { resource: string }",
+                ));
+            }
+        };
+        let Some(body) = (self.make_body)(&open.resource) else {
+            return Ok(error_like(
+                req,
+                ErrorCode::MethodNotFound,
+                format!("svs open: unknown resource '{}'", open.resource),
+            ));
+        };
+
+        let stream_id = self.table.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = sync_channel::<Msg>(self.opts.session_depth);
+        let opts = self.opts;
+        thread::spawn(move || produce(body, tx, opts));
+
+        self.table.sessions.lock().unwrap().insert(
+            stream_id,
+            Arc::new(Mutex::new(Session {
+                rx,
+                lookahead: None,
+                done: false,
+            })),
+        );
+
+        let resp = OpenResponse {
+            version: SVS_VERSION,
+            stream_id,
+            format: BodyFormat::Beve as u16,
+            compression: self.opts.compression as u8,
+        };
+        beve_response(req, &resp)
+    }
+}
+
+struct NextHandler {
+    table: Arc<SessionTable>,
+}
+
+impl HandlerErased for NextHandler {
+    fn execution(&self) -> Execution {
+        // The pull blocks until the producer has the next chunk; on the WebSocket
+        // server that must happen off the reader task so it stays free to decode a
+        // concurrent `cancel`.
+        Execution::OffReader
+    }
+
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        let next: NextRequest = match beve_from_slice(&req.body) {
+            Ok(v) => v,
+            Err(_) => {
+                return Ok(error_like(
+                    req,
+                    ErrorCode::InvalidBody,
+                    "svs next: expected BEVE { stream_id: u64 }",
+                ));
+            }
+        };
+        let Some(session) = self.table.get(next.stream_id) else {
+            return Ok(error_like(
+                req,
+                ErrorCode::InvalidQuery,
+                format!("svs next: unknown stream_id {}", next.stream_id),
+            ));
+        };
+
+        // Pull under the per-session lock (not the table lock), then release it
+        // before touching the table again to keep a single lock order.
+        let outcome = {
+            let mut guard = session.lock().unwrap();
+            if guard.done {
+                Err("svs next: stream already finished".to_string())
+            } else {
+                let pulled = guard.pull();
+                if matches!(pulled, Ok((_, true)) | Err(_)) {
+                    guard.done = true;
+                }
+                pulled
+            }
+        };
+
+        match outcome {
+            Ok((chunk, last)) => {
+                if last {
+                    self.table.remove(next.stream_id);
+                }
+                Ok(chunk_response(req, chunk, last))
+            }
+            Err(msg) => {
+                self.table.remove(next.stream_id);
+                Ok(error_like(req, ErrorCode::InternalError, msg))
+            }
+        }
+    }
+}
+
+struct CancelHandler {
+    table: Arc<SessionTable>,
+}
+
+impl HandlerErased for CancelHandler {
+    fn handle(&self, req: &Message) -> Result<Message, RepeError> {
+        // A malformed cancel still releases nothing but must not error a notify;
+        // parse leniently and drop whatever stream_id we can read.
+        if let Ok(cancel) = beve_from_slice::<CancelRequest>(&req.body) {
+            self.table.remove(cancel.stream_id);
+        }
+        // Dropping the session drops the receiver, which aborts a parked producer
+        // send. Acknowledge so a request-form cancel gets a reply (a notify-form
+        // cancel ignores it).
+        beve_response(req, &CancelAck { ok: true })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CancelAck {
+    ok: bool,
+}
+
+/// Register the three SVS routes onto `router` backed by `make_body`, the
+/// producer-side factory mapping a resource to a [`BodyWriter`] (or `None`).
+fn register_svs<F>(router: Router, make_body: F, opts: StreamOpts) -> Router
+where
+    F: Fn(&str) -> Option<BodyWriter> + Send + Sync + 'static,
+{
+    let table = Arc::new(SessionTable::new());
+    let open: Arc<dyn HandlerErased> = Arc::new(OpenHandler {
+        table: Arc::clone(&table),
+        make_body,
+        opts,
+    });
+    let next: Arc<dyn HandlerErased> = Arc::new(NextHandler {
+        table: Arc::clone(&table),
+    });
+    let cancel: Arc<dyn HandlerErased> = Arc::new(CancelHandler {
+        table: Arc::clone(&table),
+    });
+    router
+        .with_erased_handler(ROUTE_OPEN, open)
+        .with_erased_handler(ROUTE_NEXT, next)
+        .with_erased_handler(ROUTE_CANCEL, cancel)
+}
+
+/// Extension trait that registers an SVS download producer onto a [`Router`].
+///
+/// Each registration installs the `/_svs/open`, `/_svs/next`, and `/_svs/cancel`
+/// routes and serves **one** value shape; a router carries a single SVS producer
+/// (a second registration replaces the routes). `resolve` maps an opaque resource
+/// key (the `resource` field of the `open` request) to the value to stream, or
+/// `None` if there is no such resource. The body is BEVE-encoded and, per
+/// `opts.compression`, zstd-compressed as it is pulled; it is never copied whole.
+///
+/// See the [module docs](crate::value_stream) for where the producer may run
+/// (sync or WebSocket server, not the inline async server).
+pub trait RouterValueStreamExt: Sized {
+    /// Stream an arbitrary `Serialize` value, decoded by the consumer with
+    /// [`pull_value`] (generic, per-element serde).
+    fn with_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: Serialize + Send + 'static,
+        F: Fn(&str) -> Option<T> + Send + Sync + 'static;
+
+    /// Stream a bulk numeric array `Vec<T>` in BEVE typed-array form, so the
+    /// consumer can decode it at memcpy speed with [`pull_typed_slice`]. Use this
+    /// over [`with_value_stream`](Self::with_value_stream) for large primitive
+    /// arrays (samples, matrices) where per-element serde is the bottleneck.
+    fn with_typed_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: beve::BeveTypedSlice + Send + 'static,
+        F: Fn(&str) -> Option<Vec<T>> + Send + Sync + 'static;
+
+    /// Stream a bulk complex array `Vec<Complex<T>>` in BEVE complex-array form,
+    /// decoded by the consumer with [`pull_complex_slice`]. For large IQ buffers.
+    fn with_complex_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: beve::BeveTypedSlice + Send + 'static,
+        F: Fn(&str) -> Option<Vec<Complex<T>>> + Send + Sync + 'static;
+}
+
+impl RouterValueStreamExt for Router {
+    fn with_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: Serialize + Send + 'static,
+        F: Fn(&str) -> Option<T> + Send + Sync + 'static,
+    {
+        register_svs(
+            self,
+            move |resource| {
+                resolve(resource).map(|value| {
+                    Box::new(move |w: &mut dyn Write| {
+                        beve::to_writer_streaming(w, &value).map_err(beve_to_io)
+                    }) as BodyWriter
+                })
+            },
+            opts,
+        )
+    }
+
+    fn with_typed_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: beve::BeveTypedSlice + Send + 'static,
+        F: Fn(&str) -> Option<Vec<T>> + Send + Sync + 'static,
+    {
+        register_svs(
+            self,
+            move |resource| {
+                resolve(resource).map(|values| {
+                    Box::new(move |w: &mut dyn Write| {
+                        beve::to_writer_typed_slice(w, &values).map_err(beve_to_io)
+                    }) as BodyWriter
+                })
+            },
+            opts,
+        )
+    }
+
+    fn with_complex_value_stream<T, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        T: beve::BeveTypedSlice + Send + 'static,
+        F: Fn(&str) -> Option<Vec<Complex<T>>> + Send + Sync + 'static,
+    {
+        register_svs(
+            self,
+            move |resource| {
+                resolve(resource).map(|values| {
+                    Box::new(move |w: &mut dyn Write| {
+                        beve::to_writer_complex_slice(w, &values).map_err(beve_to_io)
+                    }) as BodyWriter
+                })
+            },
+            opts,
+        )
+    }
+}
+
+// ---- response framing helpers (server) ----------------------------------------
+
+fn error_like(req: &Message, code: ErrorCode, msg: impl AsRef<str>) -> Message {
+    let mut err = create_error_message(code, msg.as_ref());
+    err.header.id = req.header.id;
+    err
+}
+
+fn beve_response<T: Serialize>(req: &Message, value: &T) -> Result<Message, RepeError> {
+    Ok(Message::builder()
+        .id(req.header.id)
+        .body_bytes(beve::to_vec(value)?)
+        .body_format(BodyFormat::Beve)
+        .build())
+}
+
+/// Frame a `next` response: the `last` flag rides in a 1-byte raw-binary query so
+/// it never wraps the zero-copy chunk body, which stays raw binary.
+fn chunk_response(req: &Message, chunk: Vec<u8>, last: bool) -> Message {
+    Message::builder()
+        .id(req.header.id)
+        .query_format(QueryFormat::RawBinary)
+        .query_bytes(vec![last as u8])
+        .body_format(BodyFormat::RawBinary)
+        .body_bytes(chunk)
+        .build()
+}
+
+// ---- client: pull driver ------------------------------------------------------
+
+/// What the client does with the pulled byte stream (SVS §2: the receiver's
+/// choice). The output must be consistent with the `format`/`compression` the
+/// `open` response reports, or [`pull_stream`] cancels and errors rather than
+/// producing a mislabeled file.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamOutput<'a> {
+    /// Write the chunk stream to a file as received. Requires a compressed stream
+    /// (`compression = zstd`), since the bytes are the `.beve.zst` payload.
+    BeveZstdFile(&'a Path),
+    /// Decompress the chunk stream to a `.beve` file. Requires `compression =
+    /// zstd` and `format = BEVE`.
+    BeveFile(&'a Path),
+    /// Stream-decode the value into a `T`. Requires `format = BEVE`; a compressed
+    /// stream is decompressed on the way in. Returns `Some(T)`.
+    Value,
+}
+
+/// Pull `resource` from an SVS producer reachable through `client` into `out`.
+///
+/// Returns `Ok(Some(T))` for [`StreamOutput::Value`] and `Ok(None)` for the file
+/// outputs. File outputs are written to a temporary sibling path and renamed only
+/// after the terminating `last = 1` chunk and a flush, so a dropped connection
+/// never leaves a truncated file that looks complete (SVS §4).
+pub fn pull_stream<T: DeserializeOwned>(
+    client: &Client,
+    resource: &str,
+    out: StreamOutput<'_>,
+) -> Result<Option<T>, RepeError> {
+    let open = open_stream(client, resource)?;
+
+    // Validate the chosen output against the returned tags before pulling a byte;
+    // cancel the stream if we cannot honor them.
+    if let Err(e) = check_output(out, &open) {
+        let _ = cancel_stream(
+            client,
+            open.stream_id,
+            "output incompatible with stream tags",
+        );
+        return Err(e);
+    }
+
+    match out {
+        StreamOutput::BeveZstdFile(path) => {
+            write_file(client, open.stream_id, path, |reader, file| {
+                io::copy(reader, file)?;
+                Ok(())
+            })?;
+            Ok(None)
+        }
+        StreamOutput::BeveFile(path) => {
+            write_file(client, open.stream_id, path, |reader, file| {
+                let mut dec = zstd::stream::read::Decoder::new(reader).map_err(RepeError::Io)?;
+                io::copy(&mut dec, file)?;
+                Ok(())
+            })?;
+            Ok(None)
+        }
+        StreamOutput::Value => {
+            let reader = ChunkReader::new(client, open.stream_id);
+            let value = match open.compression {
+                Compression::None => beve::from_reader_streaming::<_, T>(reader)?,
+                Compression::Zstd => {
+                    let dec = zstd::stream::read::Decoder::new(reader).map_err(RepeError::Io)?;
+                    beve::from_reader_streaming::<_, T>(dec)?
+                }
+            };
+            // The value decoded fully; release any remainder of the stream the
+            // decoder did not need to read. Best-effort.
+            let _ = cancel_stream(client, open.stream_id, "value fully decoded");
+            Ok(Some(value))
+        }
+    }
+}
+
+/// Convenience: pull `resource` and decode it into a `T` ([`StreamOutput::Value`]).
+pub fn pull_value<T: DeserializeOwned>(client: &Client, resource: &str) -> Result<T, RepeError> {
+    pull_stream::<T>(client, resource, StreamOutput::Value)
+        .map(|v| v.expect("StreamOutput::Value always yields Some"))
+}
+
+/// Convenience: pull `resource` and write the compressed bytes to `path` as a
+/// `.beve.zst` file ([`StreamOutput::BeveZstdFile`]).
+pub fn pull_to_beve_zst_file(
+    client: &Client,
+    resource: &str,
+    path: &Path,
+) -> Result<(), RepeError> {
+    pull_stream::<()>(client, resource, StreamOutput::BeveZstdFile(path)).map(|_| ())
+}
+
+/// Convenience: pull `resource`, decompress it, and write a `.beve` file
+/// ([`StreamOutput::BeveFile`]).
+pub fn pull_to_beve_file(client: &Client, resource: &str, path: &Path) -> Result<(), RepeError> {
+    pull_stream::<()>(client, resource, StreamOutput::BeveFile(path)).map(|_| ())
+}
+
+/// Pull `resource` as a bulk numeric array decoded straight into a `Vec<T>` at
+/// memcpy speed (beve's `read_typed_slice_from_reader`), skipping the per-element
+/// serde walk [`pull_value`] would do for a `Vec<T>`.
+///
+/// Pair with a server registered via
+/// [`RouterValueStreamExt::with_typed_value_stream`], which emits the BEVE
+/// typed-array wire form this reader requires. A compressed stream is decompressed
+/// on the way in. Errors if the stream is not a typed array of `T` (e.g. a generic
+/// `with_value_stream` producer, or a mismatched element type).
+pub fn pull_typed_slice<T: beve::BeveTypedSlice>(
+    client: &Client,
+    resource: &str,
+) -> Result<Vec<T>, RepeError> {
+    let open = open_stream(client, resource)?;
+    if let Err(e) = require_beve(&open) {
+        let _ = cancel_stream(
+            client,
+            open.stream_id,
+            "format incompatible with bulk decode",
+        );
+        return Err(e);
+    }
+    let reader = ChunkReader::new(client, open.stream_id);
+    let result: Result<Vec<T>, RepeError> = match open.compression {
+        Compression::None => {
+            beve::read_typed_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
+        }
+        Compression::Zstd => match zstd::stream::read::Decoder::new(reader) {
+            Ok(dec) => beve::read_typed_slice_from_reader::<T, _>(dec).map_err(RepeError::from),
+            Err(e) => Err(RepeError::Io(e)),
+        },
+    };
+    // Release the stream whether or not the decode used every chunk (and on error).
+    let _ = cancel_stream(client, open.stream_id, "bulk typed slice complete");
+    result
+}
+
+/// Complex twin of [`pull_typed_slice`]: pull `resource` as a bulk
+/// `Vec<Complex<T>>` (beve's `read_complex_slice_from_reader`). Pair with a server
+/// registered via [`RouterValueStreamExt::with_complex_value_stream`]. For large
+/// IQ buffers.
+pub fn pull_complex_slice<T: beve::BeveTypedSlice>(
+    client: &Client,
+    resource: &str,
+) -> Result<Vec<Complex<T>>, RepeError> {
+    let open = open_stream(client, resource)?;
+    if let Err(e) = require_beve(&open) {
+        let _ = cancel_stream(
+            client,
+            open.stream_id,
+            "format incompatible with bulk decode",
+        );
+        return Err(e);
+    }
+    let reader = ChunkReader::new(client, open.stream_id);
+    let result: Result<Vec<Complex<T>>, RepeError> = match open.compression {
+        Compression::None => {
+            beve::read_complex_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
+        }
+        Compression::Zstd => match zstd::stream::read::Decoder::new(reader) {
+            Ok(dec) => beve::read_complex_slice_from_reader::<T, _>(dec).map_err(RepeError::from),
+            Err(e) => Err(RepeError::Io(e)),
+        },
+    };
+    let _ = cancel_stream(client, open.stream_id, "bulk complex slice complete");
+    result
+}
+
+/// The bulk slice readers require the stream's logical format to be BEVE (the
+/// typed/complex array is BEVE-encoded).
+fn require_beve(open: &OpenInfo) -> Result<(), RepeError> {
+    if open.format != BodyFormat::Beve as u16 {
+        return Err(RepeError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "svs: bulk slice decode needs format=BEVE, got format {}",
+                open.format
+            ),
+        )));
+    }
+    Ok(())
+}
+
+struct OpenInfo {
+    stream_id: u64,
+    format: u16,
+    compression: Compression,
+}
+
+fn open_stream(client: &Client, resource: &str) -> Result<OpenInfo, RepeError> {
+    let body = beve::to_vec(&OpenRequest {
+        resource: resource.to_string(),
+    })?;
+    let resp = client.call_with_formats(
+        ROUTE_OPEN,
+        QueryFormat::JsonPointer as u16,
+        Some(&body),
+        BodyFormat::Beve as u16,
+    )?;
+    let open: OpenResponse = resp.beve_body()?;
+    if open.version != SVS_VERSION {
+        return Err(RepeError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "svs open: server contract version {} != supported {}",
+                open.version, SVS_VERSION
+            ),
+        )));
+    }
+    let Some(compression) = Compression::from_u8(open.compression) else {
+        return Err(RepeError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("svs open: unknown compression tag {}", open.compression),
+        )));
+    };
+    Ok(OpenInfo {
+        stream_id: open.stream_id,
+        format: open.format,
+        compression,
+    })
+}
+
+fn check_output(out: StreamOutput<'_>, open: &OpenInfo) -> Result<(), RepeError> {
+    let beve = BodyFormat::Beve as u16;
+    let mismatch = |msg: String| {
+        Err(RepeError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            msg,
+        )))
+    };
+    match out {
+        StreamOutput::BeveZstdFile(_) => {
+            if open.compression != Compression::Zstd {
+                return mismatch(
+                    "svs: .beve.zst output needs a zstd-compressed stream".to_string(),
+                );
+            }
+        }
+        StreamOutput::BeveFile(_) => {
+            if open.compression != Compression::Zstd {
+                return mismatch("svs: .beve output needs a zstd-compressed stream".to_string());
+            }
+            if open.format != beve {
+                return mismatch(format!(
+                    "svs: .beve output needs format=BEVE, got format {}",
+                    open.format
+                ));
+            }
+        }
+        StreamOutput::Value => {
+            if open.format != beve {
+                return mismatch(format!(
+                    "svs: value decode needs format=BEVE, got format {}",
+                    open.format
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drive the pull into a temp file via `fill`, then commit atomically: flush,
+/// fsync, and rename onto `final_path` only after the stream terminated. The temp
+/// file is removed if anything fails before the rename.
+fn write_file<Fill>(
+    client: &Client,
+    stream_id: u64,
+    final_path: &Path,
+    fill: Fill,
+) -> Result<(), RepeError>
+where
+    Fill: FnOnce(&mut ChunkReader<'_>, &mut std::fs::File) -> Result<(), RepeError>,
+{
+    let tmp_path = temp_sibling(final_path);
+    let mut guard = TempFile::create(&tmp_path)?;
+    let mut reader = ChunkReader::new(client, stream_id);
+
+    let result = (|| {
+        fill(&mut reader, guard.file_mut())?;
+        if !reader.last_seen {
+            // The fill loop returned without the terminating chunk — treat as a
+            // truncated transfer rather than committing a short file.
+            return Err(RepeError::Io(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "svs: stream ended without a final chunk",
+            )));
+        }
+        guard.file_mut().flush()?;
+        guard.file_mut().sync_all()?;
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => guard.commit(final_path),
+        Err(e) => {
+            // On failure, also tell the server to release the stream; the temp
+            // file is removed by the guard's Drop.
+            let _ = cancel_stream(client, stream_id, "receiver aborted");
+            Err(e)
+        }
+    }
+}
+
+fn temp_sibling(final_path: &Path) -> PathBuf {
+    let mut name = final_path
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_default();
+    name.push(".svspart");
+    final_path.with_file_name(name)
+}
+
+/// Owns a temp file and removes it on drop unless [`commit`](TempFile::commit)
+/// renamed it into place first.
+struct TempFile {
+    path: PathBuf,
+    file: Option<std::fs::File>,
+}
+
+impl TempFile {
+    fn create(path: &Path) -> Result<Self, RepeError> {
+        let file = std::fs::File::create(path)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            file: Some(file),
+        })
+    }
+
+    fn file_mut(&mut self) -> &mut std::fs::File {
+        self.file.as_mut().expect("temp file open until commit")
+    }
+
+    fn commit(mut self, final_path: &Path) -> Result<(), RepeError> {
+        self.file = None; // close before rename
+        std::fs::rename(&self.path, final_path)?;
+        self.path = final_path.to_path_buf(); // committed; Drop must not remove it
+        Ok(())
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        if self.file.is_some() {
+            // Not committed — close and remove the partial temp file.
+            self.file = None;
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// A `Read` adapter that issues `next` requests on demand and surfaces the
+/// terminating `last = 1` as EOF. Modes that need a decoder wrap this; the raw
+/// file mode reads it directly.
+struct ChunkReader<'a> {
+    client: &'a Client,
+    stream_id: u64,
+    buf: Vec<u8>,
+    pos: usize,
+    finished: bool,
+    last_seen: bool,
+}
+
+impl<'a> ChunkReader<'a> {
+    fn new(client: &'a Client, stream_id: u64) -> Self {
+        Self {
+            client,
+            stream_id,
+            buf: Vec::new(),
+            pos: 0,
+            finished: false,
+            last_seen: false,
+        }
+    }
+
+    fn fetch(&mut self) -> io::Result<()> {
+        let body = beve::to_vec(&NextRequest {
+            stream_id: self.stream_id,
+        })
+        .map_err(|e| io::Error::other(e.to_string()))?;
+        let resp = self
+            .client
+            .call_with_formats(
+                ROUTE_NEXT,
+                QueryFormat::JsonPointer as u16,
+                Some(&body),
+                BodyFormat::Beve as u16,
+            )
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        let last = resp.query.first().copied() == Some(1);
+        self.buf = resp.body;
+        self.pos = 0;
+        if last {
+            self.last_seen = true;
+            self.finished = true;
+        }
+        Ok(())
+    }
+}
+
+impl Read for ChunkReader<'_> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        loop {
+            if self.pos < self.buf.len() {
+                let n = out.len().min(self.buf.len() - self.pos);
+                out[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+                self.pos += n;
+                return Ok(n);
+            }
+            if self.finished {
+                return Ok(0);
+            }
+            self.fetch()?;
+            // After a fetch the buffer may be empty (a final empty `last` chunk);
+            // loop once more, where `finished` now short-circuits to EOF.
+        }
+    }
+}
+
+fn cancel_stream(client: &Client, stream_id: u64, reason: &str) -> Result<(), RepeError> {
+    let body = beve::to_vec(&CancelRequest {
+        stream_id,
+        reason: reason.to_string(),
+    })?;
+    // Notify form: best-effort, no reply awaited (SVS §2.3).
+    client.notify_with_formats(
+        ROUTE_CANCEL,
+        QueryFormat::JsonPointer as u16,
+        Some(&body),
+        BodyFormat::Beve as u16,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drain(rx: &Receiver<Msg>) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        while let Ok(msg) = rx.recv() {
+            match msg {
+                Msg::Chunk(c) => out.push(c),
+                Msg::End | Msg::Fail(_) => break,
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn chunk_sink_splits_on_size_and_flushes_remainder() {
+        let (tx, rx) = sync_channel::<Msg>(64);
+        let mut sink = ChunkSink::new(tx, 4);
+        // 10 bytes at chunk size 4 -> [4][4][2].
+        sink.write_all(&[0u8; 10]).unwrap();
+        sink.flush_remaining().unwrap();
+        drop(sink);
+        let chunks = drain(&rx);
+        assert_eq!(
+            chunks.iter().map(|c| c.len()).collect::<Vec<_>>(),
+            vec![4, 4, 2]
+        );
+        assert_eq!(chunks.concat().len(), 10);
+    }
+
+    #[test]
+    fn chunk_sink_intermediate_flush_does_not_emit_short_chunk() {
+        let (tx, rx) = sync_channel::<Msg>(64);
+        let mut sink = ChunkSink::new(tx, 8);
+        sink.write_all(&[1u8; 3]).unwrap();
+        sink.flush().unwrap(); // must not push a 3-byte chunk
+        sink.write_all(&[2u8; 7]).unwrap(); // now 10 buffered -> one 8-chunk emitted
+        sink.flush_remaining().unwrap();
+        drop(sink);
+        let chunks = drain(&rx);
+        assert_eq!(
+            chunks.iter().map(|c| c.len()).collect::<Vec<_>>(),
+            vec![8, 2]
+        );
+    }
+
+    fn session_from(msgs: Vec<Msg>) -> Session {
+        let (tx, rx) = sync_channel::<Msg>(msgs.len().max(1));
+        for m in msgs {
+            tx.send(m).unwrap();
+        }
+        drop(tx);
+        Session {
+            rx,
+            lookahead: None,
+            done: false,
+        }
+    }
+
+    #[test]
+    fn pull_marks_only_the_final_chunk_last() {
+        let mut s = session_from(vec![
+            Msg::Chunk(vec![1]),
+            Msg::Chunk(vec![2]),
+            Msg::Chunk(vec![3]),
+            Msg::End,
+        ]);
+        assert_eq!(s.pull().unwrap(), (vec![1], false));
+        assert_eq!(s.pull().unwrap(), (vec![2], false));
+        assert_eq!(s.pull().unwrap(), (vec![3], true));
+    }
+
+    #[test]
+    fn pull_single_chunk_is_last() {
+        let mut s = session_from(vec![Msg::Chunk(vec![9, 9]), Msg::End]);
+        assert_eq!(s.pull().unwrap(), (vec![9, 9], true));
+    }
+
+    #[test]
+    fn pull_zero_chunk_stream_is_empty_last() {
+        let mut s = session_from(vec![Msg::End]);
+        assert_eq!(s.pull().unwrap(), (Vec::<u8>::new(), true));
+    }
+
+    #[test]
+    fn pull_surfaces_producer_failure_instead_of_clean_end() {
+        // The lookahead peek encounters the failure before the buffered chunk
+        // could be mislabeled `last`, so the failure surfaces as an error rather
+        // than a clean terminus — the buffered chunk is discarded, not delivered.
+        let mut s = session_from(vec![Msg::Chunk(vec![1]), Msg::Fail("boom".into())]);
+        assert_eq!(s.pull().unwrap_err(), "boom");
+    }
+
+    #[test]
+    fn pull_dropped_producer_is_an_error_not_a_terminus() {
+        let (tx, rx) = sync_channel::<Msg>(1);
+        tx.send(Msg::Chunk(vec![7])).unwrap();
+        drop(tx); // vanish without End/Fail
+        let mut s = Session {
+            rx,
+            lookahead: None,
+            done: false,
+        };
+        // First pull yields the buffered chunk, peek sees the bare close -> error.
+        assert!(s.pull().is_err());
+    }
+}

--- a/src/value_stream.rs
+++ b/src/value_stream.rs
@@ -1067,6 +1067,93 @@ fn cancel_stream(client: &Client, stream_id: u64, reason: &str) -> Result<(), Re
 // `Read` that drains that channel. The bound supplies backpressure (the SVS
 // round trip itself), so neither side runs ahead of the other.
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for crate::async_client::AsyncClient {}
+    #[cfg(feature = "websocket")]
+    impl Sealed for crate::websocket_client::WebSocketClient {}
+}
+
+/// The async REPE transport an SVS pull is driven over. Implemented for the
+/// async-TCP [`AsyncClient`] and, with the `websocket` feature, the
+/// [`WebSocketClient`](crate::WebSocketClient) — both expose the same
+/// request/notify-with-formats calls the pull loop needs, so the async pullers
+/// accept either. Sealed: it abstracts over the in-crate async clients and is not
+/// meant to be implemented downstream.
+//
+// `async fn` in a public trait normally warns (callers can't name/bound the
+// returned future), but every use here `.await`s it inline on the caller's task
+// — never spawned — so no `Send` bound is needed and the warning does not apply.
+#[allow(async_fn_in_trait)]
+pub trait AsyncSvsClient: sealed::Sealed {
+    /// Request/response with explicit query/body formats (drives `open` / `next`).
+    async fn svs_call(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<Message, RepeError>;
+
+    /// Fire-and-forget notify with explicit formats (drives best-effort `cancel`).
+    async fn svs_notify(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError>;
+}
+
+impl AsyncSvsClient for AsyncClient {
+    async fn svs_call(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<Message, RepeError> {
+        self.call_with_formats(path, query_format, body, body_format)
+            .await
+    }
+
+    async fn svs_notify(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_formats(path, query_format, body, body_format)
+            .await
+    }
+}
+
+#[cfg(feature = "websocket")]
+impl AsyncSvsClient for crate::websocket_client::WebSocketClient {
+    async fn svs_call(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<Message, RepeError> {
+        self.call_with_formats(path, query_format, body, body_format)
+            .await
+    }
+
+    async fn svs_notify(
+        &self,
+        path: &str,
+        query_format: u16,
+        body: Option<&[u8]>,
+        body_format: u16,
+    ) -> Result<(), RepeError> {
+        self.notify_with_formats(path, query_format, body, body_format)
+            .await
+    }
+}
+
 /// Chunks held in flight between the async pull task and the blocking decoder.
 /// Small: the SVS round trip already paces the producer, so this only needs to
 /// cover the gap between a `next` completing and the decoder consuming it.
@@ -1116,15 +1203,15 @@ impl Read for ChannelReader {
 /// Issue `next` requests over `client` and feed each non-empty chunk into `tx`
 /// until the `last` flag. Returns early (without error) if the decoder finished
 /// and dropped its receiver. `tx` drops on return, signalling EOF to the reader.
-async fn pull_loop_async(
-    client: &AsyncClient,
+async fn pull_loop_async<C: AsyncSvsClient>(
+    client: &C,
     stream_id: u64,
     tx: tokio::sync::mpsc::Sender<Vec<u8>>,
 ) -> Result<(), RepeError> {
     let body = next_request_body(stream_id)?;
     loop {
         let resp = client
-            .call_with_formats(
+            .svs_call(
                 ROUTE_NEXT,
                 QueryFormat::JsonPointer as u16,
                 Some(&body),
@@ -1143,14 +1230,14 @@ async fn pull_loop_async(
 }
 
 /// Best-effort async `cancel` (notify form, no reply awaited; SVS §2.3).
-async fn cancel_stream_async(
-    client: &AsyncClient,
+async fn cancel_stream_async<C: AsyncSvsClient>(
+    client: &C,
     stream_id: u64,
     reason: &str,
 ) -> Result<(), RepeError> {
     let body = cancel_request_body(stream_id, reason)?;
     client
-        .notify_with_formats(
+        .svs_notify(
             ROUTE_CANCEL,
             QueryFormat::JsonPointer as u16,
             Some(&body),
@@ -1163,8 +1250,8 @@ async fn cancel_stream_async(
 /// `decode` run concurrently across the channel, with `decode` receiving a `Read`
 /// over the (optionally zstd-decompressed) chunk stream. Shared by the async
 /// value and bulk-slice pullers.
-async fn pull_decode_async<V, F>(
-    client: &AsyncClient,
+async fn pull_decode_async<V, F, C: AsyncSvsClient>(
+    client: &C,
     resource: &str,
     decode: F,
 ) -> Result<V, RepeError>
@@ -1174,7 +1261,7 @@ where
 {
     let body = open_request_body(resource)?;
     let resp = client
-        .call_with_formats(
+        .svs_call(
             ROUTE_OPEN,
             QueryFormat::JsonPointer as u16,
             Some(&body),
@@ -1219,11 +1306,13 @@ where
 /// Async counterpart of [`pull_value`]: pull `resource` and decode the whole
 /// stream into a `T` via BEVE (streaming, optionally zstd-decompressed).
 ///
-/// Drives an [`AsyncClient`]; the producer must run on a server that honours
+/// `client` is any [`AsyncSvsClient`] — the async-TCP [`AsyncClient`] or, with
+/// the `websocket` feature, the [`WebSocketClient`](crate::WebSocketClient). The
+/// producer must run on a server that honours
 /// [`Execution::OffReader`](crate::Execution) (the sync [`Server`](crate::Server)
 /// or the WebSocket server), not the inline async server.
-pub async fn pull_value_async<T: DeserializeOwned + Send + 'static>(
-    client: &AsyncClient,
+pub async fn pull_value_async<T: DeserializeOwned + Send + 'static, C: AsyncSvsClient>(
+    client: &C,
     resource: &str,
 ) -> Result<T, RepeError> {
     pull_decode_async(client, resource, |reader| {
@@ -1233,9 +1322,10 @@ pub async fn pull_value_async<T: DeserializeOwned + Send + 'static>(
 }
 
 /// Async counterpart of [`pull_typed_slice`]: bulk-decode a streamed numeric
-/// array straight into a `Vec<T>` (memcpy of the little-endian payload).
-pub async fn pull_typed_slice_async<T: beve::BeveTypedSlice + Send + 'static>(
-    client: &AsyncClient,
+/// array straight into a `Vec<T>` (memcpy of the little-endian payload). Accepts
+/// any [`AsyncSvsClient`].
+pub async fn pull_typed_slice_async<T: beve::BeveTypedSlice + Send + 'static, C: AsyncSvsClient>(
+    client: &C,
     resource: &str,
 ) -> Result<Vec<T>, RepeError> {
     pull_decode_async(client, resource, |reader| {
@@ -1245,9 +1335,12 @@ pub async fn pull_typed_slice_async<T: beve::BeveTypedSlice + Send + 'static>(
 }
 
 /// Async counterpart of [`pull_complex_slice`]: bulk-decode a streamed complex
-/// array straight into a `Vec<Complex<T>>`.
-pub async fn pull_complex_slice_async<T: beve::BeveTypedSlice + Send + 'static>(
-    client: &AsyncClient,
+/// array straight into a `Vec<Complex<T>>`. Accepts any [`AsyncSvsClient`].
+pub async fn pull_complex_slice_async<
+    T: beve::BeveTypedSlice + Send + 'static,
+    C: AsyncSvsClient,
+>(
+    client: &C,
     resource: &str,
 ) -> Result<Vec<Complex<T>>, RepeError> {
     pull_decode_async(client, resource, |reader| {

--- a/src/value_stream.rs
+++ b/src/value_stream.rs
@@ -23,7 +23,11 @@
 //! * **Download** (server produces, client pulls) — the primary direction.
 //!   Register a producer with [`RouterValueStreamExt::with_value_stream`] and
 //!   pull with [`pull_value`] / [`pull_to_beve_file`] / [`pull_to_beve_zst_file`]
-//!   (or the general [`pull_stream`]).
+//!   (or the general [`pull_stream`]) over the synchronous [`Client`]. From async
+//!   code, drive an [`AsyncClient`] with [`pull_value_async`] /
+//!   [`pull_typed_slice_async`] / [`pull_complex_slice_async`]: these run the
+//!   blocking decoder on a `spawn_blocking` thread fed by an async pull loop, so
+//!   they never park the runtime.
 //!
 //! # Where the producer may run
 //!
@@ -37,6 +41,7 @@
 //! registered there would park a runtime worker; use the sync or WebSocket server
 //! for SVS producers.
 
+use crate::async_client::AsyncClient;
 use crate::client::Client;
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat};
 use crate::error::RepeError;
@@ -787,16 +792,29 @@ struct OpenInfo {
     compression: Compression,
 }
 
-fn open_stream(client: &Client, resource: &str) -> Result<OpenInfo, RepeError> {
-    let body = beve::to_vec(&OpenRequest {
+/// BEVE body of an `open` request for `resource`.
+fn open_request_body(resource: &str) -> Result<Vec<u8>, RepeError> {
+    Ok(beve::to_vec(&OpenRequest {
         resource: resource.to_string(),
-    })?;
-    let resp = client.call_with_formats(
-        ROUTE_OPEN,
-        QueryFormat::JsonPointer as u16,
-        Some(&body),
-        BodyFormat::Beve as u16,
-    )?;
+    })?)
+}
+
+/// BEVE body of a `next` request for `stream_id`.
+fn next_request_body(stream_id: u64) -> Result<Vec<u8>, RepeError> {
+    Ok(beve::to_vec(&NextRequest { stream_id })?)
+}
+
+/// BEVE body of a `cancel` request for `stream_id` carrying a human `reason`.
+fn cancel_request_body(stream_id: u64, reason: &str) -> Result<Vec<u8>, RepeError> {
+    Ok(beve::to_vec(&CancelRequest {
+        stream_id,
+        reason: reason.to_string(),
+    })?)
+}
+
+/// Validate and parse an `open` response into the stream's [`OpenInfo`]. Shared
+/// by the sync and async pull drivers.
+fn parse_open_response(resp: &Message) -> Result<OpenInfo, RepeError> {
     let open: OpenResponse = resp.beve_body()?;
     if open.version != SVS_VERSION {
         return Err(RepeError::Io(io::Error::new(
@@ -818,6 +836,17 @@ fn open_stream(client: &Client, resource: &str) -> Result<OpenInfo, RepeError> {
         format: open.format,
         compression,
     })
+}
+
+fn open_stream(client: &Client, resource: &str) -> Result<OpenInfo, RepeError> {
+    let body = open_request_body(resource)?;
+    let resp = client.call_with_formats(
+        ROUTE_OPEN,
+        QueryFormat::JsonPointer as u16,
+        Some(&body),
+        BodyFormat::Beve as u16,
+    )?;
+    parse_open_response(&resp)
 }
 
 fn check_output(out: StreamOutput<'_>, open: &OpenInfo) -> Result<(), RepeError> {
@@ -1017,10 +1046,7 @@ impl Read for ChunkReader<'_> {
 }
 
 fn cancel_stream(client: &Client, stream_id: u64, reason: &str) -> Result<(), RepeError> {
-    let body = beve::to_vec(&CancelRequest {
-        stream_id,
-        reason: reason.to_string(),
-    })?;
+    let body = cancel_request_body(stream_id, reason)?;
     // Notify form: best-effort, no reply awaited (SVS §2.3).
     client.notify_with_formats(
         ROUTE_CANCEL,
@@ -1028,6 +1054,206 @@ fn cancel_stream(client: &Client, stream_id: u64, reason: &str) -> Result<(), Re
         Some(&body),
         BodyFormat::Beve as u16,
     )
+}
+
+// ---- client: async pull driver (over `AsyncClient`) ---------------------------
+//
+// The SVS receiver is a blocking pull loop feeding a blocking decoder
+// (`beve::from_reader_streaming` / the bulk slice readers / `zstd`'s `Read`
+// decoder) — none of which are `async`. To drive a pull from async code without
+// blocking the runtime, we split the two halves across the async/blocking
+// boundary: an async task issues `next` requests and feeds each chunk into a
+// bounded channel, while a `spawn_blocking` task runs the decoder over a blocking
+// `Read` that drains that channel. The bound supplies backpressure (the SVS
+// round trip itself), so neither side runs ahead of the other.
+
+/// Chunks held in flight between the async pull task and the blocking decoder.
+/// Small: the SVS round trip already paces the producer, so this only needs to
+/// cover the gap between a `next` completing and the decoder consuming it.
+const ASYNC_PULL_DEPTH: usize = 4;
+
+/// A blocking [`Read`] over a channel of chunks. Lives on the `spawn_blocking`
+/// thread and is fed by [`pull_loop_async`]; `blocking_recv` parks that thread
+/// (never the runtime) until the next chunk or end-of-stream arrives.
+struct ChannelReader {
+    rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+    pos: usize,
+}
+
+impl ChannelReader {
+    fn new(rx: tokio::sync::mpsc::Receiver<Vec<u8>>) -> Self {
+        Self {
+            rx,
+            buf: Vec::new(),
+            pos: 0,
+        }
+    }
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        loop {
+            if self.pos < self.buf.len() {
+                let n = out.len().min(self.buf.len() - self.pos);
+                out[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+                self.pos += n;
+                return Ok(n);
+            }
+            match self.rx.blocking_recv() {
+                Some(chunk) => {
+                    self.buf = chunk;
+                    self.pos = 0;
+                }
+                // Sender dropped: the pull loop reached `last` (or errored). The
+                // decoder sees a clean EOF; a short read surfaces as its own error.
+                None => return Ok(0),
+            }
+        }
+    }
+}
+
+/// Issue `next` requests over `client` and feed each non-empty chunk into `tx`
+/// until the `last` flag. Returns early (without error) if the decoder finished
+/// and dropped its receiver. `tx` drops on return, signalling EOF to the reader.
+async fn pull_loop_async(
+    client: &AsyncClient,
+    stream_id: u64,
+    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+) -> Result<(), RepeError> {
+    let body = next_request_body(stream_id)?;
+    loop {
+        let resp = client
+            .call_with_formats(
+                ROUTE_NEXT,
+                QueryFormat::JsonPointer as u16,
+                Some(&body),
+                BodyFormat::Beve as u16,
+            )
+            .await?;
+        let last = resp.query.first().copied() == Some(1);
+        if !resp.body.is_empty() && tx.send(resp.body).await.is_err() {
+            // Decoder is done and dropped the receiver; nothing left to feed.
+            return Ok(());
+        }
+        if last {
+            return Ok(());
+        }
+    }
+}
+
+/// Best-effort async `cancel` (notify form, no reply awaited; SVS §2.3).
+async fn cancel_stream_async(
+    client: &AsyncClient,
+    stream_id: u64,
+    reason: &str,
+) -> Result<(), RepeError> {
+    let body = cancel_request_body(stream_id, reason)?;
+    client
+        .notify_with_formats(
+            ROUTE_CANCEL,
+            QueryFormat::JsonPointer as u16,
+            Some(&body),
+            BodyFormat::Beve as u16,
+        )
+        .await
+}
+
+/// Open `resource`, then pull and decode it: the async pull loop and the blocking
+/// `decode` run concurrently across the channel, with `decode` receiving a `Read`
+/// over the (optionally zstd-decompressed) chunk stream. Shared by the async
+/// value and bulk-slice pullers.
+async fn pull_decode_async<V, F>(
+    client: &AsyncClient,
+    resource: &str,
+    decode: F,
+) -> Result<V, RepeError>
+where
+    V: Send + 'static,
+    F: FnOnce(Box<dyn Read>) -> Result<V, RepeError> + Send + 'static,
+{
+    let body = open_request_body(resource)?;
+    let resp = client
+        .call_with_formats(
+            ROUTE_OPEN,
+            QueryFormat::JsonPointer as u16,
+            Some(&body),
+            BodyFormat::Beve as u16,
+        )
+        .await?;
+    let open = parse_open_response(&resp)?;
+    if let Err(e) = require_beve(&open) {
+        let _ = cancel_stream_async(client, open.stream_id, "format incompatible").await;
+        return Err(e);
+    }
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(ASYNC_PULL_DEPTH);
+    let compression = open.compression;
+    // Starts immediately on a blocking thread; runs concurrently with the pull
+    // loop below, the two paced by the channel bound.
+    let decode_task = tokio::task::spawn_blocking(move || -> Result<V, RepeError> {
+        let reader: Box<dyn Read> = match compression {
+            Compression::None => Box::new(ChannelReader::new(rx)),
+            Compression::Zstd => Box::new(
+                zstd::stream::read::Decoder::new(ChannelReader::new(rx)).map_err(RepeError::Io)?,
+            ),
+        };
+        decode(reader)
+    });
+
+    let pull_res = pull_loop_async(client, open.stream_id, tx).await;
+    let decode_res = decode_task.await;
+    // Best-effort release; the stream is spent (or the pull failed) either way.
+    let _ = cancel_stream_async(client, open.stream_id, "pull complete").await;
+
+    // A pull/network error explains any decode-side EOF, so surface it first.
+    pull_res?;
+    match decode_res {
+        Ok(v) => v,
+        Err(join_err) => Err(RepeError::Io(io::Error::other(format!(
+            "svs decode task failed: {join_err}"
+        )))),
+    }
+}
+
+/// Async counterpart of [`pull_value`]: pull `resource` and decode the whole
+/// stream into a `T` via BEVE (streaming, optionally zstd-decompressed).
+///
+/// Drives an [`AsyncClient`]; the producer must run on a server that honours
+/// [`Execution::OffReader`](crate::Execution) (the sync [`Server`](crate::Server)
+/// or the WebSocket server), not the inline async server.
+pub async fn pull_value_async<T: DeserializeOwned + Send + 'static>(
+    client: &AsyncClient,
+    resource: &str,
+) -> Result<T, RepeError> {
+    pull_decode_async(client, resource, |reader| {
+        beve::from_reader_streaming::<_, T>(reader).map_err(RepeError::from)
+    })
+    .await
+}
+
+/// Async counterpart of [`pull_typed_slice`]: bulk-decode a streamed numeric
+/// array straight into a `Vec<T>` (memcpy of the little-endian payload).
+pub async fn pull_typed_slice_async<T: beve::BeveTypedSlice + Send + 'static>(
+    client: &AsyncClient,
+    resource: &str,
+) -> Result<Vec<T>, RepeError> {
+    pull_decode_async(client, resource, |reader| {
+        beve::read_typed_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
+    })
+    .await
+}
+
+/// Async counterpart of [`pull_complex_slice`]: bulk-decode a streamed complex
+/// array straight into a `Vec<Complex<T>>`.
+pub async fn pull_complex_slice_async<T: beve::BeveTypedSlice + Send + 'static>(
+    client: &AsyncClient,
+    resource: &str,
+) -> Result<Vec<Complex<T>>, RepeError> {
+    pull_decode_async(client, resource, |reader| {
+        beve::read_complex_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/tests/value_stream.rs
+++ b/tests/value_stream.rs
@@ -1,0 +1,187 @@
+//! End-to-end tests for the SVS download path: a synchronous `Server` producing
+//! a streamed value and a `Client` pulling it into each of the three receiver
+//! outputs, over a real TCP loopback connection.
+#![cfg(feature = "value-stream")]
+
+use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts, StreamOutput};
+use repe::{Client, RepeError, Router, Server, pull_stream, pull_to_beve_file, pull_value};
+use serde::{Deserialize, Serialize};
+use std::net::TcpListener;
+use std::path::Path;
+use std::thread;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Payload {
+    id: u64,
+    label: String,
+    samples: Vec<f64>,
+    tags: Vec<String>,
+}
+
+fn sample_payload() -> Payload {
+    // Large enough (~1.6 MiB of f64 plus strings) to span many chunks once the
+    // test forces a small chunk size, exercising the lookahead/last logic and
+    // multi-chunk reassembly rather than a single-frame happy path.
+    Payload {
+        id: 0xFEED_BEEF,
+        label: "serialized value stream".to_string(),
+        samples: (0..200_000).map(|i| (i as f64) * 0.5 - 1234.5).collect(),
+        tags: (0..64).map(|i| format!("tag-{i:03}")).collect(),
+    }
+}
+
+/// Start a sync `Server` whose router streams `payload` for the resource key
+/// `"payload"`, with the given options. Returns a connected client. The server
+/// thread is detached (the process exits at test end).
+fn serve(payload: Payload, opts: StreamOpts) -> Client {
+    let router = Router::new().with_value_stream(
+        move |resource: &str| (resource == "payload").then(|| payload.clone()),
+        opts,
+    );
+    let server = Server::new(router);
+    let listener: TcpListener = server.listen("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+    Client::connect(addr).expect("connect")
+}
+
+fn small_chunks(compression: Compression) -> StreamOpts {
+    StreamOpts {
+        chunk_bytes: 16 * 1024,
+        compression,
+        zstd_level: 3,
+        session_depth: 4,
+    }
+}
+
+#[test]
+fn value_mode_roundtrips_compressed() {
+    let payload = sample_payload();
+    let client = serve(payload.clone(), small_chunks(Compression::Zstd));
+    let got: Payload = pull_value(&client, "payload").expect("pull value");
+    assert_eq!(got, payload);
+}
+
+#[test]
+fn value_mode_roundtrips_uncompressed() {
+    let payload = sample_payload();
+    let client = serve(payload.clone(), small_chunks(Compression::None));
+    let got: Payload = pull_value(&client, "payload").expect("pull value");
+    assert_eq!(got, payload);
+}
+
+#[test]
+fn beve_zst_file_decodes_back_to_the_value() {
+    let payload = sample_payload();
+    let client = serve(payload.clone(), small_chunks(Compression::Zstd));
+
+    let dir = std::env::temp_dir().join(format!("svs-zst-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("value.beve.zst");
+
+    pull_stream::<()>(&client, "payload", StreamOutput::BeveZstdFile(&path)).expect("pull file");
+
+    // The file is the raw compressed stream: decompress, then BEVE-decode.
+    let compressed = std::fs::read(&path).expect("read file");
+    let beve_bytes = zstd::decode_all(&compressed[..]).expect("zstd decode");
+    let decoded: Payload = beve::from_slice(&beve_bytes).expect("beve decode");
+    assert_eq!(decoded, payload);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn beve_file_is_decompressed_and_decodes_back_to_the_value() {
+    let payload = sample_payload();
+    let client = serve(payload.clone(), small_chunks(Compression::Zstd));
+
+    let dir = std::env::temp_dir().join(format!("svs-beve-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("value.beve");
+
+    pull_to_beve_file(&client, "payload", &path).expect("pull decompressed file");
+
+    // The file is already-decompressed BEVE: decode directly.
+    let beve_bytes = std::fs::read(&path).expect("read file");
+    let decoded: Payload = beve::from_slice(&beve_bytes).expect("beve decode");
+    assert_eq!(decoded, payload);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn unknown_resource_errors() {
+    let client = serve(sample_payload(), StreamOpts::default());
+    let err = pull_value::<Payload>(&client, "does-not-exist").unwrap_err();
+    match err {
+        RepeError::ServerError { code, .. } => {
+            assert_eq!(code, repe::ErrorCode::MethodNotFound);
+        }
+        other => panic!("expected a server MethodNotFound error, got {other:?}"),
+    }
+}
+
+#[test]
+fn output_incompatible_with_tags_is_rejected_before_writing() {
+    // Server streams uncompressed; asking for a `.beve.zst` (raw-compressed)
+    // output must be refused rather than mislabeling uncompressed bytes.
+    let client = serve(sample_payload(), small_chunks(Compression::None));
+
+    let dir = std::env::temp_dir().join(format!("svs-bad-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("value.beve.zst");
+
+    let err = pull_stream::<()>(&client, "payload", StreamOutput::BeveZstdFile(&path)).unwrap_err();
+    assert!(
+        matches!(err, RepeError::Io(_)),
+        "expected a tag-mismatch error, got {err:?}"
+    );
+    // And nothing was committed at the final path.
+    assert!(
+        !path.exists(),
+        "no file should be written on a tag mismatch"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn many_small_payloads_each_terminate_cleanly() {
+    // Drive several sequential pulls over one connection to confirm a stream is
+    // fully released (`last` reached, session removed) and the next one starts
+    // clean — i.e. no leaked session state across transfers.
+    let payload = Payload {
+        id: 1,
+        label: "tiny".to_string(),
+        samples: vec![1.0, 2.0, 3.0],
+        tags: vec!["x".to_string()],
+    };
+    let client = serve(payload.clone(), small_chunks(Compression::Zstd));
+    for _ in 0..5 {
+        let got: Payload = pull_value(&client, "payload").expect("pull");
+        assert_eq!(got, payload);
+    }
+}
+
+#[test]
+fn interrupted_file_pull_leaves_no_final_file() {
+    // A receiver that never reaches `last` must not leave a file at the final
+    // path. We simulate this by pointing the temp/commit logic at a directory we
+    // can inspect and pulling a resource that does not exist (open fails before
+    // any chunk), then asserting the final path is absent.
+    let client = serve(sample_payload(), small_chunks(Compression::Zstd));
+    let dir = std::env::temp_dir().join(format!("svs-int-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path: &Path = &dir.join("nope.beve");
+
+    let err = pull_to_beve_file(&client, "missing", path);
+    assert!(err.is_err());
+    assert!(
+        !path.exists(),
+        "final file must not exist after a failed pull"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tests/value_stream_async.rs
+++ b/tests/value_stream_async.rs
@@ -142,6 +142,69 @@ async fn unknown_resource_errors() {
         small_chunks(Compression::None),
     ));
     let client = AsyncClient::connect(addr).await.expect("connect");
-    let got = pull_value_async::<Payload>(&client, "does-not-exist").await;
+    let got = pull_value_async::<Payload, _>(&client, "does-not-exist").await;
     assert!(got.is_err(), "unknown resource must error");
+}
+
+// The same async pullers drive a `WebSocketClient`. The WebSocket server runs
+// the SVS `next` handler off the reader task (it honours `Execution::OffReader`),
+// so blocking for backpressure there is fine.
+#[cfg(feature = "websocket")]
+mod websocket {
+    use super::*;
+    use repe::{WebSocketClient, WebSocketServer};
+
+    /// Spawn a detached WebSocket server for `router` on path `/repe` and return a
+    /// connected client.
+    async fn ws_client(router: Router) -> WebSocketClient {
+        let listener = WebSocketServer::listen("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let _ = WebSocketServer::new(router)
+                .serve_listener(listener, "/repe")
+                .await;
+        });
+        WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .expect("connect")
+    }
+
+    #[tokio::test]
+    async fn value_mode_over_websocket() {
+        let payload = sample_payload();
+        let p = payload.clone();
+        let client = ws_client(Router::new().with_value_stream(
+            move |resource: &str| (resource == "payload").then(|| p.clone()),
+            small_chunks(Compression::Zstd),
+        ))
+        .await;
+        let got: Payload = pull_value_async(&client, "payload").await.expect("pull");
+        assert_eq!(got, payload);
+    }
+
+    #[tokio::test]
+    async fn typed_slice_over_websocket() {
+        let v = f64_samples();
+        let vc = v.clone();
+        let client = ws_client(Router::new().with_typed_value_stream(
+            move |resource: &str| (resource == "buf").then(|| vc.clone()),
+            small_chunks(Compression::None),
+        ))
+        .await;
+        let got: Vec<f64> = pull_typed_slice_async(&client, "buf").await.expect("pull");
+        assert_eq!(got, v);
+    }
+
+    #[tokio::test]
+    async fn complex_slice_over_websocket() {
+        let v = iq_samples();
+        let vc = v.clone();
+        let client = ws_client(Router::new().with_complex_value_stream(
+            move |resource: &str| (resource == "iq").then(|| vc.clone()),
+            small_chunks(Compression::Zstd),
+        ))
+        .await;
+        let got: Vec<Complex<f32>> = pull_complex_slice_async(&client, "iq").await.expect("pull");
+        assert_eq!(got, v);
+    }
 }

--- a/tests/value_stream_async.rs
+++ b/tests/value_stream_async.rs
@@ -1,0 +1,147 @@
+//! End-to-end tests for the async SVS pull driver: a synchronous `Server`
+//! producing a streamed value (it honours `Execution::OffReader`) and an
+//! `AsyncClient` pulling it from async code, across the async/blocking decode
+//! boundary, over a real TCP loopback connection. Covers the value, typed-slice,
+//! and complex-slice receivers, each compressed and uncompressed.
+#![cfg(feature = "value-stream")]
+
+use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts};
+use repe::{
+    AsyncClient, Complex, Router, Server, pull_complex_slice_async, pull_typed_slice_async,
+    pull_value_async,
+};
+use serde::{Deserialize, Serialize};
+use std::net::{SocketAddr, TcpListener};
+use std::thread;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Payload {
+    id: u64,
+    label: String,
+    samples: Vec<f64>,
+    tags: Vec<String>,
+}
+
+fn sample_payload() -> Payload {
+    // ~1.6 MiB, spans many 16 KiB chunks so the pull loop / lookahead / blocking
+    // decode bridge are exercised across multiple `next` round trips.
+    Payload {
+        id: 0xFEED_BEEF,
+        label: "serialized value stream".to_string(),
+        samples: (0..200_000).map(|i| (i as f64) * 0.5 - 1234.5).collect(),
+        tags: (0..64).map(|i| format!("tag-{i:03}")).collect(),
+    }
+}
+
+fn f64_samples() -> Vec<f64> {
+    (0..200_000).map(|i| (i as f64) * 0.5 - 1234.5).collect()
+}
+
+fn iq_samples() -> Vec<Complex<f32>> {
+    (0..200_000)
+        .map(|i| Complex {
+            re: (i as f32) * 1e-3,
+            im: -(i as f32) * 2e-3,
+        })
+        .collect()
+}
+
+fn small_chunks(compression: Compression) -> StreamOpts {
+    StreamOpts {
+        chunk_bytes: 16 * 1024,
+        compression,
+        zstd_level: 3,
+        session_depth: 4,
+    }
+}
+
+/// Spawn a detached sync `Server` for `router` on an ephemeral port and return
+/// its address (the sync server honours `OffReader`, which the SVS `next`
+/// handler reports).
+fn spawn(router: Router) -> SocketAddr {
+    let server = Server::new(router);
+    let listener: TcpListener = server.listen("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+    addr
+}
+
+async fn run_value(compression: Compression) {
+    let payload = sample_payload();
+    let p = payload.clone();
+    let addr = spawn(Router::new().with_value_stream(
+        move |resource: &str| (resource == "payload").then(|| p.clone()),
+        small_chunks(compression),
+    ));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+    let got: Payload = pull_value_async(&client, "payload").await.expect("pull");
+    assert_eq!(got, payload);
+}
+
+#[tokio::test]
+async fn value_mode_roundtrips_uncompressed() {
+    run_value(Compression::None).await;
+}
+
+#[tokio::test]
+async fn value_mode_roundtrips_compressed() {
+    run_value(Compression::Zstd).await;
+}
+
+async fn run_typed(compression: Compression) {
+    let v = f64_samples();
+    let vc = v.clone();
+    let addr = spawn(Router::new().with_typed_value_stream(
+        move |resource: &str| (resource == "buf").then(|| vc.clone()),
+        small_chunks(compression),
+    ));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+    let got: Vec<f64> = pull_typed_slice_async(&client, "buf").await.expect("pull");
+    assert_eq!(got, v);
+}
+
+#[tokio::test]
+async fn typed_slice_roundtrips_uncompressed() {
+    run_typed(Compression::None).await;
+}
+
+#[tokio::test]
+async fn typed_slice_roundtrips_compressed() {
+    run_typed(Compression::Zstd).await;
+}
+
+async fn run_complex(compression: Compression) {
+    let v = iq_samples();
+    let vc = v.clone();
+    let addr = spawn(Router::new().with_complex_value_stream(
+        move |resource: &str| (resource == "iq").then(|| vc.clone()),
+        small_chunks(compression),
+    ));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+    let got: Vec<Complex<f32>> = pull_complex_slice_async(&client, "iq").await.expect("pull");
+    assert_eq!(got, v);
+}
+
+#[tokio::test]
+async fn complex_slice_roundtrips_uncompressed() {
+    run_complex(Compression::None).await;
+}
+
+#[tokio::test]
+async fn complex_slice_roundtrips_compressed() {
+    run_complex(Compression::Zstd).await;
+}
+
+/// A missing resource must surface as an error, not hang.
+#[tokio::test]
+async fn unknown_resource_errors() {
+    let addr = spawn(Router::new().with_value_stream(
+        move |resource: &str| (resource == "payload").then(sample_payload),
+        small_chunks(Compression::None),
+    ));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+    let got = pull_value_async::<Payload>(&client, "does-not-exist").await;
+    assert!(got.is_err(), "unknown resource must error");
+}

--- a/tests/value_stream_bulk.rs
+++ b/tests/value_stream_bulk.rs
@@ -1,0 +1,132 @@
+//! End-to-end tests for the SVS bulk path: a `with_typed_value_stream` /
+//! `with_complex_value_stream` producer streaming a numeric or complex array, and
+//! a client decoding it at bulk speed with `pull_typed_slice` / `pull_complex_slice`.
+#![cfg(feature = "value-stream")]
+
+use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts};
+use repe::{
+    Client, Complex, RepeError, Router, Server, pull_complex_slice, pull_to_beve_zst_file,
+    pull_typed_slice,
+};
+use std::net::TcpListener;
+use std::thread;
+
+fn serve(router: Router) -> Client {
+    let server = Server::new(router);
+    let listener: TcpListener = server.listen("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+    Client::connect(addr).expect("connect")
+}
+
+fn small_chunks(compression: Compression) -> StreamOpts {
+    StreamOpts {
+        chunk_bytes: 16 * 1024,
+        compression,
+        zstd_level: 3,
+        session_depth: 4,
+    }
+}
+
+fn f64_samples() -> Vec<f64> {
+    (0..200_000).map(|i| (i as f64) * 0.5 - 1234.5).collect()
+}
+
+fn iq_samples() -> Vec<Complex<f32>> {
+    (0..200_000)
+        .map(|i| Complex {
+            re: (i as f32) * 1e-3,
+            im: -(i as f32) * 2e-3,
+        })
+        .collect()
+}
+
+fn typed_router(values: Vec<f64>, opts: StreamOpts) -> Router {
+    Router::new().with_typed_value_stream(
+        move |resource: &str| (resource == "buf").then(|| values.clone()),
+        opts,
+    )
+}
+
+fn complex_router(values: Vec<Complex<f32>>, opts: StreamOpts) -> Router {
+    Router::new().with_complex_value_stream(
+        move |resource: &str| (resource == "iq").then(|| values.clone()),
+        opts,
+    )
+}
+
+#[test]
+fn typed_slice_roundtrips_uncompressed() {
+    let v = f64_samples();
+    let client = serve(typed_router(v.clone(), small_chunks(Compression::None)));
+    let got: Vec<f64> = pull_typed_slice(&client, "buf").expect("pull typed");
+    assert_eq!(got, v);
+}
+
+#[test]
+fn typed_slice_roundtrips_compressed() {
+    let v = f64_samples();
+    let client = serve(typed_router(v.clone(), small_chunks(Compression::Zstd)));
+    let got: Vec<f64> = pull_typed_slice(&client, "buf").expect("pull typed");
+    assert_eq!(got, v);
+}
+
+#[test]
+fn complex_slice_roundtrips_uncompressed() {
+    let v = iq_samples();
+    let client = serve(complex_router(v.clone(), small_chunks(Compression::None)));
+    let got: Vec<Complex<f32>> = pull_complex_slice(&client, "iq").expect("pull complex");
+    assert_eq!(got, v);
+}
+
+#[test]
+fn complex_slice_roundtrips_compressed() {
+    let v = iq_samples();
+    let client = serve(complex_router(v.clone(), small_chunks(Compression::Zstd)));
+    let got: Vec<Complex<f32>> = pull_complex_slice(&client, "iq").expect("pull complex");
+    assert_eq!(got, v);
+}
+
+#[test]
+fn empty_typed_slice_roundtrips() {
+    let client = serve(typed_router(Vec::new(), small_chunks(Compression::Zstd)));
+    let got: Vec<f64> = pull_typed_slice(&client, "buf").expect("pull empty typed");
+    assert!(got.is_empty());
+}
+
+#[test]
+fn wrong_element_type_is_rejected() {
+    // The stream is an f64 typed array; pulling it as i32 must error (the bulk
+    // reader validates the element class/width against the wire header) rather
+    // than silently misreading.
+    let client = serve(typed_router(f64_samples(), small_chunks(Compression::None)));
+    let err = pull_typed_slice::<i32>(&client, "buf").unwrap_err();
+    assert!(
+        matches!(err, RepeError::Beve(_)),
+        "expected a BEVE type mismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn typed_producer_bytes_are_also_a_valid_beve_zst_file() {
+    // A typed producer emits ordinary BEVE on the wire, so the format-agnostic
+    // file output works too: pull to a .beve.zst, decompress + bulk-decode, and
+    // confirm it matches the source.
+    let v = f64_samples();
+    let client = serve(typed_router(v.clone(), small_chunks(Compression::Zstd)));
+
+    let dir = std::env::temp_dir().join(format!("svs-typed-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("buf.beve.zst");
+
+    pull_to_beve_zst_file(&client, "buf", &path).expect("pull file");
+
+    let compressed = std::fs::read(&path).unwrap();
+    let beve_bytes = zstd::decode_all(&compressed[..]).unwrap();
+    let decoded = beve::read_typed_slice::<f64>(&beve_bytes).unwrap();
+    assert_eq!(decoded, v);
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

Implements the **Serialized Value Stream (SVS)** download path behind the optional `value-stream` feature: stream a large (multi-GB even compressed) BEVE-serialized, optionally zstd-compressed in-memory value over an ordinary REPE request/response connection. Flow control is the round trip itself (no ACK window, no unbounded queue), and the producer never materializes a full serialized or compressed copy.

The wire contract is the cross-language [SVS spec](https://github.com/repe-org/REPE/blob/main/serialized-stream-protocol.md) in the REPE org repo; this is repe-rs's reference implementation of it.

## Server (producer)

Via `RouterValueStreamExt` on `Router`:

- `with_value_stream<T: Serialize>` — stream an arbitrary value (generic serde).
- `with_typed_value_stream<T: BeveTypedSlice>` — stream a `Vec<T>` as a bulk typed array.
- `with_complex_value_stream<T>` — stream a `Vec<Complex<T>>` (e.g. IQ buffers).

Each registers `/_svs/{open,next,cancel}` backed by a bounded per-stream session (a thread running serialize → optional zstd → chunk into a bounded channel). The `next` handler reports `Execution::OffReader` (correct on the WebSocket server) and blocks for backpressure on the sync `Server`. Not for the inline async server (it doesn't honor `OffReader`); documented in the module.

## Client (consumer)

- `pull_value::<T>` / `pull_to_beve_file` / `pull_to_beve_zst_file` / general `pull_stream` — the three receiver outputs (in-memory value, decompressed `.beve` file, raw `.beve.zst` file). File modes commit atomically (temp-then-rename only after the terminating `last` chunk), so a dropped connection never leaves a truncated file that looks whole.
- `pull_typed_slice::<T>` / `pull_complex_slice::<T>` — bulk (memcpy) decode of a numeric / complex array straight into the result `Vec`, via beve 2.5's `read_typed_slice_from_reader` / `read_complex_slice_from_reader`.
- **Async**: `pull_value_async` / `pull_typed_slice_async` / `pull_complex_slice_async`, generic over a sealed `AsyncSvsClient` transport — they drive either the async-TCP `AsyncClient` or (with `websocket`) the `WebSocketClient`. The decoders are blocking `Read`-based, so each splits across the async/blocking boundary — an async task issues `next` and feeds a bounded channel, a `spawn_blocking` task runs the decoder over a blocking `Read` that drains it. The channel bound is the backpressure; the runtime is never parked.

## Also

- `Router::with_erased_handler` — the low-level escape hatch (register a raw `HandlerErased` returning a fully custom `Message`) the SVS handlers are built on; broadly useful beyond SVS.
- Bumps `beve` 2.3 → 2.5.

## Scope / non-goals

- **Pull-only**, matching the SVS contract. Client→server **push** is out of scope — that's `repe::stream`'s credit-windowed, resumable domain, a distinct protocol, not an SVS direction.

## Tests / examples

- `tests/value_stream.rs` + `tests/value_stream_bulk.rs` + `tests/value_stream_async.rs`: round-trips for every receiver mode (sync, async-TCP, and async-WebSocket), compressed and uncompressed, the bulk typed/complex path, the atomic-file guarantee, and tag/output-mismatch + unknown-resource errors.
- `examples/value_stream.rs` (demo); `examples/stream_pull_vs_push.rs` (a push-vs-pull throughput comparison vs `repe::stream`).
- Plan: `docs/streaming-serialized-values.md`; `docs/streaming.md` callout + mkdocs nav.

All gated behind `value-stream`; the default build is unchanged. Full suite (230 tests with the feature) passes against the published beve 2.5.0; clippy + rustfmt clean.

