### PR TITLE
Upgrade beve from 7.0.1 to 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Changed
+- The lockfile resolves `beve` to **7.1.0** (from 7.0.1). The requirement in `Cargo.toml` stays `beve = "7"`, which already admitted it, so this is lockfile-only and downstreams resolve their own.
+
+  Nothing in it reaches repe. beve's `src/` is byte-identical between 7.0.1 and 7.1.0 — the release is a manifest change moving the optional `mat` (MATLAB v7.3 / HDF5) feature to `hdf5-pure` 0.35, plus README corrections. repe does not enable `mat`, so no repe source, wire output, or MSRV changes, and the full suite passes untouched. 7.0.1 itself was a docs.rs configuration fix.
+
 - The interop suite's pinned Glaze tag moves to **v8.0.0** (from v7.7.1), in `interop/cpp/CMakeLists.txt`, the `interop` CI workflow, and the fixture generator's default. Dev-only: `interop/` is not in the published crate, and no repe source changes.
 
   Regenerating against Glaze 8 leaves **all 11 fixture frames byte-identical** — only `manifest.json`'s `glaze_version` field changes — so the REPE wire output is unaffected by the Glaze major, and `tests/interop.rs` passes untouched. Glaze's baseline compiler requirement is unchanged (GCC 13+, Clang 18+), so the CI job's `g++-14` still builds the generator.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "7.0.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d51a36973f4663eb11c39509e9f92bd99553c44705b0d230b7bf6fbb7f98cc"
+checksum = "5e5b2bf165b993a52802d2dcbfb77d8834a083928a306002d14f1261b9d588e1"
 dependencies = [
  "bytemuck",
  "half",


### PR DESCRIPTION
Lockfile-only. `Cargo.toml` already requires `beve = "7"`, which admits 7.1.0, so the requirement is unchanged and downstreams resolve their own.

## Nothing in the release reaches repe

beve's `src/` is **byte-identical** between 7.0.1 and 7.1.0 (`diff -rq` over the two registry checkouts reports no differing file under `src/`). The only manifest change is:

```
-hdf5-pure = { version = "0.34", optional = true }
+hdf5-pure = { version = "0.35", optional = true }
```

That is the optional `mat` (MATLAB v7.3 / HDF5) feature, which repe does not enable. Upstream, it changes `.mat` bytes for values that intern objects under `#refs#` — each interned object now carries the `H5PATH` attribute MATLAB writes — and the rest of 7.1.0 is README corrections. 7.0.1 before it was a docs.rs configuration fix with no code at all.

So: no repe source change, no wire change, no MSRV move (beve still needs 1.89; repe's 1.96 floor comes from `uniudp`), and no repe version bump. Every beve primitive repe builds on is untouched.

## Verification

- `cargo build --all-features` — clean
- `cargo test --all-features` — all pass, 0 failures (unit, integration, interop fixtures, doctests)
- `cargo clippy --all-features --all-targets` — clean

## Changed

- `Cargo.lock` — `beve` 7.0.1 → 7.1.0
- `CHANGELOG.md` — entry under `[Unreleased]`