### PR TITLE
Bump uniudp to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [Unreleased]
 
 ### Changed
-- **MSRV raised to 1.96** (from 1.89), required by `uniudp 1.1.0`. Cargo's `rust-version` has no per-feature granularity, so the crate declares the highest floor any feature needs; in practice the new floor only binds when the optional `fleet-udp` feature is enabled, and the rest of repe still compiles on 1.89.
-- Depend on `uniudp = "1.1.0"` (raised from `1.0.0`) behind `fleet-udp`, which refreshes its crypto/RNG stack (`hmac` 0.13, `sha2` 0.11, `rand` 0.10, `mio` 1.2). No repe API change.
-- Moved the lockfile off the yanked `spin 0.9.8` to `0.9.9` (an unyanked release in the same `^0.9.2` range `reed-solomon-erasure` requires), silencing the yank warning `cargo publish` emitted. Transitive and lockfile-only; it does not affect downstreams, which resolve their own.
+- **MSRV raised to 1.96** (from 1.89), required by `uniudp` 1.1.0 and later. Cargo's `rust-version` has no per-feature granularity, so the crate declares the highest floor any feature needs; in practice the new floor only binds when the optional `fleet-udp` feature is enabled, and the rest of repe still compiles on 1.89.
+- Depend on `uniudp = "1.2.1"` (raised from `1.0.0`) behind `fleet-udp`. 1.1.0 refreshed its crypto/RNG stack (`hmac` 0.13, `sha2` 0.11, `rand` 0.10, `mio` 1.2); 1.2.x replaced the unmaintained `reed-solomon-erasure` with `reed-solomon-engine` 0.2 and added receiver accessors for the pending reassembly backlog. The UDP wire format is unchanged, so a peer on the older version still interoperates. No repe API change: repe drives only uniudp's sender.
+- The yanked `spin 0.9.8` is gone from the lockfile, which silences the yank warning `cargo publish` emitted during the 6.0.0 release. It arrived transitively through `reed-solomon-erasure`, which the uniudp bump drops; the swap to `reed-solomon-engine` is a net removal of 13 packages from the lockfile. Lockfile-only; downstreams resolve their own.
 
 ## [6.0.0] - 2026-07-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,12 +114,6 @@ dependencies = [
  "serde",
  "simdutf8",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -566,15 +549,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -632,16 +606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
+ "hashbrown",
 ]
 
 [[package]]
@@ -650,7 +615,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -714,12 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,15 +692,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "memchr"
@@ -808,37 +758,12 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -849,7 +774,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -964,34 +889,18 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
-name = "reed-solomon-erasure"
-version = "6.0.0"
+name = "reed-solomon-engine"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
-dependencies = [
- "libm",
- "lru",
- "parking_lot 0.11.2",
- "smallvec",
- "spin",
-]
+checksum = "5d902386f55ac0890d3d0f56c932daa0b80b55bcf56631565eed76f0f7f54b6f"
 
 [[package]]
 name = "regex"
@@ -1034,7 +943,7 @@ dependencies = [
  "futures-util",
  "half",
  "js-sys",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.8.5",
  "repe-derive",
  "serde",
@@ -1208,12 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,15 +1273,15 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "uniudp"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cdb87c5cc7421efa800ebcbc28c1ea9a1861baccb6f927955bde031a158343"
+checksum = "f7af87e163bdddd588c26cba4fdb8de1fa99ff0eb2c0633e7a3bdbdcfd8fdb44"
 dependencies = [
  "crc32c",
  "hmac",
  "mio",
  "rand 0.10.2",
- "reed-solomon-erasure",
+ "reed-solomon-engine",
  "sha2",
  "subtle",
  "zeroize",
@@ -1497,22 +1400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,12 +1407,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ serde_json = "1"
 thiserror = "1"
 repe-derive = { path = "repe-derive", version = "0.1.0" }
 parking_lot = { version = "0.12", optional = true }
-uniudp = { version = "1.1.0", optional = true }
+uniudp = { version = "1.2.1", optional = true }
 futures-channel = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }


### PR DESCRIPTION
Raises `uniudp` from 1.1.0 to 1.2.1 behind the optional `fleet-udp` feature.

## What's in 1.2.x

- **1.2.0** replaces the unmaintained `reed-solomon-erasure` with `reed-solomon-engine` 0.2 in uniudp's FEC path. The wire format does not change: both crates use the same systematic Vandermonde construction over GF(2^8) with reduction polynomial 0x11D, so a peer on 1.0/1.1 still interoperates with one on 1.2.1. Upstream verified this by encoding with both crates across all 1024 `(data_shards, parity_shards)` pairs the protocol permits.
- **1.2.1** adds `Receiver::pending_messages` and `Receiver::estimated_pending_bytes`, so callers can read usage against the pending-reassembly limits instead of only seeing the lagging `pending_budget_rejections` counter.

## Impact on repe

None on the API. `src/udp_client.rs` imports only `uniudp::fec`, `uniudp::options`, and `uniudp::sender` — repe drives the sender side, so the new receiver accessors do not reach repe's surface.

MSRV stays at **1.96**; 1.2.1 declares the same floor 1.1.0 did.

## Lockfile

Dropping `reed-solomon-erasure` also removes the yanked `spin 0.9.8` lineage entirely, rather than the `0.9.9` pin the previous commit used to route around it. Net removal of 13 packages (14 out, `reed-solomon-engine` in). The stale CHANGELOG entry describing the spin pin is rewritten accordingly.

Because the 1.1.0 bump has not shipped yet, the `Unreleased` entries are folded into a single 1.0.0 → 1.2.1 bump rather than stacked as two.

## Verification

- `cargo build --features fleet-udp` — clean
- `cargo test --features fleet-udp` — all pass, including the three `tests/uniudp_fleet_tests.rs` cases
- `cargo test --all-features` — clean
- `cargo clippy --features fleet-udp --all-targets` — no warnings