### PR TITLE
Gate stream_pull_vs_push example behind the value-stream feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ required-features = ["value-stream"]
 name = "writer_stream_digest"
 required-features = ["value-stream"]
 
+[[example]]
+name = "stream_pull_vs_push"
+required-features = ["value-stream"]
+
 [dependencies]
 # beve's default feature set is already lean (core ser/de + streaming +
 # typed/complex bulk slice helpers); the heavy MATLAB/HDF5 `mat` interop is opt-in


### PR DESCRIPTION
## Problem

`examples/stream_pull_vs_push.rs` uses items that only exist under the `value-stream` feature (`pull_value`, `Router::with_value_stream`, `TransferControl`), but it had no `[[example]]` entry in `Cargo.toml`. So under default features Cargo tries to compile it and fails:

```
error[E0432]: unresolved import `repe::pull_value`
error[E0599]: no method named `with_value_stream` found for struct `Router`
```

This breaks a plain `cargo test` and `cargo build --examples` on `main` — a papercut for anyone running the default test loop locally.

## Fix

Add the missing `[[example]]` entry with `required-features = ["value-stream"]`, matching what its two value-stream siblings (`value_stream`, `writer_stream_digest`) already declare. The example is now skipped under default features and built when the feature is enabled.

## Verification

```
cargo test --no-run                                          # default features: compiles clean (example skipped)
cargo build --examples                                       # default features: ok
cargo build --example stream_pull_vs_push --features value-stream   # ok
```

One-line-ish, no source or behavior change.
