### PR TITLE
Bump the interop suite's pinned Glaze tag to v8.0.0

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  GLAZE_TAG: v7.7.1
+  GLAZE_TAG: v8.0.0
 
 jobs:
   interop:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- The interop suite's pinned Glaze tag moves to **v8.0.0** (from v7.7.1), in `interop/cpp/CMakeLists.txt`, the `interop` CI workflow, and the fixture generator's default. Dev-only: `interop/` is not in the published crate, and no repe source changes.
+
+  Regenerating against Glaze 8 leaves **all 11 fixture frames byte-identical** — only `manifest.json`'s `glaze_version` field changes — so the REPE wire output is unaffected by the Glaze major, and `tests/interop.rs` passes untouched. Glaze's baseline compiler requirement is unchanged (GCC 13+, Clang 18+), so the CI job's `g++-14` still builds the generator.
+
+  The reason to move: Glaze 8.0.0 is where Glaze adopted BEVE **Version 2**, the same move `beve` made in 5.0 and repe picked up in 7.0.0. Pinning against 7.7.1 meant the two ends of the suite sat on opposite sides of that line. They now match. `docs/interop.md` is updated to say so — variants are still unpinned coverage rather than a known incompatibility, and the note about matching the variant *shape* (serde's external tagging vs. a bare `std::variant` vs. `tag`/`ids`) still stands.
+
 ## [7.0.0] - 2026-08-10
 
 ### Changed

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -65,13 +65,13 @@ The reverse direction — a repe-produced body with an extra key decoding on a G
 
 ## A note on BEVE variants
 
-The guarantee above covers BEVE **objects** and **typed numeric arrays**, which is what the fixtures exercise. It does not cover a sum type — a Rust `enum` against a C++ `std::variant` — and that gap is currently real rather than merely unpinned.
+The guarantee above covers BEVE **objects** and **typed numeric arrays**, which is what the fixtures exercise. It does not cover a sum type — a Rust `enum` against a C++ `std::variant`. That is a gap in coverage, not a known incompatibility, and it is worth knowing why.
 
-The BEVE specification has its own version line, independent of REPE's. BEVE **Version 2** deprecates the type-tag extension that Version 1 used to mark a variant, and writes one as ordinary self-describing data instead. Both implementations have moved: the `beve` crate as of its 5.0 release, and Glaze as of 8.0.0. A peer older than either — including the Glaze v7.7.1 tag these fixtures are generated from — is Version 1 on this axis. Decoding is backward compatible and encoding is not, so an older peer's variant is read correctly here while one this crate writes is not.
+The BEVE specification has its own version line, independent of REPE's. BEVE **Version 2** deprecates the type-tag extension that Version 1 used to mark a variant, and writes one as ordinary self-describing data instead. Both implementations have made that move — the `beve` crate in its 5.0 release, Glaze in 8.0.0 — and both sides of this suite are now past it: repe depends on `beve 7`, and the fixtures are generated from Glaze v8.0.0. A peer older than either writes and expects the Version 1 form; decoding is backward compatible and encoding is not, so an older peer's variant is read correctly here while one this crate writes is not.
 
 Version 2 alone does not make the two sides agree, because it fixes the encoding but not the *shape*, and each language picks that per type. Rust's serde defaults to external tagging (`{"Name": payload}`); a plain C++ `std::variant` is written bare, which corresponds to `#[serde(untagged)]`; a Glaze variant with `tag`/`ids` is internally tagged, which corresponds to `#[serde(tag = "...")]`. Pair them deliberately — the encoding is only half the contract.
 
-None of this is pinned by the fixture suite, so nothing here fails loudly if it drifts. If you would rather not carry the coordination, model the case as an object with an explicit discriminant field, or send it over JSON. Structs, numbers, strings, containers, and typed numeric arrays are unaffected either way, and are what the fixtures cover.
+None of this is pinned by the fixture suite, so nothing here fails loudly if it drifts. Until it is, either pair the shapes deliberately and test the pairing yourself, or sidestep it: model the case as an object with an explicit discriminant field, or send it over JSON. Structs, numbers, strings, containers, and typed numeric arrays are unaffected either way, and are what the fixtures cover.
 
 ## Versioning note (v1 vs v2)
 

--- a/interop/README.md
+++ b/interop/README.md
@@ -24,12 +24,12 @@ in `tests/interop.rs` read `fixtures/` at runtime.
 ## Regenerating the fixtures
 
 Requires CMake and a C++23 compiler. By default Glaze is fetched at the pinned
-tag (`v7.7.1`) so the committed bytes and CI stay in lockstep:
+tag (`v8.0.0`) so the committed bytes and CI stay in lockstep:
 
 ```sh
 cmake -S interop/cpp -B interop/cpp/build
 cmake --build interop/cpp/build
-interop/cpp/build/generate_fixtures interop/fixtures v7.7.1
+interop/cpp/build/generate_fixtures interop/fixtures v8.0.0
 ```
 
 To iterate against a local Glaze checkout instead of fetching:

--- a/interop/cpp/CMakeLists.txt
+++ b/interop/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #   cmake -S interop/cpp -B interop/cpp/build [-DGLAZE_SOURCE_DIR=/path/to/glaze]
 #   cmake --build interop/cpp/build
-#   interop/cpp/build/generate_fixtures interop/fixtures v7.7.1
+#   interop/cpp/build/generate_fixtures interop/fixtures v8.0.0
 
 cmake_minimum_required(VERSION 3.21)
 project(repe_interop_fixtures CXX)
@@ -15,7 +15,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(GLAZE_SOURCE_DIR "" CACHE PATH "Path to a local Glaze checkout (overrides the FetchContent fetch)")
-set(GLAZE_GIT_TAG "v7.7.1" CACHE STRING "Glaze git tag to fetch when GLAZE_SOURCE_DIR is unset")
+set(GLAZE_GIT_TAG "v8.0.0" CACHE STRING "Glaze git tag to fetch when GLAZE_SOURCE_DIR is unset")
 
 if(GLAZE_SOURCE_DIR)
     message(STATUS "Using local Glaze checkout: ${GLAZE_SOURCE_DIR}")

--- a/interop/cpp/generate_fixtures.cpp
+++ b/interop/cpp/generate_fixtures.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
    fs::create_directories(out);
 
    manifest_doc manifest;
-   manifest.glaze_version = (argc > 2) ? argv[2] : "v7.7.1";
+   manifest.glaze_version = (argc > 2) ? argv[2] : "v8.0.0";
 
    // 1. JSON request: JSON-pointer query + JSON object body.
    {

--- a/interop/fixtures/manifest.json
+++ b/interop/fixtures/manifest.json
@@ -1,6 +1,6 @@
 {
    "repe_version": "1",
-   "glaze_version": "v7.7.1",
+   "glaze_version": "v8.0.0",
    "note": "Authentic Glaze-produced REPE v1 frames. Regenerate with interop/cpp; do not hand-edit.",
    "fixtures": [
       {


### PR DESCRIPTION
Moves the interop suite's pinned Glaze tag from **v7.7.1** to **v8.0.0**, the current Glaze release.

## Why

Glaze 8.0.0 is where Glaze adopted BEVE **Version 2** — the same move `beve` made in 5.0 and repe picked up in 7.0.0. Pinning the fixtures against v7.7.1 left the two ends of this suite on opposite sides of that line. They now match.

## The useful result: the bytes did not move

Regenerating against Glaze 8 leaves **all 11 fixture frames byte-identical**. The entire fixture diff is one line:

```diff
-   "glaze_version": "v7.7.1",
+   "glaze_version": "v8.0.0",
```

So the REPE wire output is unaffected by the Glaze major, and `tests/interop.rs` passes untouched. That is what the suite exists to detect, and it detected nothing — which is the answer you want from a major-version bump on the other side of a wire contract.

## Verification

- Built the generator locally against the fetched v8.0.0 (Apple clang 21, C++23) and regenerated.
- Ran the exact CI loop against the committed tree: regenerate → `git diff --exit-code -- interop/fixtures` → clean.
- `cargo test --test interop` — 3 passed, no test edits.
- Glaze's baseline compiler requirement is unchanged between the two tags (GCC 13+, Clang 18+), so the CI job's `g++-14` still builds it. The `GCC 16+` line in Glaze's README is for the optional P2996 reflection path, not the baseline.

## Scope

The tag is bumped in all four places that carry it — the CMake default, the workflow's `GLAZE_TAG`, the generator's `argv` fallback, and the regeneration instructions in `interop/README.md` — so nothing regenerates against a different source than CI checks.

`docs/interop.md` is updated to match. Variants are now accurately described as *unpinned coverage* rather than a known incompatibility, since both sides speak BEVE Version 2. The caveat that Version 2 fixes the encoding and not the **shape** (serde's external tagging vs. a bare `std::variant` vs. `tag`/`ids`) still stands and is kept.

Dev-only: `interop/` is not in the published crate, and there are no repe source changes — nothing here affects `repe 7.0.0` as published.

## Now unblocked

Adding a variant fixture would pin the one thing this section still describes as unpinned. It was not possible while the generator built against a pre-Version-2 Glaze; it is now. Left out of this PR because it needs a deliberate choice of which tagging shape to pin, and new C++ types, manifest fields, and Rust assertions to go with it.
