### PR TITLE
Add WebSocket size limits and an outbound oversize guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [6.0.0] - Unreleased
+## [6.0.0] - 2026-07-20
 
 ### Added
 - `WebSocketLimits` — per-connection size limits for the WebSocket transport, with `WebSocketClient::connect_with_limits`, `WebSocketServer::with_limits`, and the associated-function variants `WebSocketServer::accept_with_limits` / `accept_with_handshake_and_limits`. Previously every REPE WebSocket connection was stuck with the underlying transport's defaults (16 MiB per frame, 64 MiB per message), because repe passed no configuration to the handshake and exposed no way to supply one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [6.0.0] - Unreleased
+
+### Added
+- `WebSocketLimits` — per-connection size limits for the WebSocket transport, with `WebSocketClient::connect_with_limits`, `WebSocketServer::with_limits`, and the associated-function variants `WebSocketServer::accept_with_limits` / `accept_with_handshake_and_limits`. Previously every REPE WebSocket connection was stuck with the underlying transport's defaults (16 MiB per frame, 64 MiB per message), because repe passed no configuration to the handshake and exposed no way to supply one.
+
+  The type is repe-owned rather than a re-export of the transport's own config struct: repe exposes no transport types in its public API, and keeping it that way means a transport version bump stays an internal detail instead of a repe breaking change. It also confines the surface to the knobs that carry protocol meaning, leaving out buffer-tuning fields that make the transport panic when set inconsistently.
+
+  Note the direction. WebSocket size limits are enforced by the **reader**, so `max_incoming_frame_size` / `max_incoming_message_size` govern what this endpoint accepts, not what the peer will. A larger payload in either direction requires the *receiving* end to be configured for it.
+
+- An outbound guard, so an undeliverable message reports instead of vanishing. Because limits are read-side and no handshake field carries them, a sender cannot discover what the peer accepts: an oversized message left the sender cleanly, the peer's reader rejected it and closed the connection, and the sender observed a dropped socket with no error at all. A reconnecting client that re-requested the same payload looped forever.
+
+  `WebSocketLimits::assumed_peer_frame_limit` is checked before sending. A refused **response** is replaced with an `ErrorCode::InternalError` response carrying the same request id, so the caller gets a real REPE error and the connection stays up; a refused **notify** is dropped, having no response to carry the failure. Both reach the server's `on_error` hooks as the new `ConnectionError::OutboundTooLarge`. On the client, an oversized request fails locally with `RepeError::MessageTooLarge` before reaching the wire.
+
+  It defaults **on**, at the transport's own 16 MiB default frame size. This cannot break a working deployment: before `WebSocketLimits` existed there was no way to raise a peer's inbound limit, so no message above it has ever been deliverable to a default peer, and the guard converts a failure that was already happening silently into one that says so. The case to know about is a peer that is not this library, configured with a larger inbound limit; raise `assumed_peer_frame_limit` to match it, or clear it to disable the check.
+
+  Limits set here reach only connections repe upgrades itself. A connection the embedder upgraded and handed to `SharedWebSocketServer::serve_connection` carries whatever inbound limits that upgrade was given and cannot be retrofitted, since the transport fixes them at construction and exposes no setter. The outbound guard, being repe's own, applies on every path.
+
+- `SharedWebSocketServer::accept` / `accept_with_handshake` / `limits`. The associated `WebSocketServer::accept` takes no `self`, so in an embedder-owned accept loop it cannot see a builder-set `with_limits` and upgrades with the defaults instead: the limits appear configured and silently are not. These `&self` methods close that gap; prefer them for one-port co-hosting.
+- `proxy_connection_with_limits`, so a proxy's forwarding writer can refuse a response the downstream reader would reject.
+
+### Changed
+- **BREAKING:** `RepeError` is now `#[non_exhaustive]` and gains a `MessageTooLarge { size, limit }` variant. Downstream matches need a `_` arm. This is the one-time cost of making every future error variant a non-breaking addition.
+- **BREAKING:** `ConnectionError` gains `OutboundTooLarge { method, size, limit }`. It is already `#[non_exhaustive]`, so a match with a `_` arm is unaffected.
+- **BREAKING:** `proxy_connection` now applies the outbound guard at the default 16 MiB, forwarding an error response rather than a message the downstream reader would reject. Use `proxy_connection_with_limits` to change or disable it.
+
 ## [5.0.0] - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repe"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "beve",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repe"
