### PR TITLE
Add opaque byte streams and async file pullers to value-stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,10 @@ pub use uniudp_fleet::{SendResult, UniUdpFleet, UniUdpNode, UniUdpNodeConfig};
 #[cfg(all(feature = "value-stream", not(target_arch = "wasm32")))]
 pub use value_stream::{
     AsyncSvsClient, Compression, RouterValueStreamExt, StreamOpts, StreamOutput,
-    pull_complex_slice, pull_complex_slice_async, pull_stream, pull_to_beve_file,
-    pull_to_beve_zst_file, pull_typed_slice, pull_typed_slice_async, pull_value, pull_value_async,
+    pull_complex_slice, pull_complex_slice_async, pull_consume_async, pull_stream,
+    pull_to_beve_file, pull_to_beve_zst_file, pull_to_file, pull_to_file_async,
+    pull_to_file_verified_async, pull_typed_slice, pull_typed_slice_async, pull_value,
+    pull_value_async,
 };
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub use wasm_client::WasmClient;

--- a/src/value_stream.rs
+++ b/src/value_stream.rs
@@ -11,6 +11,17 @@
 //! transfer, to write the compressed bytes to a file, decompress them to a file,
 //! or stream-decode them straight into a `T`.
 //!
+//! A producer may also stream **opaque, already-serialized bytes** verbatim from
+//! any [`Read`] ([`RouterValueStreamExt::with_reader_stream`]) rather than
+//! re-serializing a value. That is the fit when the bytes already exist in their
+//! final on-disk form: the consumer pulls them with [`pull_to_file`] /
+//! [`pull_to_file_async`] (or the format-agnostic [`pull_consume_async`]) and,
+//! with [`Compression::None`], writes a byte-identical copy. SVS does not commit
+//! a content digest on the wire, so when end-to-end integrity matters the
+//! producer and consumer agree on one out of band and the consumer recomputes it
+//! over the streamed bytes with [`pull_to_file_verified_async`], which vetoes the
+//! atomic rename on a mismatch.
+//!
 //! This module is the repe-rs **reference implementation** of the SVS contract.
 //! The normative wire definition (routes, `stream_id` encoding, the `last`-flag
 //! placement, the `format`/`compression` tags) lives in the REPE org repository
@@ -21,13 +32,22 @@
 //! # Directions
 //!
 //! * **Download** (server produces, client pulls) — the primary direction.
-//!   Register a producer with [`RouterValueStreamExt::with_value_stream`] and
-//!   pull with [`pull_value`] / [`pull_to_beve_file`] / [`pull_to_beve_zst_file`]
-//!   (or the general [`pull_stream`]) over the synchronous [`Client`]. From async
-//!   code, drive an [`AsyncClient`] with [`pull_value_async`] /
-//!   [`pull_typed_slice_async`] / [`pull_complex_slice_async`]: these run the
-//!   blocking decoder on a `spawn_blocking` thread fed by an async pull loop, so
-//!   they never park the runtime.
+//!   Register a producer with [`RouterValueStreamExt::with_value_stream`] (a
+//!   serde value), [`with_typed_value_stream`] / [`with_complex_value_stream`] (a
+//!   bulk numeric / complex array), or [`with_reader_stream`] (opaque bytes from
+//!   a [`Read`]). Pull with [`pull_value`] / [`pull_to_beve_file`] /
+//!   [`pull_to_beve_zst_file`] / [`pull_to_file`] (or the general
+//!   [`pull_stream`]) over the synchronous [`Client`]. From async code, drive an
+//!   [`AsyncClient`] (or a `WebSocketClient`) with [`pull_value_async`] /
+//!   [`pull_typed_slice_async`] / [`pull_complex_slice_async`] /
+//!   [`pull_to_file_async`] / [`pull_to_file_verified_async`], or the
+//!   format-agnostic [`pull_consume_async`]: these run the blocking decoder on a
+//!   `spawn_blocking` thread fed by an async pull loop, so they never park the
+//!   runtime.
+//!
+//! [`with_typed_value_stream`]: RouterValueStreamExt::with_typed_value_stream
+//! [`with_complex_value_stream`]: RouterValueStreamExt::with_complex_value_stream
+//! [`with_reader_stream`]: RouterValueStreamExt::with_reader_stream
 //!
 //! # Where the producer may run
 //!
