### PR TITLE
Ignore header reserved field per REPE spec

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -891,7 +891,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
         RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
         RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
         RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
-        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
         RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
             expected: *expected,
             got: *got,

--- a/src/client.rs
+++ b/src/client.rs
@@ -814,7 +814,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
         RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
         RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
         RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
-        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
         RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
             expected: *expected,
             got: *got,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,8 +18,8 @@ pub enum ErrorCode {
     Ok = 0,
     /// The request's REPE version is not supported by this server.
     VersionMismatch = 1,
-    /// The fixed header was malformed: bad spec magic, wrong length, a
-    /// non-zero reserved field, or a length that disagrees with the body.
+    /// The fixed header was malformed: bad spec magic, wrong length, or a
+    /// length that disagrees with the body.
     InvalidHeader = 2,
     /// The query was malformed or used a query format this server does not
     /// accept (e.g. a raw-binary query against a JSON-pointer router).

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,6 @@ pub enum RepeError {
     InvalidSpec(u16),
     #[error("invalid header length: expected 48, got {0}")]
     InvalidHeaderLength(usize),
-    #[error("header reserved field must be zero")]
-    ReservedNonZero,
     #[error("header length mismatch: expected {expected}, got {got}")]
     LengthMismatch { expected: u64, got: u64 },
     #[error("buffer too small: need {need} bytes, have {have}")]
@@ -40,7 +38,6 @@ impl RepeError {
             RepeError::VersionMismatch(_) => ErrorCode::VersionMismatch,
             RepeError::InvalidSpec(_) => ErrorCode::InvalidHeader,
             RepeError::InvalidHeaderLength(_) => ErrorCode::InvalidHeader,
-            RepeError::ReservedNonZero => ErrorCode::InvalidHeader,
             RepeError::LengthMismatch { .. } => ErrorCode::InvalidHeader,
             RepeError::BufferTooSmall { .. } => ErrorCode::ParseError,
             RepeError::ResponseIdMismatch { .. } => ErrorCode::InvalidHeader,
@@ -83,7 +80,6 @@ mod tests {
             (RepeError::VersionMismatch(2), ErrorCode::VersionMismatch),
             (RepeError::InvalidSpec(0x1234), ErrorCode::InvalidHeader),
             (RepeError::InvalidHeaderLength(10), ErrorCode::InvalidHeader),
-            (RepeError::ReservedNonZero, ErrorCode::InvalidHeader),
             (
                 RepeError::LengthMismatch {
                     expected: 5,

--- a/src/header.rs
+++ b/src/header.rs
@@ -86,9 +86,11 @@ impl Header {
             return Err(RepeError::InvalidSpec(spec));
         }
 
-        if reserved != 0 {
-            return Err(RepeError::ReservedNonZero);
-        }
+        // Per the REPE spec the `reserved` field is "Must be zero, receivers
+        // must ignore this field." We parse it (to advance past the bytes and
+        // preserve it for round-trip fidelity) but do not reject a non-zero
+        // value, so a future REPE revision can assign meaning to these bits
+        // without breaking this receiver.
 
         let expected = HEADER_SIZE as u64 + query_length + body_length;
         if length != expected {
@@ -119,7 +121,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decode_rejects_invalid_spec_and_reserved_non_zero() {
+    fn decode_rejects_invalid_spec_but_ignores_reserved() {
         let mut header = Header::new();
         header.length = HEADER_SIZE as u64;
         let mut bytes = header.encode();
@@ -131,13 +133,14 @@ mod tests {
             other => panic!("unexpected error: {other:?}"),
         }
 
-        // Reserved field must be zero
+        // Per the REPE spec, receivers must ignore the `reserved` field: a
+        // non-zero value decodes successfully (and is preserved) rather than
+        // being rejected.
         let mut bytes = header.encode();
         bytes[12..16].copy_from_slice(&1u32.to_le_bytes());
-        match Header::decode(&bytes).unwrap_err() {
-            RepeError::ReservedNonZero => {}
-            other => panic!("unexpected error: {other:?}"),
-        }
+        let decoded =
+            Header::decode(&bytes).expect("non-zero reserved must be ignored, not rejected");
+        assert_eq!(decoded.reserved, 1);
     }
 
     #[test]

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -789,7 +789,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
         RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
         RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
         RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
-        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
         RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
             expected: *expected,
             got: *got,

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -823,7 +823,6 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
         RepeError::VersionMismatch(version) => RepeError::VersionMismatch(*version),
         RepeError::InvalidSpec(spec) => RepeError::InvalidSpec(*spec),
         RepeError::InvalidHeaderLength(length) => RepeError::InvalidHeaderLength(*length),
-        RepeError::ReservedNonZero => RepeError::ReservedNonZero,
         RepeError::LengthMismatch { expected, got } => RepeError::LengthMismatch {
             expected: *expected,
             got: *got,

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -3040,11 +3040,11 @@ mod tests {
             Some(ErrorCode::ResourceExhausted)
         );
         assert_eq!(
-            ConnectionError::Connection(RepeError::ReservedNonZero).error_code(),
+            ConnectionError::Connection(RepeError::InvalidSpec(0)).error_code(),
             None
         );
         assert_eq!(
-            ConnectionError::Handshake(RepeError::ReservedNonZero).error_code(),
+            ConnectionError::Handshake(RepeError::InvalidSpec(0)).error_code(),
             None
         );
     }


### PR DESCRIPTION
## What

Conform `Header::decode` to the base REPE spec, which defines the 48-byte header's `reserved` field as *"Must be zero, receivers must ignore this field."*

repe-rs previously **rejected** any non-zero `reserved` with `RepeError::ReservedNonZero`. That is stricter than the spec and forecloses ever assigning meaning to those bits in a future backward-compatible revision — the whole purpose of a must-ignore field. Protocol version negotiation is handled separately via the `version` field at the message layer (`server_request.rs`, the clients), not the reserved bits.

## Changes

- `Header::decode` now parses and preserves `reserved` but no longer rejects a non-zero value (it is ignored, per spec).
- Removed the now-unproducible `RepeError::ReservedNonZero` variant and all its references: the `to_error_code` mapping, the error-clone passthrough arms in the four client modules, and test references.
- Updated the header decode test to assert a non-zero `reserved` decodes successfully and is preserved.
- Dropped "a non-zero reserved field" from the `ErrorCode::InvalidHeader` doc comment.

## Breaking change

Removes the public `RepeError::ReservedNonZero` variant (`RepeError` is not `#[non_exhaustive]`). Warrants a major version bump on the next release.

## Verification

- `cargo test --all-features` — 164 lib tests + all integration/streaming/websocket binaries pass, 0 failures.
- `cargo build --all-targets --all-features` — clean.