-version = "5.0.0"
+version = "6.0.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Rust implementation of the REPE RPC protocol (JSON-focused)"

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -292,6 +292,54 @@ Removing per-connection serialization also removes an implicit safety net. Inlin
 
 The wiring above — install a `TransferControl`, spawn the producer off the reader, and route inbound ack/cancel/resume through your own handlers — is deliberately left to the embedder. A higher-level `WebSocketServer` stream-source surface that owns all of it (you would supply only the byte source and the chunk method names, and `begin`/ack/cancel/resume would be handled internally) is **deferred** until a second distinct windowed-transfer consumer of the built-in server exists, so the trait is designed against more than one transfer shape rather than over-fit to one. Its prerequisites — cancellation-on-disconnect ([above](#cancellation-on-disconnect-and-shutdown)) and orderly drain ([below](#draining-in-flight-connections)) — now exist, so the surface can be designed against this consumer once a second appears. When it is built it should be *pull-based* (the server asks the source for the next chunk only when the credit window has room) and expose a seek so replay/resume can re-emit from an arbitrary offset. Until then, off-reader dispatch plus the [`repe::stream`](streaming.md) API fully cover a single consumer.
 
+## Message Size Limits
+
+WebSocket size limits are enforced by the **reader**. Each endpoint carries its own thresholds, a writer consults none of them, and nothing in the handshake communicates either side's choice. Everything in this section follows from that asymmetry.
+
+### Configuring what an endpoint accepts
+
+`WebSocketLimits` sets the thresholds for a connection. It is a repe-owned type rather than a re-export of the underlying transport's config, so a transport version bump does not become a repe breaking change.
+
+```rust
+use repe::{WebSocketClient, WebSocketLimits, WebSocketServer};
+use repe::server::Router;
+
+let limits = WebSocketLimits::default()
+    .with_max_incoming_frame_size(Some(64 << 20))
+    .with_max_incoming_message_size(Some(64 << 20))
+    .with_assumed_peer_frame_limit(Some(64 << 20));
+
+// Server: applies to every connection it upgrades itself.
+let server = WebSocketServer::new(Router::new()).with_limits(limits);
+
+// Client: applies to this connection.
+// let client = WebSocketClient::connect_with_limits(url, limits).await?;
+```
+
+Raising a limit on one side does **not** raise it on the other. `max_incoming_frame_size` governs what *this* endpoint will read, so a larger payload in either direction requires the *receiving* end to be configured for it. Both ends usually want the same value.
+
+Two paths do not pick up a server's limits, because repe never ran their handshake:
+
+- `SharedWebSocketServer::serve_connection` and friends take a stream the embedder already upgraded. The transport fixes inbound limits at construction and exposes no setter, so they cannot be retrofitted; set them on your own upgrade call.
+- `WebSocketServer::accept` and `accept_with_handshake` are associated functions and cannot see a builder. Use `accept_with_limits` / `accept_with_handshake_and_limits`.
+
+The outbound guard below is repe's own, so it applies on every path regardless.
+
+### Guarding outbound size
+
+Because limits are read-side and undiscoverable, an oversized message fails in a way that looks like nothing at all: it leaves the sender cleanly, the peer's reader rejects it and closes the connection, and the sender sees a dropped socket with no error. A client that reconnects and re-requests the same payload reproduces it indefinitely.
+
+`assumed_peer_frame_limit` is an assumption you configure, checked before sending:
+
+- an oversized **response** is replaced with an `ErrorCode::InternalError` response carrying the same request id, so the caller gets a real error and the connection stays up;
+- an oversized **notify** is dropped, since it has no response to carry a failure;
+- both reach the server's `on_error` hooks as `ConnectionError::OutboundTooLarge`;
+- on the client, an oversized request fails locally with `RepeError::MessageTooLarge` before it reaches the wire.
+
+It defaults on, at the transport's own 16 MiB default frame size. Set it to the peer's `max_incoming_frame_size` when you know it, or clear it with `.with_assumed_peer_frame_limit(None)` for a peer whose limits are known to be absent.
+
+For a payload with no useful upper bound, prefer [SVS streaming](streaming-serialized-values.md) over raising limits: it chunks the transfer, so frame size stays bounded however large the payload grows, and no assumption about the peer is needed.
+
 ## Graceful Shutdown
 
 `serve` and `serve_listener` run until the listener errors or the task is dropped. To stop accepting cleanly without tearing down the runtime, use `serve_with_shutdown` (which binds an address) or `serve_listener_with_shutdown` (which takes an already-bound listener); both `select!` between accepting connections and a shutdown future and return `Ok(())` once it resolves.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -923,6 +923,10 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             code: *code,
             message: message.clone(),
         },
+        RepeError::MessageTooLarge { size, limit } => RepeError::MessageTooLarge {
+            size: *size,
+            limit: *limit,
+        },
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -846,6 +846,10 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             code: *code,
             message: message.clone(),
         },
+        RepeError::MessageTooLarge { size, limit } => RepeError::MessageTooLarge {
+            size: *size,
+            limit: *limit,
+        },
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,13 @@
 use crate::constants::ErrorCode;
 use std::fmt::{Display, Formatter};
 
+/// A REPE protocol, transport, or codec failure.
+///
+/// Marked `#[non_exhaustive]`: match with a `_` arm. New variants are added as
+/// the protocol and its transports grow, and requiring a major release for each
+/// one would price a clearer error out of ever shipping.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RepeError {
     #[error("version mismatch: {0}")]
     VersionMismatch(u8),
@@ -30,6 +36,23 @@ pub enum RepeError {
     },
     #[error("server error {code}: {message}")]
     ServerError { code: ErrorCode, message: String },