@@ -328,6 +348,10 @@ struct OpenHandler<F> {
     table: Arc<SessionTable>,
     make_body: F,
     opts: StreamOpts,
+    /// The logical content's serialization format, reported in the `open`
+    /// response so the consumer can reject an incompatible output. BEVE for the
+    /// value/typed/complex producers, raw-binary for the opaque byte producer.
+    format: u16,
 }
 
 impl<F> HandlerErased for OpenHandler<F>
@@ -370,7 +394,7 @@ where
         let resp = OpenResponse {
             version: SVS_VERSION,
             stream_id,
-            format: BodyFormat::Beve as u16,
+            format: self.format,
             compression: self.opts.compression as u8,
         };
         beve_response(req, &resp)
@@ -463,7 +487,10 @@ struct CancelAck {
 
 /// Register the three SVS routes onto `router` backed by `make_body`, the
 /// producer-side factory mapping a resource to a [`BodyWriter`] (or `None`).
-fn register_svs<F>(router: Router, make_body: F, opts: StreamOpts) -> Router
+/// `format` is the logical content's serialization format reported in the `open`
+/// response (BEVE for the serde/typed/complex producers, raw-binary for the
+/// opaque byte producer).
+fn register_svs<F>(router: Router, make_body: F, format: u16, opts: StreamOpts) -> Router
 where
     F: Fn(&str) -> Option<BodyWriter> + Send + Sync + 'static,
 {
@@ -472,6 +499,7 @@ where
         table: Arc::clone(&table),
         make_body,
         opts,
+        format,
     });
     let next: Arc<dyn HandlerErased> = Arc::new(NextHandler {
         table: Arc::clone(&table),
@@ -519,6 +547,31 @@ pub trait RouterValueStreamExt: Sized {
     where
         T: beve::BeveTypedSlice + Send + 'static,
         F: Fn(&str) -> Option<Vec<Complex<T>>> + Send + Sync + 'static;
+
+    /// Stream **opaque, already-serialized bytes** verbatim from a producer-side
+    /// [`Read`] — no re-serialization. The stream is tagged
+    /// `format = RawBinary`, so the consumer pulls it with [`pull_to_file`] /
+    /// [`pull_to_file_async`] / [`pull_consume_async`] (the BEVE-typed pullers
+    /// reject it).
+    ///
+    /// This is the right producer when the bytes already exist in their final
+    /// on-disk form and must cross the wire unchanged: a file the server already
+    /// wrote, a buffer it already encoded with its own serializer. With
+    /// [`Compression::None`] the chunk stream is those exact bytes, so the
+    /// consumer can write a byte-identical copy and verify it with its own
+    /// digest. The element-type coupling of [`with_value_stream`] (the consumer
+    /// must decode through *this* crate's serializer) does not apply.
+    ///
+    /// `resolve` maps a resource key to the byte source, or `None` if there is no
+    /// such resource. Use `R = Box<dyn Read + Send>` to serve more than one
+    /// concrete source type (e.g. a `File` for one resource, a `Cursor` for
+    /// another) from a single registration.
+    ///
+    /// [`with_value_stream`]: Self::with_value_stream
+    fn with_reader_stream<R, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        R: Read + Send + 'static,
+        F: Fn(&str) -> Option<R> + Send + Sync + 'static;
 }
 
 impl RouterValueStreamExt for Router {
@@ -536,6 +589,7 @@ impl RouterValueStreamExt for Router {
                     }) as BodyWriter
                 })
             },
+            BodyFormat::Beve as u16,
             opts,
         )
     }
@@ -554,6 +608,7 @@ impl RouterValueStreamExt for Router {
                     }) as BodyWriter
                 })
             },
+            BodyFormat::Beve as u16,
             opts,
         )
     }
@@ -572,6 +627,25 @@ impl RouterValueStreamExt for Router {
                     }) as BodyWriter
                 })
             },
+            BodyFormat::Beve as u16,
+            opts,
+        )
+    }
+
+    fn with_reader_stream<R, F>(self, resolve: F, opts: StreamOpts) -> Self
+    where
+        R: Read + Send + 'static,
+        F: Fn(&str) -> Option<R> + Send + Sync + 'static,
+    {
+        register_svs(
+            self,
+            move |resource| {
+                resolve(resource).map(|mut reader| {
+                    Box::new(move |w: &mut dyn Write| io::copy(&mut reader, w).map(|_| ()))
+                        as BodyWriter
+                })
+            },
+            BodyFormat::RawBinary as u16,
             opts,
         )
     }
