### PR TITLE
Carry MessageTooLarge to a waiter, and build wasm32 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,37 @@ jobs:
       - name: Docs
         run: cargo doc --no-deps
 
+  # `wasm_client` is gated on `all(feature = "websocket-wasm", target_arch =
+  # "wasm32")`, so the `check` job above never compiles it: `--all-features` on
+  # ubuntu leaves the cfg false. Without this job the module is unbuilt, which
+  # is how it spent 6.0.0 through 7.0.1 failing to compile against a
+  # `RepeError` variant added in 6.0.0.
+  #
+  # `--all-features` is wrong here on purpose. `websocket` pulls
+  # tokio-tungstenite and `value-stream` pulls zstd, neither of which targets
+  # wasm32; `websocket-wasm` is the feature that claims to.
+  wasm:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clippy (websocket-wasm)
+        run: cargo clippy --features websocket-wasm --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Clippy (core, no features)
+        run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
+
   nightly:
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The `websocket-wasm` feature compiles again.** It has not built for `wasm32-unknown-unknown` since 6.0.0, failing with `error[E0004]: non-exhaustive patterns: &RepeError::MessageTooLarge { .. } not covered` — 6.0.0 added that variant and `clone_fatal_error_for_waiter` in `wasm_client.rs` was never extended to carry it to a waiter. A browser client could not depend on this crate's own WebSocket transport at all across 6.0.0, 6.1.0, 7.0.0 and 7.0.1; the workaround was to frame by hand over the public `Message` API. The variant is now cloned through like every other.
+
+  No `_` arm was added. `RepeError` is this crate's own, so `#[non_exhaustive]` does not force a wildcard on an in-crate match, and the compile error a new variant produces here is worth keeping — it is the reminder to decide how that variant reaches a waiter. What was missing is a build that surfaces it.
+
+- A `collapsible_if` clippy warning in `wasm_client.rs`, unreported for the same reason.
+
+### Changed
+- CI builds `wasm32-unknown-unknown`. `wasm_client` is gated on `all(feature = "websocket-wasm", target_arch = "wasm32")`, so the existing `--all-features` job on ubuntu leaves that cfg false and never compiles the module — which is how it stayed broken across four releases. The new job runs clippy at `-D warnings` for `--features websocket-wasm` and for the core crate with no features.
+
+  It deliberately does not run `--all-features`: `websocket` pulls tokio-tungstenite and `value-stream` pulls zstd, neither of which targets wasm32. `websocket-wasm` is the feature that claims to, so it is the one held to it.
+
 ## [7.0.1] - 2026-08-10
 
 ### Changed

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -712,10 +712,10 @@ impl JsTimeout {
     }
 
     fn clear(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            if let Some(window) = web_sys::window() {
-                window.clear_timeout_with_handle(handle);
-            }
+        if let Some(handle) = self.handle.take()
+            && let Some(window) = web_sys::window()
+        {
+            window.clear_timeout_with_handle(handle);
         }
         self.callback.take();
     }
@@ -821,5 +821,14 @@ fn clone_fatal_error_for_waiter(err: &RepeError, request_id: u64) -> RepeError {
             code: *code,
             message: message.clone(),
         },
+        RepeError::MessageTooLarge { size, limit } => RepeError::MessageTooLarge {
+            size: *size,
+            limit: *limit,
+        },
+        // Deliberately no `_` arm. `RepeError` is this crate's own, so
+        // `#[non_exhaustive]` does not force one here, and the compile error a
+        // new variant causes is the reminder to decide how it reaches a
+        // waiter. The wasm32 CI job is what surfaces that error -- an
+        // `--all-features` host build never compiles this module.
     }
 }


### PR DESCRIPTION
## The bug

`websocket-wasm` has not compiled for `wasm32-unknown-unknown` since **6.0.0**:

```
error[E0004]: non-exhaustive patterns: `&RepeError::MessageTooLarge { .. }` not covered
   --> src/wasm_client.rs:788:11
```

6.0.0 added `RepeError::MessageTooLarge`. `clone_fatal_error_for_waiter` matches every variant to hand a fatal error to each pending waiter, and was never extended, so the match stopped being exhaustive.

A browser client could not use this crate's own WebSocket transport at all across **6.0.0, 6.1.0, 7.0.0 and 7.0.1**. The workaround is to frame by hand over the public `Message` API, which is what at least one downstream is doing.

## Why it survived four releases

`wasm_client` is gated:

```rust
#[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
pub mod wasm_client;
```

CI's `check` job runs `--all-features` on `ubuntu-latest`, where `target_arch` is not `wasm32`, so the cfg is false and the module is never compiled. The feature is in `--all-features` and still got zero coverage. Nothing in CI has ever built this file.

## The fix

**`MessageTooLarge` is cloned through like every other variant.** That one arm is sufficient — nothing else behind it fails.

**No `_` arm.** `RepeError` is this crate's own type, so `#[non_exhaustive]` forces no wildcard on an in-crate match; the exhaustiveness here is ordinary compiler enforcement and it is doing useful work. A new variant *should* fail this match, because "how does this reach a waiter" is a real decision — annotated with the request id like `Io`/`Json`/`Beve`, or copied through. A wildcard would turn that into a silent misclassification and would have concealed this bug rather than fixed it.

Keeping that compile error only helps if something builds it, hence:

**CI gains a `wasm` job**, running clippy at `-D warnings` for `--features websocket-wasm` and for the core crate with no features.

It deliberately does not run `--all-features` on wasm32: `websocket` pulls tokio-tungstenite and `value-stream` pulls zstd, neither of which targets wasm32. `websocket-wasm` is the feature that claims to, so it is the one held to it.

## Also

The new job immediately surfaced a `collapsible_if` in `wasm_client.rs:715`, unreported for the same reason. Fixed here, since the job runs `-D warnings`.

## Testing

- `cargo clippy --features websocket-wasm --target wasm32-unknown-unknown -- -D warnings` — clean (was `E0004` before this change)
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 391 passed, 0 failed
- `cargo fmt --all -- --check` — clean

No source change reaches a non-wasm32 target.