+    /// An outbound message exceeded the peer's assumed maximum frame size and
+    /// was not sent.
+    ///
+    /// This is a *pre-send* check against a configured assumption, not an
+    /// observation. WebSocket size limits are enforced by the **reader**, so a
+    /// sender has no way to discover what the peer will accept: the local write
+    /// succeeds, and the peer's reader closes the connection. Left unguarded,
+    /// an oversized message costs the sender a dropped connection with no error
+    /// at all, and a reconnecting client that re-requests the same payload
+    /// loops forever. Substituting this error keeps the connection alive and
+    /// tells the sender exactly what happened.
+    ///
+    /// `limit` is the configured assumption, not a value learned from the peer.
+    #[error(
+        "outbound message of {size} bytes exceeds the assumed peer frame limit of {limit} bytes"
+    )]
+    MessageTooLarge { size: usize, limit: usize },
 }
 
 impl RepeError {
@@ -47,6 +70,11 @@ impl RepeError {
             RepeError::UnknownEnumValue(_) => ErrorCode::ParseError,
             RepeError::UnexpectedBodyFormat { .. } => ErrorCode::InvalidBody,
             RepeError::ServerError { code, .. } => *code,
+            // Not `ResourceExhausted`: that code tells the client to retry, and
+            // retrying an oversized response reproduces it exactly. The handler
+            // produced a result that cannot be delivered, which is the internal
+            // condition `InternalError` describes.
+            RepeError::MessageTooLarge { .. } => ErrorCode::InternalError,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod wasm_client;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub mod websocket_client;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub mod websocket_limits;
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub mod websocket_server;
 
 #[doc(hidden)]
@@ -117,6 +119,8 @@ pub use value_stream::{
 pub use wasm_client::WasmClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_client::{AlreadySubscribed, WebSocketClient};
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub use websocket_limits::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_MESSAGE_SIZE, WebSocketLimits};
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_server::{
     ConnectionError, HandshakeContext, SharedWebSocketServer, ShutdownToken, WebSocketServer,

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -16,7 +16,7 @@ use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinError;
 use tokio::time::{Duration, timeout};
 use tokio_tungstenite::tungstenite::{self, Message as WsMessage};
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
 
 type PendingSender = oneshot::Sender<Result<Message, RepeError>>;
 type PendingRequests = HashMap<u64, PendingSender>;
@@ -50,6 +50,10 @@ impl std::error::Error for AlreadySubscribed {}
 
 struct WebSocketClientInner {
     writer: Mutex<WsWriter>,
+    /// Size limits for this connection. The read-side thresholds were applied
+    /// to the transport at connect time; `assumed_peer_frame_limit` is retained
+    /// because it is repe's own guard, checked on every send.
+    limits: crate::WebSocketLimits,
     pending: StdMutex<PendingRequests>,
     next_id: AtomicU64,
     /// Unbounded sender for inbound notify messages (any header whose
@@ -136,11 +140,32 @@ impl Drop for WebSocketClient {
 }
 
 impl WebSocketClient {
+    /// Connect with the default [`WebSocketLimits`](crate::WebSocketLimits).
     pub async fn connect(url: &str) -> std::io::Result<Self> {
-        let (stream, _response) = connect_async(url).await.map_err(websocket_connect_error)?;
+        Self::connect_with_limits(url, crate::WebSocketLimits::default()).await
+    }
+
+    /// Connect with explicit size limits.
+    ///
+    /// `limits` sets both what this client accepts while reading and the
+    /// assumed peer limit above which an outbound message is refused with
+    /// [`RepeError::MessageTooLarge`] rather than sent. Raising the inbound
+    /// thresholds here does not raise the server's: WebSocket limits are
+    /// per-endpoint and read-side, so a larger payload in either direction
+    /// requires the *receiving* end to be configured for it.
+    pub async fn connect_with_limits(
+        url: &str,
+        limits: crate::WebSocketLimits,
+    ) -> std::io::Result<Self> {
+        // `disable_nagle: false` matches what `connect_async` passes, so the
+        // only behavior this changes is the configured limits.
+        let (stream, _response) = connect_async_with_config(url, Some(limits.into()), false)
+            .await
+            .map_err(websocket_connect_error)?;
         let (writer, reader) = stream.split();
         let inner = Arc::new(WebSocketClientInner {
             writer: Mutex::new(writer),
+            limits,
             pending: StdMutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
             notify_tx: StdMutex::new(None),
@@ -149,6 +174,11 @@ impl WebSocketClient {
         spawn_response_loop(reader, Arc::downgrade(&inner));
 
         Ok(Self { inner })
+    }
+
+    /// This connection's size limits.
+    pub fn limits(&self) -> crate::WebSocketLimits {
+        self.inner.limits
     }
 
     /// Subscribe to inbound notify messages (server-pushed messages with
@@ -570,9 +600,15 @@ impl WebSocketClient {
     }
 
     async fn write_request(&self, msg: &Message) -> Result<(), RepeError> {
+        let bytes = msg.to_vec();
+        // Refuse before sending. The local write would succeed either way; it is
+        // the peer's reader that rejects an oversized frame and closes the
+        // connection, so without this the caller loses the socket and never
+        // learns why.
+        self.inner.limits.check_outbound(bytes.len())?;
         let mut writer = self.inner.writer.lock().await;
         writer
-            .send(WsMessage::Binary(msg.to_vec()))
+            .send(WsMessage::Binary(bytes))
             .await
             .map_err(websocket_transport_error)?;
         Ok(())
@@ -854,6 +890,10 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
         RepeError::ServerError { code, message } => RepeError::ServerError {
             code: *code,
             message: message.clone(),
+        },
+        RepeError::MessageTooLarge { size, limit } => RepeError::MessageTooLarge {
+            size: *size,
+            limit: *limit,
         },
     }
 }

--- a/src/websocket_limits.rs
+++ b/src/websocket_limits.rs
@@ -1,0 +1,203 @@
+//! Size limits for a REPE WebSocket connection.
+//!
+//! WebSocket size limits are enforced by the **reader**. Both ends carry their
+//! own thresholds, a writer consults none of them, and nothing in the handshake
+//! communicates either side's choice. That asymmetry is the whole reason this
+//! module exists, and it produces a failure that is easy to misread: an
+//! oversized message leaves the sender cleanly, and the receiver's reader
+//! rejects it and closes the connection. The sender observes a dropped socket,
+//! not an error, and a client that reconnects and re-requests the same payload
+//! reproduces it forever.
+//!
+//! [`WebSocketLimits`] therefore covers both directions:
+//!
+//! - the **incoming** thresholds this endpoint enforces while reading, and
+//! - an **assumed** limit for the peer, checked before sending so an
+//!   undeliverable message becomes a [`RepeError::MessageTooLarge`] instead of
+//!   a silent disconnect.
+//!
+//! [`RepeError::MessageTooLarge`]: crate::RepeError::MessageTooLarge
+
+/// Default assumed peer frame limit, and the default incoming frame limit.
+///
+/// 16 MiB is the underlying transport's own default, so for a REPE endpoint
+/// talking to another REPE endpoint it is the peer's actual threshold unless
+/// that peer was deliberately reconfigured.
+pub const DEFAULT_MAX_FRAME_SIZE: usize = 16 << 20;
+
+/// Default incoming message limit: 64 MiB, the underlying transport's default.
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 64 << 20;
+
+/// Size limits for one WebSocket connection.
+///
+/// This is a repe-owned type rather than a re-export of the underlying
+/// transport's configuration struct. repe exposes no transport types in its
+/// public API, and keeping it that way means a transport version bump stays an
+/// internal detail instead of a repe breaking change. It also keeps the surface
+/// to the knobs that carry protocol meaning: buffer-tuning fields are
+/// deliberately absent, which additionally avoids the transport's habit of
+/// panicking on internally inconsistent buffer settings.
+///
+/// # Example
+///
+/// ```
+/// use repe::WebSocketLimits;
+///
+/// // Accept larger inbound messages, and expect the peer to do the same.
+/// let limits = WebSocketLimits::default()
+///     .with_max_incoming_frame_size(Some(64 << 20))
+///     .with_assumed_peer_frame_limit(Some(64 << 20));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebSocketLimits {
+    /// Largest single inbound frame this endpoint will accept, or `None` for
+    /// unlimited. Enforced while reading.
+    pub max_incoming_frame_size: Option<usize>,
+    /// Largest reassembled inbound message this endpoint will accept, or `None`
+    /// for unlimited. Enforced while reading.
+    pub max_incoming_message_size: Option<usize>,
+    /// Size above which an **outbound** message is refused with
+    /// [`RepeError::MessageTooLarge`] rather than sent, or `None` to send
+    /// whatever the application produces.
+    ///
+    /// This is an assumption the application configures, never a value learned
+    /// from the peer: no WebSocket handshake field carries it. Set it to the
+    /// peer's `max_incoming_frame_size` when that is known.
+    ///
+    /// Defaults to [`DEFAULT_MAX_FRAME_SIZE`], which is what an unconfigured
+    /// peer enforces. That default cannot break a working deployment: before
+    /// this type existed there was no way to raise a peer's inbound limit, so
+    /// no message larger than it has ever been deliverable to a default peer.
+    /// The guard converts a failure that was already happening silently into
+    /// one that says so. The exception worth knowing about is a peer that is
+    /// not this library, configured with a larger inbound limit; raise this
+    /// field to match it.
+    ///
+    /// [`RepeError::MessageTooLarge`]: crate::RepeError::MessageTooLarge
+    pub assumed_peer_frame_limit: Option<usize>,
+}
+
+impl Default for WebSocketLimits {
+    fn default() -> Self {
+        Self {
+            max_incoming_frame_size: Some(DEFAULT_MAX_FRAME_SIZE),
+            max_incoming_message_size: Some(DEFAULT_MAX_MESSAGE_SIZE),
+            assumed_peer_frame_limit: Some(DEFAULT_MAX_FRAME_SIZE),
+        }
+    }
+}
+
+impl WebSocketLimits {
+    /// Limits with every threshold removed.
+    ///
+    /// The outbound guard is off, so an undeliverable message again fails as a
+    /// dropped connection rather than an error. Reserve this for a transport
+    /// whose peer limits are known to be absent.
+    pub fn unlimited() -> Self {
+        Self {
+            max_incoming_frame_size: None,
+            max_incoming_message_size: None,
+            assumed_peer_frame_limit: None,
+        }
+    }
+
+    /// Set the largest inbound frame this endpoint accepts.
+    pub fn with_max_incoming_frame_size(mut self, bytes: Option<usize>) -> Self {
+        self.max_incoming_frame_size = bytes;
+        self
+    }
+
+    /// Set the largest reassembled inbound message this endpoint accepts.
+    pub fn with_max_incoming_message_size(mut self, bytes: Option<usize>) -> Self {
+        self.max_incoming_message_size = bytes;
+        self
+    }
+
+    /// Set the assumed peer frame limit used by the outbound guard.
+    pub fn with_assumed_peer_frame_limit(mut self, bytes: Option<usize>) -> Self {
+        self.assumed_peer_frame_limit = bytes;
+        self
+    }
+
+    /// The outbound guard: `Err` when `size` exceeds the assumed peer limit.
+    pub(crate) fn check_outbound(&self, size: usize) -> Result<(), crate::RepeError> {
+        match self.assumed_peer_frame_limit {
+            Some(limit) if size > limit => Err(crate::RepeError::MessageTooLarge { size, limit }),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+impl From<WebSocketLimits> for tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+    fn from(limits: WebSocketLimits) -> Self {
+        // Only the read-side thresholds map through. The outbound guard has no
+        // transport equivalent, which is precisely why repe implements it.
+        Self {
+            max_frame_size: limits.max_incoming_frame_size,
+            max_message_size: limits.max_incoming_message_size,
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_outbound_guard_matches_an_unconfigured_peers_inbound_limit() {
+        let limits = WebSocketLimits::default();
+        assert!(limits.check_outbound(DEFAULT_MAX_FRAME_SIZE).is_ok());
+        let err = limits
+            .check_outbound(DEFAULT_MAX_FRAME_SIZE + 1)
+            .expect_err("one byte over the limit must be refused");
+        assert!(matches!(
+            err,
+            crate::RepeError::MessageTooLarge { size, limit }
+                if size == DEFAULT_MAX_FRAME_SIZE + 1 && limit == DEFAULT_MAX_FRAME_SIZE
+        ));
+    }
+
+    #[test]
+    fn removing_the_assumed_limit_disables_the_outbound_guard() {
+        let limits = WebSocketLimits::default().with_assumed_peer_frame_limit(None);
+        assert!(limits.check_outbound(usize::MAX).is_ok());
+        assert!(
+            WebSocketLimits::unlimited()
+                .check_outbound(usize::MAX)
+                .is_ok()
+        );
+    }
+
+    /// The error names the configured assumption, since that is the number the
+    /// caller can act on; the peer's real threshold is not observable.
+    #[test]
+    fn the_error_reports_both_the_size_and_the_assumed_limit() {
+        let err = WebSocketLimits::default()
+            .with_assumed_peer_frame_limit(Some(1024))
+            .check_outbound(4096)
+            .expect_err("over the limit");
+        let text = err.to_string();
+        assert!(text.contains("4096"), "{text}");
+        assert!(text.contains("1024"), "{text}");
+    }
+
+    #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+    #[test]
+    fn only_the_read_side_thresholds_map_onto_the_transport_config() {
+        use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+        let cfg: WebSocketConfig = WebSocketLimits::default()
+            .with_max_incoming_frame_size(Some(123))
+            .with_max_incoming_message_size(Some(456))
+            .into();
+        assert_eq!(cfg.max_frame_size, Some(123));
+        assert_eq!(cfg.max_message_size, Some(456));
+        // Buffer tuning is left at the transport's defaults: repe does not
+        // expose those knobs, and inconsistent values make the transport panic.
+        assert_eq!(
+            cfg.write_buffer_size,
+            WebSocketConfig::default().write_buffer_size
+        );
+    }
+}

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -30,7 +30,7 @@ use tokio_tungstenite::tungstenite::handshake::server::{
     Callback, ErrorResponse, Request, Response,
 };
 use tokio_tungstenite::tungstenite::{self, Message as WsMessage, http::StatusCode};
-use tokio_tungstenite::{WebSocketStream, accept_hdr_async};
+use tokio_tungstenite::{WebSocketStream, accept_hdr_async_with_config};
 use tokio_util::sync::CancellationToken;
 
 type ConnectHook = Arc<dyn Fn(PeerHandle) + Send + Sync>;
@@ -100,6 +100,23 @@ pub enum ConnectionError {
         /// The query path of the handler that panicked.
         method: String,
     },
+    /// An outbound message exceeded the connection's
+    /// [`assumed_peer_frame_limit`](crate::WebSocketLimits::assumed_peer_frame_limit)
+    /// and was not sent.
+    ///
+    /// A response was replaced with an [`ErrorCode::InternalError`] response so
+    /// the caller learns its request produced an undeliverable result; a notify
+    /// was dropped, since it has no response to carry the failure. Either way
+    /// the connection stays up, which is the point: sending the message would
+    /// have made the peer's reader close it.
+    OutboundTooLarge {
+        /// The query path of the message that was too large.
+        method: String,
+        /// Serialized size of the message that was refused.
+        size: usize,
+        /// The configured assumption it exceeded.
+        limit: usize,
+    },
     /// An off-reader request was rejected because the connection's
     /// [`with_offreader_limit`](WebSocketServer::with_offreader_limit)
     /// cap was reached. The client received an
@@ -120,6 +137,9 @@ impl ConnectionError {
         match self {
             ConnectionError::HandlerPanic { .. } => Some(ErrorCode::InternalError),
             ConnectionError::Saturation { .. } => Some(ErrorCode::ResourceExhausted),
+            // A refused response is substituted with an InternalError response;
+            // a refused notify carries no code because notifies have none.
+            ConnectionError::OutboundTooLarge { .. } => Some(ErrorCode::InternalError),
             ConnectionError::Handshake(_) | ConnectionError::Connection(_) => None,
         }
     }
@@ -139,6 +159,17 @@ impl std::fmt::Display for ConnectionError {
             ConnectionError::Saturation { method } => {
                 write!(f, "off-reader dispatch limit reached for {method}; retry")
             }
+            ConnectionError::OutboundTooLarge {
+                method,
+                size,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "outbound message for {method} is {size} bytes, over the {limit} byte assumed \
+                     peer frame limit; not sent"
+                )
+            }
         }
     }
 }
@@ -147,7 +178,9 @@ impl std::error::Error for ConnectionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ConnectionError::Handshake(err) | ConnectionError::Connection(err) => Some(err),
-            ConnectionError::HandlerPanic { .. } | ConnectionError::Saturation { .. } => None,
+            ConnectionError::HandlerPanic { .. }
+            | ConnectionError::Saturation { .. }
+            | ConnectionError::OutboundTooLarge { .. } => None,
         }
     }
 }
@@ -392,6 +425,7 @@ fn report_error(hooks: &[ErrorHook], err: ConnectionError) {
 
 pub struct WebSocketServer {
     router: Router,
+    limits: crate::WebSocketLimits,
     outbound_capacity: usize,
     offreader_limit: Option<usize>,
     peer_id_counter: Arc<AtomicU64>,
@@ -405,6 +439,7 @@ impl WebSocketServer {
     pub fn new(router: Router) -> Self {
         Self {
             router,
+            limits: crate::WebSocketLimits::default(),
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
             offreader_limit: Some(DEFAULT_OFFREADER_LIMIT),
             peer_id_counter: Arc::new(AtomicU64::new(0)),
@@ -433,6 +468,22 @@ impl WebSocketServer {
             "WebSocketServer outbound capacity must be >= 1"
         );
         self.outbound_capacity = capacity;
+        self
+    }
+
+    /// Size limits for every connection this server accepts. Defaults to
+    /// [`WebSocketLimits::default`](crate::WebSocketLimits::default).
+    ///
+    /// The inbound thresholds are applied during the handshake, so they reach
+    /// only connections this server upgrades itself: [`serve`](Self::serve) and
+    /// friends, plus [`accept_with_limits`](Self::accept_with_limits). A
+    /// connection the embedder upgraded and handed to
+    /// [`SharedWebSocketServer::serve_connection`] carries whatever inbound
+    /// limits that upgrade was given, and cannot be retrofitted here: the
+    /// underlying transport fixes them at construction and exposes no setter.
+    /// The outbound guard, being repe's own, applies on every path.
+    pub fn with_limits(mut self, limits: crate::WebSocketLimits) -> Self {
+        self.limits = limits;
         self
     }
 
@@ -769,6 +820,7 @@ impl WebSocketServer {
         SharedWebSocketServer {
             config: Arc::new(ConnectionConfig {
                 router: self.router,
+                limits: self.limits,
                 outbound_capacity: self.outbound_capacity,
                 offreader_limit: self.offreader_limit,
                 peer_id_counter: self.peer_id_counter,
@@ -793,9 +845,24 @@ impl WebSocketServer {
         stream: TcpStream,
         path: &str,
     ) -> Result<WebSocketStream<TcpStream>, RepeError> {
+        Self::accept_with_limits(stream, path, crate::WebSocketLimits::default()).await
+    }
+
+    /// [`accept`](Self::accept) with explicit size limits.
+    ///
+    /// An associated function cannot see a builder-set
+    /// [`with_limits`](Self::with_limits), and the inbound thresholds are fixed
+    /// during the handshake, so an embedder driving its own accept must pass
+    /// them here. Use the same value the server was built with, or the inbound
+    /// limits will not match what the rest of the server expects.
+    pub async fn accept_with_limits(
+        stream: TcpStream,
+        path: &str,
+        limits: crate::WebSocketLimits,
+    ) -> Result<WebSocketStream<TcpStream>, RepeError> {
         // No handshake capture: this path feeds `serve_connection`, which
         // does not fire handshake-aware hooks.
-        accept_repe_websocket(stream, &normalize_path(path), false)
+        accept_repe_websocket(stream, &normalize_path(path), false, limits)
             .await
             .map(|(ws, _handshake)| ws)
     }
@@ -815,7 +882,20 @@ impl WebSocketServer {
         stream: TcpStream,
         path: &str,
     ) -> Result<(WebSocketStream<TcpStream>, HandshakeContext), RepeError> {
-        let (ws, handshake) = accept_repe_websocket(stream, &normalize_path(path), true).await?;
+        Self::accept_with_handshake_and_limits(stream, path, crate::WebSocketLimits::default())
+            .await
+    }
+
+    /// [`accept_with_handshake`](Self::accept_with_handshake) with explicit
+    /// size limits. See [`accept_with_limits`](Self::accept_with_limits) for why
+    /// an associated function cannot read them from the builder.
+    pub async fn accept_with_handshake_and_limits(
+        stream: TcpStream,
+        path: &str,
+        limits: crate::WebSocketLimits,
+    ) -> Result<(WebSocketStream<TcpStream>, HandshakeContext), RepeError> {
+        let (ws, handshake) =
+            accept_repe_websocket(stream, &normalize_path(path), true, limits).await?;
         // `capture_handshake = true` always yields `Some` on the accept
         // path (the validator populates it before returning `Ok`).
         Ok((
@@ -827,6 +907,7 @@ impl WebSocketServer {
 
 struct ConnectionConfig {
     router: Router,
+    limits: crate::WebSocketLimits,
     outbound_capacity: usize,
     offreader_limit: Option<usize>,
     peer_id_counter: Arc<AtomicU64>,
@@ -852,6 +933,38 @@ pub struct SharedWebSocketServer {
 }
 
 impl SharedWebSocketServer {
+    /// Perform the REPE WebSocket handshake using this server's configured
+    /// [`WebSocketLimits`](crate::WebSocketLimits).
+    ///
+    /// Prefer this over the associated [`WebSocketServer::accept`] in an
+    /// embedder-owned accept loop. That one takes no `self`, so it cannot see a
+    /// builder-set [`with_limits`](WebSocketServer::with_limits) and accepts
+    /// with the defaults instead: the limits would appear to be configured and
+    /// silently not be.
+    pub async fn accept(
+        &self,
+        stream: TcpStream,
+        path: &str,
+    ) -> Result<WebSocketStream<TcpStream>, RepeError> {
+        WebSocketServer::accept_with_limits(stream, path, self.config.limits).await
+    }
+
+    /// [`accept`](Self::accept), also returning the upgrade's
+    /// [`HandshakeContext`].
+    pub async fn accept_with_handshake(
+        &self,
+        stream: TcpStream,
+        path: &str,
+    ) -> Result<(WebSocketStream<TcpStream>, HandshakeContext), RepeError> {
+        WebSocketServer::accept_with_handshake_and_limits(stream, path, self.config.limits).await
+    }
+
+    /// This server's size limits, for an embedder that upgrades the stream
+    /// through some path of its own and needs to configure it to match.
+    pub fn limits(&self) -> crate::WebSocketLimits {
+        self.config.limits
+    }
+
     /// Run one connection's reader/writer loop using this server's
     /// router, hooks, and capacities. Pair with
     /// [`WebSocketServer::accept`] to serve a stream the embedder
@@ -960,7 +1073,7 @@ impl SharedWebSocketServer {
         shutdown: Option<&ShutdownToken>,
     ) {
         let capture = !self.config.on_connect_ctx.is_empty();
-        match accept_repe_websocket(stream, expected_path, capture).await {
+        match accept_repe_websocket(stream, expected_path, capture, self.config.limits).await {
             Ok((ws, handshake)) => {
                 let conn_token = match shutdown {
                     Some(token) => token.child_token(),
@@ -989,6 +1102,24 @@ pub async fn proxy_connection<S>(
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
+    proxy_connection_with_limits(ws_stream, upstream, crate::WebSocketLimits::default()).await
+}
+
+/// [`proxy_connection`] with explicit size limits.
+///
+/// Only the outbound guard applies: the stream is already upgraded, so its
+/// inbound thresholds were fixed by whoever performed the handshake. A response
+/// forwarded from upstream that exceeds `assumed_peer_frame_limit` is refused
+/// rather than sent, since sending it would make the downstream reader close the
+/// connection and leave the proxy with no error to report.
+pub async fn proxy_connection_with_limits<S>(
+    ws_stream: WebSocketStream<S>,
+    upstream: AsyncClient,
+    limits: crate::WebSocketLimits,
+) -> Result<(), RepeError>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
     let (mut writer, mut reader) = ws_stream.split();
 
     loop {
@@ -1005,10 +1136,14 @@ where
         };
 
         if let Some(response) = upstream.forward_message(&request).await? {
-            writer
-                .send(WsMessage::Binary(response.into_wire_bytes()))
-                .await
-                .map_err(websocket_transport_error)?;
+            // A proxy has no error hooks, so the refusal is reported by
+            // substituting the error response `frame_outbound` builds.
+            if let Some(bytes) = frame_outbound(response, &limits, &[]) {
+                writer
+                    .send(WsMessage::Binary(bytes))
+                    .await
+                    .map_err(websocket_transport_error)?;
+            }
         }
     }
 
@@ -1028,6 +1163,7 @@ async fn accept_repe_websocket(
     stream: TcpStream,
     expected_path: &str,
     capture_handshake: bool,
+    limits: crate::WebSocketLimits,
 ) -> Result<(WebSocketStream<TcpStream>, Option<HandshakeContext>), RepeError> {
     // The handshake `Callback` borrows the request only for the duration
     // of `on_request`, so stash the captured context in a shared slot the
@@ -1035,12 +1171,13 @@ async fn accept_repe_websocket(
     // hook will read it, the slot is absent and the validator skips the
     // capture entirely.
     let captured = capture_handshake.then(|| Arc::new(std::sync::Mutex::new(None)));
-    let ws = accept_hdr_async(
+    let ws = accept_hdr_async_with_config(
         stream,
         WebSocketPathValidator {
             expected: expected_path.to_owned(),
             captured: captured.clone(),
         },
+        Some(limits.into()),
     )
     .await
     .map_err(websocket_transport_error)?;
@@ -1094,6 +1231,8 @@ async fn handle_connection_with_config(
         ws_writer,
         outbound_rx,
         shutdown_rx,
+        config.limits,
+        Arc::clone(&config.on_error),
     )));
 
     let reader_result = {
@@ -1362,10 +1501,61 @@ async fn spawn_off_reader(
     true
 }
 
+/// Serialize an outbound message, refusing one the peer is assumed to reject.
+///
+/// Every outbound message funnels through the writer task, which makes this the
+/// one place the guard has to live. A response is replaced by an error response
+/// carrying the same request id, so the caller gets a real REPE error instead of
+/// a vanished connection. A notify has no response to carry anything, so it is
+/// dropped and reported through the error hooks.
+///
+/// Returns `None` when nothing should go on the wire.
+fn frame_outbound(
+    m: Message,
+    limits: &crate::WebSocketLimits,
+    on_error: &[ErrorHook],
+) -> Option<Vec<u8>> {
+    let method = m.query_str().unwrap_or("").to_string();
+    let notify = m.header.notify != 0;
+    let id = m.header.id;
+    let bytes = m.into_wire_bytes();
+    let Err(err) = limits.check_outbound(bytes.len()) else {
+        return Some(bytes);
+    };
+    let (size, limit) = match err {
+        RepeError::MessageTooLarge { size, limit } => (size, limit),
+        _ => unreachable!("check_outbound yields only MessageTooLarge"),
+    };
+    report_error(
+        on_error,
+        ConnectionError::OutboundTooLarge {
+            method: method.clone(),
+            size,
+            limit,
+        },
+    );
+    if notify {
+        return None;
+    }
+    let mut replacement = crate::message::create_error_message(
+        ErrorCode::InternalError,
+        format!(
+            "response is {size} bytes, over the {limit} byte assumed peer frame limit; \
+             raise the peer's inbound limit or reduce the response"
+        ),
+    );
+    // Carry the request id across so the client matches this to its pending
+    // request. Only the id changes, so the header's length stays correct.
+    replacement.header.id = id;
+    Some(replacement.into_wire_bytes())
+}
+
 async fn writer_task(
     mut ws_writer: SplitSink<WebSocketStream<TcpStream>, WsMessage>,
     mut outbound_rx: mpsc::Receiver<Message>,
     mut shutdown_rx: oneshot::Receiver<()>,
+    limits: crate::WebSocketLimits,
+    on_error: Arc<Vec<ErrorHook>>,
 ) -> Result<(), RepeError> {
     let mut result: Result<(), RepeError> = Ok(());
     loop {
@@ -1375,10 +1565,10 @@ async fn writer_task(
             // notifies make the wire before shutdown.
             msg = outbound_rx.recv() => match msg {
                 Some(m) => {
-                    if let Err(err) = ws_writer
-                        .send(WsMessage::Binary(m.into_wire_bytes()))
-                        .await
-                    {
+                    let Some(bytes) = frame_outbound(m, &limits, &on_error) else {
+                        continue;
+                    };
+                    if let Err(err) = ws_writer.send(WsMessage::Binary(bytes)).await {
                         result = Err(websocket_transport_error(err));
                         break;
                     }
@@ -1394,7 +1584,10 @@ async fn writer_task(
                 // drops.
                 let deadline = tokio::time::Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
                 while let Ok(m) = outbound_rx.try_recv() {
-                    let send_fut = ws_writer.send(WsMessage::Binary(m.into_wire_bytes()));
+                    let Some(bytes) = frame_outbound(m, &limits, &on_error) else {
+                        continue;
+                    };
+                    let send_fut = ws_writer.send(WsMessage::Binary(bytes));
                     match tokio::time::timeout_at(deadline, send_fut).await {
                         Ok(Ok(())) => {}
                         Ok(Err(err)) => {
@@ -1666,6 +1859,7 @@ mod tests {
     ) -> Result<(), RepeError> {
         let config = Arc::new(ConnectionConfig {
             router,
+            limits: crate::WebSocketLimits::default(),
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
             offreader_limit: Some(DEFAULT_OFFREADER_LIMIT),
             peer_id_counter: Arc::new(AtomicU64::new(0)),
@@ -1691,7 +1885,9 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let (ws_stream, _handshake) =
-                accept_repe_websocket(stream, "/repe", false).await.unwrap();
+                accept_repe_websocket(stream, "/repe", false, crate::WebSocketLimits::default())
+                    .await
+                    .unwrap();
             run_default_connection(ws_stream, router).await.unwrap();
         });
 
@@ -1781,7 +1977,9 @@ mod tests {
             let upstream = AsyncClient::connect(upstream_addr).await.unwrap();
             let (stream, _) = proxy_listener.accept().await.unwrap();
             let (ws_stream, _handshake) =
-                accept_repe_websocket(stream, "/repe", false).await.unwrap();
+                accept_repe_websocket(stream, "/repe", false, crate::WebSocketLimits::default())
+                    .await
+                    .unwrap();
             proxy_connection(ws_stream, upstream).await.unwrap();
         });
 

--- a/tests/websocket_limits.rs
+++ b/tests/websocket_limits.rs
@@ -1,0 +1,176 @@
+#![cfg(feature = "websocket")]
+//! End-to-end behavior of [`repe::WebSocketLimits`] over a real socket.
+//!
+//! The failure these guard against is not a wrong answer, it is a *missing*
+//! one: an oversized message leaves the sender cleanly and the peer's reader
+//! closes the connection, so the sender sees a dropped socket rather than an
+//! error. Every test here therefore asserts on what the caller observes, not on
+//! any internal state.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use repe::server::Router;
+use repe::{RepeError, WebSocketClient, WebSocketLimits, WebSocketServer};
+use serde_json::{Value, json};
+
+/// Spawn a detached server for `router` on an ephemeral port and connect a
+/// client, both with the given limits.
+async fn pair(
+    router: Router,
+    server_limits: WebSocketLimits,
+    client_limits: WebSocketLimits,
+) -> WebSocketClient {
+    let listener = WebSocketServer::listen("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = WebSocketServer::new(router)
+            .with_limits(server_limits)
+            .serve_listener(listener, "/repe")
+            .await;
+    });
+    WebSocketClient::connect_with_limits(&format!("ws://{addr}/repe"), client_limits)
+        .await
+        .expect("connect")
+}
+
+/// A router whose one route returns a body of `len` bytes.
+fn echo_sized_router() -> Router {
+    Router::new().with_json("/blob", |payload: Value| {
+        let len = payload.get("len").and_then(Value::as_u64).unwrap_or(0) as usize;
+        Ok(json!({ "data": "x".repeat(len) }))
+    })
+}
+
+/// The headline case: a response the client could never have read arrives as a
+/// REPE error instead of a closed connection, and the connection survives to
+/// serve the next request.
+#[tokio::test]
+async fn an_oversized_response_becomes_an_error_and_the_connection_survives() {
+    let small = WebSocketLimits::default()
+        .with_max_incoming_frame_size(Some(64 * 1024))
+        .with_max_incoming_message_size(Some(64 * 1024))
+        .with_assumed_peer_frame_limit(Some(64 * 1024));
+    let client = pair(echo_sized_router(), small, small).await;
+
+    let err = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 256 * 1024 }))
+        .await
+        .expect_err("an undeliverable response must not look like success");
+    let text = err.to_string();
+    assert!(
+        text.contains("assumed peer frame limit"),
+        "the error should explain what happened, got: {text}"
+    );
+
+    // The point of substituting an error rather than sending: the socket is
+    // still usable. A torn-down connection would fail this.
+    let ok: Value = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 8 }))
+        .await
+        .expect("connection must survive a refused response");
+    assert_eq!(ok["data"], "xxxxxxxx");
+}
+
+/// The refusal is reported to the server's own error hooks too, so an operator
+/// can see it without a client complaining.
+#[tokio::test]
+async fn the_server_reports_a_refused_response_through_its_error_hooks() {
+    let small = WebSocketLimits::default().with_assumed_peer_frame_limit(Some(4096));
+    let seen = Arc::new(AtomicUsize::new(0));
+    let seen_hook = Arc::clone(&seen);
+
+    let listener = WebSocketServer::listen("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = WebSocketServer::new(echo_sized_router())
+            .with_limits(small)
+            .on_error(move |err| {
+                if matches!(err, repe::ConnectionError::OutboundTooLarge { .. }) {
+                    seen_hook.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .serve_listener(listener, "/repe")
+            .await;
+    });
+    let client = WebSocketClient::connect_with_limits(&format!("ws://{addr}/repe"), small)
+        .await
+        .expect("connect");
+
+    let _ = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 64 * 1024 }))
+        .await;
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "the refusal should reach on_error exactly once"
+    );
+}
+
+/// A client request too large for the server is refused locally, before it hits
+/// the wire, so the client keeps its connection instead of losing it silently.
+#[tokio::test]
+async fn an_oversized_request_is_refused_locally_without_dropping_the_connection() {
+    let small = WebSocketLimits::default().with_assumed_peer_frame_limit(Some(8192));
+    let client = pair(echo_sized_router(), small, small).await;
+
+    let err = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "pad": "y".repeat(32 * 1024) }))
+        .await
+        .expect_err("an oversized request must be refused");
+    assert!(
+        matches!(err, RepeError::MessageTooLarge { .. }),
+        "expected MessageTooLarge, got: {err}"
+    );
+
+    let ok: Value = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 4 }))
+        .await
+        .expect("connection must survive a locally refused request");
+    assert_eq!(ok["data"], "xxxx");
+}
+
+/// Raising the limits on both ends carries a payload that the defaults refuse,
+/// which is the whole reason the knob exists.
+#[tokio::test]
+async fn raising_the_limits_on_both_ends_carries_a_payload_the_defaults_refuse() {
+    // Comfortably over the 16 MiB default so the default would refuse it.
+    let big_len = 20 * 1024 * 1024;
+    let generous = WebSocketLimits::default()
+        .with_max_incoming_frame_size(Some(64 << 20))
+        .with_max_incoming_message_size(Some(64 << 20))
+        .with_assumed_peer_frame_limit(Some(64 << 20));
+
+    // The default refuses it...
+    let strict = pair(echo_sized_router(), Default::default(), Default::default()).await;
+    assert!(
+        strict
+            .call_typed_json::<_, _, Value>("/blob", &json!({ "len": big_len }))
+            .await
+            .is_err(),
+        "the default limits should refuse a 20 MiB response"
+    );
+
+    // ...and raising both ends carries it.
+    let client = pair(echo_sized_router(), generous, generous).await;
+    let got: Value = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": big_len }))
+        .await
+        .expect("raised limits should carry a 20 MiB response");
+    assert_eq!(got["data"].as_str().expect("data").len(), big_len);
+}
+
+/// Turning the guard off restores the unguarded behavior, for a peer whose
+/// limits are known to be absent.
+#[tokio::test]
+async fn clearing_the_assumed_peer_limit_sends_without_checking() {
+    let unguarded = WebSocketLimits::default().with_assumed_peer_frame_limit(None);
+    // The client sends without checking; the server accepts it because its own
+    // inbound thresholds are the generous defaults.
+    let client = pair(echo_sized_router(), Default::default(), unguarded).await;
+    let got: Value = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 16 }))
+        .await
+        .expect("a request under the peer's inbound limit still works");
+    assert_eq!(got["data"].as_str().expect("data").len(), 16);
+}


### PR DESCRIPTION
## Problem

Every REPE WebSocket connection was stuck with the underlying transport's default size limits. repe passed no configuration to the handshake and re-exported nothing a downstream could use to name one, so `max_frame_size` / `max_message_size` were unreachable.

Exceeding them did not fail as an error. WebSocket size limits are enforced by the **reader**: each endpoint carries its own thresholds, a writer consults none of them, and nothing in the handshake communicates either side's choice. So an oversized message leaves the sender cleanly, the peer's reader rejects it and closes the connection, and the sender observes a dropped socket with no error at all. A client that reconnects and re-requests the same payload reproduces it indefinitely.

## What this adds

`WebSocketLimits` covers both directions, since the assumed peer limit is the mirror of the inbound limit and splitting them would force callers to set two things that must agree.

```rust
let limits = WebSocketLimits::default()
    .with_max_incoming_frame_size(Some(64 << 20))
    .with_assumed_peer_frame_limit(Some(64 << 20));

WebSocketClient::connect_with_limits(url, limits).await?;
WebSocketServer::new(router).with_limits(limits);
```

**Why a repe-owned type rather than re-exporting the transport's config struct.** repe currently exposes zero transport types in its public API. Re-exporting one would make a transport version bump a repe breaking change, permanently. It also confines the surface to knobs that carry protocol meaning, leaving out the buffer-tuning fields that make the transport panic when set inconsistently.

**The outbound guard.** `assumed_peer_frame_limit` is checked before sending. A refused response is replaced with an `InternalError` response carrying the same request id, so the caller gets a real error and the connection survives; a refused notify is dropped, having no response to carry the failure. Both reach the server's `on_error` hooks as `ConnectionError::OutboundTooLarge`. It lives in the writer task because every outbound message funnels through there, which is also why the proxy forwarder needed its own call.

## Notable decisions

**The guard defaults on, at the transport's own 16 MiB default.** This cannot break a working deployment: until now there was no way to raise a peer's inbound limit, so no message above it has ever been deliverable to a default peer. The guard converts a failure that was already happening silently into one that says so. The case to know about is a peer that is not this library, configured with a larger inbound limit.

**`SharedWebSocketServer` gains `&self` accept methods.** `WebSocketServer::accept` is an associated function, so in an embedder-owned accept loop it cannot see a builder-set `with_limits` and upgrades with the defaults instead. The limits would appear configured and silently not be, which is a worse failure mode than not having the feature.

**`RepeError` becomes `#[non_exhaustive]`** alongside its new variant, so no future error variant costs a major release. Note this does not weaken internal exhaustiveness: within the defining crate the attribute does not apply, so repe itself still gets a compile error if it forgets to handle a new variant.

## Breaking changes

- `RepeError` is `#[non_exhaustive]` and gains `MessageTooLarge { size, limit }`. Downstream matches need a `_` arm.
- `ConnectionError` gains `OutboundTooLarge { method, size, limit }` (already `#[non_exhaustive]`).
- `proxy_connection` now applies the guard at the default 16 MiB. Use `proxy_connection_with_limits` to change or disable it.

## Tests

391 pass, fmt and clippy clean. Five new integration tests over real loopback sockets, including the headline case (an oversized response arrives as a REPE error and **the connection survives to serve the next request**) and a 20 MiB round-trip that the defaults refuse and raised limits carry.

## Not covered

`WasmClient` does not get the guard. The browser WebSocket exposes no inbound thresholds, so only the outbound half would apply, and it sits behind a separate feature gate. Worth a follow-up.