@@ -622,6 +696,15 @@ pub enum StreamOutput<'a> {
     /// Stream-decode the value into a `T`. Requires `format = BEVE`; a compressed
     /// stream is decompressed on the way in. Returns `Some(T)`.
     Value,
+    /// Write the logical content to a file, format-agnostic: a `compression =
+    /// none` stream is copied verbatim (a byte-identical copy of an opaque
+    /// [`with_reader_stream`](RouterValueStreamExt::with_reader_stream) source), a
+    /// `compression = zstd` stream is decompressed on the way in. No `format`
+    /// constraint, so it accepts a raw-binary stream the [`BeveFile`] mode would
+    /// reject.
+    ///
+    /// [`BeveFile`]: StreamOutput::BeveFile
+    RawFile(&'a Path),
 }
 
 /// Pull `resource` from an SVS producer reachable through `client` into `out`.
@@ -678,6 +761,23 @@ pub fn pull_stream<T: DeserializeOwned>(
             let _ = cancel_stream(client, open.stream_id, "value fully decoded");
             Ok(Some(value))
         }
+        StreamOutput::RawFile(path) => {
+            let compression = open.compression;
+            write_file(client, open.stream_id, path, |reader, file| {
+                match compression {
+                    Compression::None => {
+                        io::copy(reader, file)?;
+                    }
+                    Compression::Zstd => {
+                        let mut dec =
+                            zstd::stream::read::Decoder::new(reader).map_err(RepeError::Io)?;
+                        io::copy(&mut dec, file)?;
+                    }
+                }
+                Ok(())
+            })?;
+            Ok(None)
+        }
     }
 }
 
@@ -701,6 +801,15 @@ pub fn pull_to_beve_zst_file(
 /// ([`StreamOutput::BeveFile`]).
 pub fn pull_to_beve_file(client: &Client, resource: &str, path: &Path) -> Result<(), RepeError> {
     pull_stream::<()>(client, resource, StreamOutput::BeveFile(path)).map(|_| ())
+}
+
+/// Convenience: pull `resource` and write its logical content to `path`,
+/// format-agnostic ([`StreamOutput::RawFile`]). For a `compression = none`
+/// opaque byte stream this writes a byte-identical copy of the producer's source;
+/// a compressed stream is decompressed first. The file is committed atomically
+/// (temp sibling, renamed only after the terminating chunk and an fsync).
+pub fn pull_to_file(client: &Client, resource: &str, path: &Path) -> Result<(), RepeError> {
+    pull_stream::<()>(client, resource, StreamOutput::RawFile(path)).map(|_| ())
 }
 
 /// Pull `resource` as a bulk numeric array decoded straight into a `Vec<T>` at
@@ -884,6 +993,8 @@ fn check_output(out: StreamOutput<'_>, open: &OpenInfo) -> Result<(), RepeError>
                 ));
             }
         }
+        // Format-agnostic: any stream's logical content can land in a raw file.
+        StreamOutput::RawFile(_) => {}
     }
     Ok(())
 }
@@ -1246,19 +1357,10 @@ async fn cancel_stream_async<C: AsyncSvsClient>(
         .await
 }
 
