### PR TITLE
Upgrade beve from 3 to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING:** upgraded the `beve` dependency from `3` to `7`. As in the 4.0.0 bump, beve types appear in repe's public API (`RepeError::Beve(beve::Error)`, the re-exported `beve::{BeveTypedSlice, Complex}`, and the `T: beve::BeveTypedSlice` bounds on the typed/complex body, route, and stream-pull surfaces), so a beve major is a repe major. Downstreams that also depend on `beve` directly must move to `beve 7`. Every beve primitive repe builds on — the aligned typed-array family, the streaming typed/complex writers and their size functions, the bulk `read_typed_slice` / `read_complex_slice` decoders, `to_writer_streaming` / `from_reader_streaming` / `serialized_size` — is unchanged, so there is no repe API change of its own and no MSRV move (beve 7 requires 1.89; repe's 1.96 floor comes from `uniudp`).
+
+  Three of the four majors do not reach repe: beve 4, 6, and 7 move the optional `mat` (MATLAB v7.3 / HDF5) dependency forward, and repe does not enable that feature.
+
+- **BREAKING (wire):** beve 5.0 is BEVE **Version 2** compliance, which changes the bytes a serde **enum** encodes to inside a BEVE body. Nothing repe itself puts on the wire is affected — the REPE header is hand-packed, and every body type repe defines (the SVS `open`/`next`/`cancel` messages) is a plain struct — but an application enum in a `body_beve` / `with_typed` / `call_typed_beve` body now encodes differently:
+
+  | Variant kind | via beve 3 | via beve 7 |
+  | --- | --- | --- |
+  | unit | bare `u32` index (`Circle` → `0`) | the name as a string (`"Circle"`) |
+  | newtype / tuple / struct | type-tag extension (`0x0E`) + index + payload | single-key object (`{"Rect": {...}}`) |
+
+  This is what `serde_json` writes, so a repe endpoint's BEVE and JSON bodies now describe an enum the same way. Both old forms still **decode**, so a peer on this version reads bodies written by a peer on repe 6.x or earlier; the reverse does not hold. Two peers exchanging enums must therefore be upgraded reader-first, or together.
+
+  It also matters for **C++ interop**. Glaze moved to BEVE Version 2 in 8.0.0, so this bump brings the two implementations back onto the same encoding; a Glaze peer older than that (including the v7.7.1 tag `interop/fixtures/` is generated from) reads the Version 1 form only. Nothing in `interop/fixtures/` exercises variants, so the interop suite is unaffected and still passes unchanged. See [`docs/interop.md`](docs/interop.md#a-note-on-beve-variants), which also covers the separate matter of the variant *shape* — Version 2 fixes the encoding, not whether a Rust enum and a `std::variant` were configured to describe themselves the same way.
+
+- beve 5.0.1/5.0.2 additionally tightened the serializer: a hand-written `Serialize` whose body does not match the field or entry count it declared to `serialize_struct` / `serialize_map` is now an error at `end` rather than an object header promising data the reader never finds. This affects an application body type with a hand-written impl; a `#[derive(Serialize)]` type (including one using `skip_serializing_if`) cannot trip it.
+
 ## [6.1.0] - 2026-07-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "3.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60351705268cf62ecb454c6ea870501f2a2f784c233546139d70e1d4b58929bf"
+checksum = "72d51a36973f4663eb11c39509e9f92bd99553c44705b0d230b7bf6fbb7f98cc"
 dependencies = [
  "bytemuck",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,12 @@ required-features = ["value-stream"]
 # `*::call_typed_slice_aligned`), the streaming complex primitives
 # (`to_writer_complex_slice` / `complex_slice_size` behind
 # `write_message_complex_slice`), and the `read_typed_slice` / `read_complex_slice`
-# bulk decoders behind the typed-numeric body fast path. Pinned to beve 3: its core
-# ser/de API is unchanged from 2.x, so the major bump only reflects beve's optional
-# `mat` dependency moving forward, which repe does not enable.
-beve = "3"
+# bulk decoders behind the typed-numeric body fast path. Pinned to beve 7. Of the
+# four majors since 3, only beve 5 reaches repe: it is BEVE Version 2 compliance,
+# which changes how a serde enum encodes (see CHANGELOG) and removes a serializer-
+# options API repe never used. 4, 6, and 7 move the optional `mat` dependency
+# forward, which repe does not enable. Every primitive named above is unchanged.
+beve = "7"
 serde = { version = "1", features = ["derive" ] }
 serde_json = "1"
 thiserror = "1"

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -63,6 +63,16 @@ One direction of this is pinned cross-implementation. The `json_request_unknown_
 
 The reverse direction — a repe-produced body with an extra key decoding on a Glaze *server* under its default policy — is still follow-up. It needs a running Glaze server (the fixture generator only emits bytes, it does not receive them) and depends on the C++ side defaulting its REPE server to ignore unknown keys; Glaze's `error_on_unknown_keys` is strict by default today. That is the ecosystem-level half of the same recommendation.
 
+## A note on BEVE variants
+
+The guarantee above covers BEVE **objects** and **typed numeric arrays**, which is what the fixtures exercise. It does not cover a sum type — a Rust `enum` against a C++ `std::variant` — and that gap is currently real rather than merely unpinned.
+
+The BEVE specification has its own version line, independent of REPE's. BEVE **Version 2** deprecates the type-tag extension that Version 1 used to mark a variant, and writes one as ordinary self-describing data instead. Both implementations have moved: the `beve` crate as of its 5.0 release, and Glaze as of 8.0.0. A peer older than either — including the Glaze v7.7.1 tag these fixtures are generated from — is Version 1 on this axis. Decoding is backward compatible and encoding is not, so an older peer's variant is read correctly here while one this crate writes is not.
+
+Version 2 alone does not make the two sides agree, because it fixes the encoding but not the *shape*, and each language picks that per type. Rust's serde defaults to external tagging (`{"Name": payload}`); a plain C++ `std::variant` is written bare, which corresponds to `#[serde(untagged)]`; a Glaze variant with `tag`/`ids` is internally tagged, which corresponds to `#[serde(tag = "...")]`. Pair them deliberately — the encoding is only half the contract.
+
+None of this is pinned by the fixture suite, so nothing here fails loudly if it drifts. If you would rather not carry the coordination, model the case as an object with an explicit discriminant field, or send it over JSON. Structs, numbers, strings, containers, and typed numeric arrays are unaffected either way, and are what the fixtures cover.
+
 ## Versioning note (v1 vs v2)
 
 The [REPE specification](https://github.com/repe-org/REPE) has a work-in-progress


### PR DESCRIPTION
Moves `beve` from `3` to `7` (7.0.1, published today).

## What actually changes

Three of the four majors do not reach repe: **beve 4, 6, and 7** move the optional `mat` (MATLAB v7.3 / HDF5) dependency forward, and repe does not enable that feature. Every beve primitive repe builds on is unchanged — the aligned typed-array family, the streaming typed/complex writers and their size functions, the bulk `read_typed_slice` / `read_complex_slice` decoders, `to_writer_streaming` / `from_reader_streaming` / `serialized_size`. So there is **no repe API change of its own**, and no MSRV move (beve 7 needs 1.89; repe's 1.96 floor comes from `uniudp`).

It is still a repe major, for the same reason 4.0.0 was: beve types are in repe's public API (`RepeError::Beve`, the re-exported `beve::{BeveTypedSlice, Complex}`, the `T: beve::BeveTypedSlice` bounds), so a downstream that also depends on `beve` directly must move in step.

## The one that reaches a caller: beve 5

beve 5.0 is BEVE **Version 2** compliance, which changes the bytes a serde **enum** encodes to inside a BEVE body. Verified against both versions rather than taken from the changelog:

| Variant kind | via beve 3 | via beve 7 |
| --- | --- | --- |
| unit (`Circle`) | bare `u32` index — `51 00 00 00 00` | the name as a string — `02 18 43 69 72 63 6c 65` |
| struct (`Rect { w, h }`) | type-tag ext + index + payload — `0e 51 01 00 00 00 03 08 …` | single-key object — `03 04 10 52 65 63 74 03 08 …` |

That is what `serde_json` writes, so an endpoint's BEVE and JSON bodies now describe an enum the same way. Both old forms still **decode**, so upgrade reader-first or together.

Nothing repe itself puts on the wire is affected: the REPE header is hand-packed, and every body type repe defines (the SVS `open`/`next`/`cancel`/ack messages) is a plain struct. This only reaches an *application* enum in a `body_beve` / `with_typed` / `call_typed_beve` body.

beve 5.0.1/5.0.2 also made a hand-written `Serialize` whose body disagrees with the field or entry count it declared an error at `end`, rather than an object header promising data the reader never finds. A derived impl (including one using `skip_serializing_if`) cannot trip it.

## C++ interop

`docs/interop.md` gains a section on where this leaves Glaze. Glaze made the same Version 2 move in **8.0.0**, so the two implementations are back on one encoding — but the fixtures are generated from **v7.7.1**, which is not. Worth stating explicitly, because Version 2 fixes the encoding and not the *shape*: a plain `std::variant` is written bare (serde's `untagged`), a Glaze variant with `tag`/`ids` is internally tagged (serde's `tag = "..."`), and serde defaults to external tagging. The fixture suite pins none of it, so nothing here fails loudly if it drifts.

Bumping the pinned Glaze tag to 8.x is worth doing, but it is a separate change: it needs the C++ generator rebuilt and the fixtures regenerated, and it is not required by this upgrade.

## Verification

- `cargo test --all-features` — **391 passed, 0 failed** across 26 suites, no test edits.
- `tests/interop.rs` passes unchanged; the committed Glaze fixtures cover objects and typed numeric arrays, no variants.
- `cargo clippy --all-features --all-targets` clean, `cargo fmt --check` clean, `--no-default-features` builds.
- Lockfile diff is one package.

Version bump left to a separate `release:` commit, per convention; the entry lands under `[Unreleased]`.