-/// Open `resource`, then pull and decode it: the async pull loop and the blocking
-/// `decode` run concurrently across the channel, with `decode` receiving a `Read`
-/// over the (optionally zstd-decompressed) chunk stream. Shared by the async
-/// value and bulk-slice pullers.
-async fn pull_decode_async<V, F, C: AsyncSvsClient>(
-    client: &C,
-    resource: &str,
-    decode: F,
-) -> Result<V, RepeError>
-where
-    V: Send + 'static,
-    F: FnOnce(Box<dyn Read>) -> Result<V, RepeError> + Send + 'static,
-{
+/// Send the `open` request over an async client and parse the response into an
+/// [`OpenInfo`]. Shared by every async puller; the per-puller format check (if
+/// any) runs on the returned `OpenInfo`.
+async fn open_async<C: AsyncSvsClient>(client: &C, resource: &str) -> Result<OpenInfo, RepeError> {
     let body = open_request_body(resource)?;
     let resp = client
         .svs_call(
@@ -1268,39 +1370,71 @@ where
             BodyFormat::Beve as u16,
         )
         .await?;
-    let open = parse_open_response(&resp)?;
-    if let Err(e) = require_beve(&open) {
-        let _ = cancel_stream_async(client, open.stream_id, "format incompatible").await;
-        return Err(e);
-    }
+    parse_open_response(&resp)
+}
 
+/// Pull an already-opened stream and consume it: the async pull loop and the
+/// blocking `consume` run concurrently across the channel, with `consume`
+/// receiving a `Read` over the (optionally zstd-decompressed) chunk stream.
+///
+/// A pull/network error is surfaced *before* `consume`'s value, so a truncated
+/// transfer never returns a value built from a short read: the value (and
+/// anything it owns, e.g. an uncommitted temp file) is dropped on that path.
+async fn run_pull<V, F, C: AsyncSvsClient>(
+    client: &C,
+    open: OpenInfo,
+    consume: F,
+) -> Result<V, RepeError>
+where
+    V: Send + 'static,
+    F: FnOnce(Box<dyn Read>) -> Result<V, RepeError> + Send + 'static,
+{
     let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(ASYNC_PULL_DEPTH);
     let compression = open.compression;
     // Starts immediately on a blocking thread; runs concurrently with the pull
     // loop below, the two paced by the channel bound.
-    let decode_task = tokio::task::spawn_blocking(move || -> Result<V, RepeError> {
+    let consume_task = tokio::task::spawn_blocking(move || -> Result<V, RepeError> {
         let reader: Box<dyn Read> = match compression {
             Compression::None => Box::new(ChannelReader::new(rx)),
             Compression::Zstd => Box::new(
                 zstd::stream::read::Decoder::new(ChannelReader::new(rx)).map_err(RepeError::Io)?,
             ),
         };
-        decode(reader)
+        consume(reader)
     });
 
     let pull_res = pull_loop_async(client, open.stream_id, tx).await;
-    let decode_res = decode_task.await;
+    let consume_res = consume_task.await;
     // Best-effort release; the stream is spent (or the pull failed) either way.
     let _ = cancel_stream_async(client, open.stream_id, "pull complete").await;
 
-    // A pull/network error explains any decode-side EOF, so surface it first.
+    // A pull/network error explains any consume-side EOF, so surface it first.
     pull_res?;
-    match decode_res {
+    match consume_res {
         Ok(v) => v,
         Err(join_err) => Err(RepeError::Io(io::Error::other(format!(
-            "svs decode task failed: {join_err}"
+            "svs consume task failed: {join_err}"
         )))),
     }
+}
+
+/// Open `resource`, require it be BEVE, and `run_pull` it. Shared by the async
+/// value and bulk-slice pullers (which all decode BEVE).
+async fn pull_beve_async<V, F, C: AsyncSvsClient>(
+    client: &C,
+    resource: &str,
+    decode: F,
+) -> Result<V, RepeError>
+where
+    V: Send + 'static,
+    F: FnOnce(Box<dyn Read>) -> Result<V, RepeError> + Send + 'static,
+{
+    let open = open_async(client, resource).await?;
+    if let Err(e) = require_beve(&open) {
+        let _ = cancel_stream_async(client, open.stream_id, "format incompatible").await;
+        return Err(e);
+    }
+    run_pull(client, open, decode).await
 }
 
 /// Async counterpart of [`pull_value`]: pull `resource` and decode the whole
@@ -1315,7 +1449,7 @@ pub async fn pull_value_async<T: DeserializeOwned + Send + 'static, C: AsyncSvsC
     client: &C,
     resource: &str,
 ) -> Result<T, RepeError> {
-    pull_decode_async(client, resource, |reader| {
+    pull_beve_async(client, resource, |reader| {
         beve::from_reader_streaming::<_, T>(reader).map_err(RepeError::from)
     })
     .await
@@ -1328,7 +1462,7 @@ pub async fn pull_typed_slice_async<T: beve::BeveTypedSlice + Send + 'static, C:
     client: &C,
     resource: &str,
 ) -> Result<Vec<T>, RepeError> {
-    pull_decode_async(client, resource, |reader| {
+    pull_beve_async(client, resource, |reader| {
         beve::read_typed_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
     })
     .await
@@ -1343,10 +1477,129 @@ pub async fn pull_complex_slice_async<
     client: &C,
     resource: &str,
 ) -> Result<Vec<Complex<T>>, RepeError> {
-    pull_decode_async(client, resource, |reader| {
+    pull_beve_async(client, resource, |reader| {
         beve::read_complex_slice_from_reader::<T, _>(reader).map_err(RepeError::from)
     })
     .await
+}
+
+/// Async, format-agnostic escape hatch: pull `resource` and hand its logical
+/// content to `consume` as a blocking [`Read`] (a `compression = zstd` stream is
+/// decompressed on the way in; `none` is delivered verbatim). Unlike
+/// [`pull_value_async`] this places no `format` constraint, so it drives an
+/// opaque [`with_reader_stream`](RouterValueStreamExt::with_reader_stream)
+/// producer as well as a BEVE one.
+///
+/// `consume` runs on a `spawn_blocking` thread and may block freely. The value it
+/// returns is delivered only if the pull completed cleanly; on a truncated /
+/// dropped transfer this returns the pull error and the value is dropped (so a
+/// temp file `consume` opened is discarded rather than committed — see
+/// [`pull_to_file_async`] / [`pull_to_file_verified_async`], which build on this).
+pub async fn pull_consume_async<V, F, C: AsyncSvsClient>(
+    client: &C,
+    resource: &str,
+    consume: F,
+) -> Result<V, RepeError>
+where
+    V: Send + 'static,
+    F: FnOnce(Box<dyn Read>) -> Result<V, RepeError> + Send + 'static,
+{
+    let open = open_async(client, resource).await?;
+    run_pull(client, open, consume).await
+}
+
+/// A [`Write`] that forwards every byte to two sinks. Used to write a file while
+/// feeding the same bytes to a digest in a single pass.
+struct TeeWriter<'a, A: Write, B: Write> {
+    file: &'a mut A,
+    digest: &'a mut B,
+}
+
+impl<A: Write, B: Write> Write for TeeWriter<'_, A, B> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file.write_all(buf)?;
+        self.digest.write_all(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()?;
+        self.digest.flush()
+    }
+}
+
+/// Async counterpart of [`pull_to_file`]: pull `resource` and write its logical
+/// content to `path`, committed atomically (temp sibling, renamed only after the
+/// terminating chunk and an fsync). A `compression = none` opaque byte stream is
+/// written verbatim; a compressed stream is decompressed first. Returns the
+/// number of content bytes written.
+///
+/// To verify content integrity before the file is published, use
+/// [`pull_to_file_verified_async`].
+pub async fn pull_to_file_async<C: AsyncSvsClient>(
+    client: &C,
+    resource: &str,
+    path: &Path,
+) -> Result<u64, RepeError> {
+    let tmp_path = temp_sibling(path);
+    let (guard, bytes) = pull_consume_async(client, resource, move |mut reader| {
+        let mut guard = TempFile::create(&tmp_path)?;
+        let bytes = io::copy(&mut reader, guard.file_mut())?;
+        guard.file_mut().flush()?;
+        guard.file_mut().sync_all()?;
+        Ok((guard, bytes))
+    })
+    .await?;
+    guard.commit(path)?;
+    Ok(bytes)
+}
+
+/// Async file pull with a caller-supplied integrity gate. As content bytes are
+/// written to the temp file they are also fed to `digest` (any [`Write`] — a
+/// hasher, a CRC accumulator); after the stream completes cleanly and before the
+/// temp file is renamed into place, `verify(digest)` is called. If it returns
+/// `Err`, the temp file is discarded and nothing is committed at `path`; if it
+/// returns `Ok`, the file is renamed in atomically.
+///
+/// This is the integrity seam SVS itself does not commit on the wire: the
+/// producer and consumer agree on a content digest out of band (e.g. carried in
+/// an application manifest), the consumer recomputes it here in one pass over the
+/// streamed bytes, and a mismatch vetoes publication. A truncated transfer is
+/// caught upstream of `verify` (it surfaces as the pull error) and likewise
+/// commits nothing.
+pub async fn pull_to_file_verified_async<C, D, V>(
+    client: &C,
+    resource: &str,
+    path: &Path,
+    digest: D,
+    verify: V,
+) -> Result<(), RepeError>
+where
+    C: AsyncSvsClient,
+    D: Write + Send + 'static,
+    V: FnOnce(D) -> Result<(), RepeError>,
+{
+    let tmp_path = temp_sibling(path);
+    let (guard, digest) = pull_consume_async(client, resource, move |mut reader| {
+        let mut guard = TempFile::create(&tmp_path)?;
+        let mut digest = digest;
+        {
+            let mut tee = TeeWriter {
+                file: guard.file_mut(),
+                digest: &mut digest,
+            };
+            io::copy(&mut reader, &mut tee)?;
+        }
+        guard.file_mut().flush()?;
+        guard.file_mut().sync_all()?;
+        Ok((guard, digest))
+    })
+    .await?;
+    // The stream terminated cleanly (a truncation would have surfaced as the pull
+    // error above, before this point, discarding `guard`). Let the caller accept
+    // or reject the content; only an accept commits the file.
+    verify(digest)?;
+    guard.commit(path)
 }
 
 #[cfg(test)]

--- a/tests/value_stream.rs
+++ b/tests/value_stream.rs
@@ -4,8 +4,11 @@
 #![cfg(feature = "value-stream")]
 
 use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts, StreamOutput};
-use repe::{Client, RepeError, Router, Server, pull_stream, pull_to_beve_file, pull_value};
+use repe::{
+    Client, RepeError, Router, Server, pull_stream, pull_to_beve_file, pull_to_file, pull_value,
+};
 use serde::{Deserialize, Serialize};
+use std::io::Cursor;
 use std::net::TcpListener;
 use std::path::Path;
 use std::thread;
@@ -163,6 +166,87 @@ fn many_small_payloads_each_terminate_cleanly() {
         let got: Payload = pull_value(&client, "payload").expect("pull");
         assert_eq!(got, payload);
     }
+}
+
+// ---- opaque byte (reader) streams --------------------------------------------
+
+/// ~1 MiB of a non-trivial byte pattern, large enough to span many 16 KiB chunks
+/// so reassembly and the lookahead/last logic are exercised; any truncation or
+/// off-by-one would corrupt the verbatim compare.
+fn raw_blob() -> Vec<u8> {
+    (0..1_000_000u32)
+        .map(|i| (i.wrapping_mul(2_654_435_761) >> 24) as u8)
+        .collect()
+}
+
+/// Start a sync `Server` whose router streams `blob` verbatim (opaque bytes) for
+/// the resource key `"blob"`, with the given options. Returns a connected client.
+fn serve_reader(blob: Vec<u8>, opts: StreamOpts) -> Client {
+    let router = Router::new().with_reader_stream(
+        move |resource: &str| (resource == "blob").then(|| Cursor::new(blob.clone())),
+        opts,
+    );
+    let server = Server::new(router);
+    let listener: TcpListener = server.listen("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    thread::spawn(move || {
+        let _ = server.serve(listener);
+    });
+    Client::connect(addr).expect("connect")
+}
+
+#[test]
+fn reader_stream_writes_a_byte_identical_file_uncompressed() {
+    let blob = raw_blob();
+    let client = serve_reader(blob.clone(), small_chunks(Compression::None));
+
+    let dir = std::env::temp_dir().join(format!("svs-raw-none-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("blob.bin");
+
+    pull_to_file(&client, "blob", &path).expect("pull raw file");
+
+    let got = std::fs::read(&path).expect("read file");
+    assert_eq!(
+        got, blob,
+        "uncompressed reader stream must be byte-identical"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn reader_stream_roundtrips_through_compression() {
+    // Even tagged for zstd, the logical content the consumer writes must equal
+    // the producer's source bytes (compression is transparent end to end).
+    let blob = raw_blob();
+    let client = serve_reader(blob.clone(), small_chunks(Compression::Zstd));
+
+    let dir = std::env::temp_dir().join(format!("svs-raw-zstd-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("blob.bin");
+
+    pull_to_file(&client, "blob", &path).expect("pull raw file");
+
+    let got = std::fs::read(&path).expect("read file");
+    assert_eq!(
+        got, blob,
+        "decompressed content must equal the source bytes"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn value_puller_rejects_a_raw_binary_stream() {
+    // A raw-binary stream is tagged `format != BEVE`; the value decoder must
+    // refuse it up front rather than feed raw bytes to BEVE.
+    let client = serve_reader(raw_blob(), small_chunks(Compression::None));
+    let err = pull_value::<Payload>(&client, "blob").unwrap_err();
+    assert!(
+        matches!(err, RepeError::Io(_)),
+        "expected a format-mismatch error, got {err:?}"
+    );
 }
 
 #[test]

--- a/tests/value_stream_async.rs
+++ b/tests/value_stream_async.rs
@@ -7,10 +7,11 @@
 
 use repe::value_stream::{Compression, RouterValueStreamExt, StreamOpts};
 use repe::{
-    AsyncClient, Complex, Router, Server, pull_complex_slice_async, pull_typed_slice_async,
-    pull_value_async,
+    AsyncClient, Complex, RepeError, Router, Server, pull_complex_slice_async, pull_consume_async,
+    pull_to_file_async, pull_to_file_verified_async, pull_typed_slice_async, pull_value_async,
 };
 use serde::{Deserialize, Serialize};
+use std::io::{self, Cursor, Read};
 use std::net::{SocketAddr, TcpListener};
 use std::thread;
 
@@ -146,6 +147,124 @@ async fn unknown_resource_errors() {
     assert!(got.is_err(), "unknown resource must error");
 }
 
+// ---- opaque byte (reader) streams --------------------------------------------
+
+/// ~1 MiB of a non-trivial byte pattern; spans many 16 KiB chunks so reassembly
+/// and the async pull/decode bridge are exercised across many `next` round trips.
+fn raw_blob() -> Vec<u8> {
+    (0..1_000_000u32)
+        .map(|i| (i.wrapping_mul(2_654_435_761) >> 24) as u8)
+        .collect()
+}
+
+/// A fresh, process-unique temp directory for a file-mode test.
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("svs-async-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A router that streams `blob` verbatim (opaque bytes) for the key `"blob"`.
+fn reader_router(blob: Vec<u8>, compression: Compression) -> Router {
+    Router::new().with_reader_stream(
+        move |resource: &str| (resource == "blob").then(|| Cursor::new(blob.clone())),
+        small_chunks(compression),
+    )
+}
+
+#[tokio::test]
+async fn reader_stream_to_file_is_byte_identical() {
+    let blob = raw_blob();
+    let addr = spawn(reader_router(blob.clone(), Compression::None));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+
+    let dir = temp_dir("raw-file");
+    let path = dir.join("blob.bin");
+    let n = pull_to_file_async(&client, "blob", &path)
+        .await
+        .expect("pull");
+    assert_eq!(n as usize, blob.len());
+    assert_eq!(std::fs::read(&path).unwrap(), blob);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn consume_async_reads_decompressed_content() {
+    let blob = raw_blob();
+    let addr = spawn(reader_router(blob.clone(), Compression::Zstd));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+
+    let got: Vec<u8> = pull_consume_async(&client, "blob", |mut r: Box<dyn Read>| {
+        let mut buf = Vec::new();
+        r.read_to_end(&mut buf)?;
+        Ok(buf)
+    })
+    .await
+    .expect("consume");
+    assert_eq!(got, blob, "consume must see the decompressed content");
+}
+
+#[tokio::test]
+async fn verified_pull_commits_when_the_digest_matches() {
+    let blob = raw_blob();
+    let addr = spawn(reader_router(blob.clone(), Compression::None));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+
+    let dir = temp_dir("verify-ok");
+    let path = dir.join("blob.bin");
+
+    // `Vec<u8>` is the digest sink: it collects every teed content byte, so the
+    // verify both checks integrity and proves the tee saw exactly the content.
+    let expected = blob.clone();
+    pull_to_file_verified_async(
+        &client,
+        "blob",
+        &path,
+        Vec::<u8>::new(),
+        move |seen: Vec<u8>| {
+            if seen == expected {
+                Ok(())
+            } else {
+                Err(RepeError::Io(io::Error::other("digest mismatch")))
+            }
+        },
+    )
+    .await
+    .expect("verified pull");
+    assert_eq!(std::fs::read(&path).unwrap(), blob);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn verified_pull_commits_nothing_when_rejected() {
+    let blob = raw_blob();
+    let addr = spawn(reader_router(blob, Compression::None));
+    let client = AsyncClient::connect(addr).await.expect("connect");
+
+    let dir = temp_dir("verify-bad");
+    let path = dir.join("blob.bin");
+
+    let err = pull_to_file_verified_async(
+        &client,
+        "blob",
+        &path,
+        Vec::<u8>::new(),
+        |_seen: Vec<u8>| Err(RepeError::Io(io::Error::other("rejected by test"))),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, RepeError::Io(_)));
+    assert!(!path.exists(), "a rejected verify must not commit the file");
+    assert!(
+        !dir.join("blob.bin.svspart").exists(),
+        "the temp sibling must be cleaned up on rejection"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // The same async pullers drive a `WebSocketClient`. The WebSocket server runs
 // the SVS `next` handler off the reader task (it honours `Execution::OffReader`),
 // so blocking for backpressure there is fine.
@@ -206,5 +325,34 @@ mod websocket {
         .await;
         let got: Vec<Complex<f32>> = pull_complex_slice_async(&client, "iq").await.expect("pull");
         assert_eq!(got, v);
+    }
+
+    // An opaque byte stream pulled to a verified file over WebSocket: the exact
+    // shape a remote save uses (server streams bytes it already holds, client
+    // writes a byte-identical copy and gates the rename on a content digest).
+    #[tokio::test]
+    async fn verified_reader_stream_over_websocket() {
+        let blob = raw_blob();
+        let client = ws_client(reader_router(blob.clone(), Compression::None)).await;
+
+        let dir = temp_dir("ws-verify");
+        let path = dir.join("blob.bin");
+        let expected = blob.clone();
+        pull_to_file_verified_async(
+            &client,
+            "blob",
+            &path,
+            Vec::<u8>::new(),
+            move |seen: Vec<u8>| {
+                (seen == expected)
+                    .then_some(())
+                    .ok_or_else(|| RepeError::Io(io::Error::other("digest mismatch")))
+            },
+        )
+        .await
+        .expect("verified ws pull");
+        assert_eq!(std::fs::read(&path).unwrap(), blob);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## Summary

Extends the SVS (Serialized Value Stream) download path with two capabilities it was missing: streaming **already-serialized bytes verbatim** (rather than re-serializing a value), and pulling a stream **straight to a file from async code**.

The motivating case is a producer that already holds the bytes in their final on-disk form (a file it wrote, a buffer it encoded with its own serializer) and a consumer that wants a byte-identical copy with an end-to-end integrity check, driven over an async transport. The existing pullers only decode a value, and the file modes were sync-only.

## Producer

- `RouterValueStreamExt::with_reader_stream<R: Read + Send>`: stream opaque bytes from any `Read` without re-serializing a value. Tags the stream `format = RawBinary`. With `Compression::None` the chunk stream is the source bytes verbatim, so a consumer can write a byte-identical copy. Use `R = Box<dyn Read + Send>` to serve several concrete sources from one registration.
- The `open` response `format` tag is now set per registration instead of hardcoded to BEVE.

## Consumer

- `pull_consume_async`: format-agnostic async escape hatch that hands the logical content to a caller closure as a blocking `Read`. A truncated transfer surfaces *before* the closure's value is returned, so a value built over a short read (e.g. an unfinished temp file) is dropped rather than returned.
- `pull_to_file_async`: async atomic file pull (temp sibling, fsync, rename only after the terminating chunk) - the async counterpart of the sync file modes.
- `pull_to_file_verified_async`: tees content bytes into a caller-supplied digest and runs a verify closure after a clean EOF and before the rename, so an integrity check recomputed over the streamed bytes (compared against an out-of-band digest) can veto publication. SVS commits no digest on the wire; this is the integrity seam for callers that need one.
- Sync `StreamOutput::RawFile` and `pull_to_file` for symmetry.

The async file pullers are built on `pull_consume_async`, which is itself a small refactor of the existing async pull driver: `open_async` + `run_pull` are factored out so the per-puller BEVE-format check moves into the typed pullers and the raw path places no format constraint.

## Wire contract

Unchanged. The new producer reuses the existing `format` tag (`RawBinary`), and no digest is added to the wire (integrity is left to the optional consumer-side verify gate). No new dependency is added.

## Tests

Byte-identical round trips (sync, async, WebSocket); the verify gate (accept commits the file, reject leaves none and cleans up the temp sibling); the format-agnostic consume path; and that the BEVE value puller rejects a raw-binary stream. Existing value-stream / bulk / async suites still pass; clippy clean.