### PR TITLE
Route server-pushed notifies to the browser client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- **`WasmClient::subscribe_notifies()` / `unsubscribe_notifies()`.** The browser client matched every inbound frame by request id and dropped anything unmatched, so a server-pushed notify could not reach the application at all — push-driven protocols were native-only. Notifies are now routed to a subscriber, checked before the correlation map so they cannot collide with an in-flight request sharing the same id.
+
+  Same one-subscriber contract as `WebSocketClient`, including `Err(AlreadySubscribed)` rather than a silent steal. The receiver is a `futures_channel::mpsc::UnboundedReceiver<Message>` — a `Stream`, drained with `StreamExt::next()` — because tokio does not build for `wasm32-unknown-unknown`. See [docs/websocket.md](docs/websocket.md#from-the-browser).
+
+### Fixed
+- **A notify subscription now ends when the connection does,** on both `WebSocketClient` and `WasmClient`. The channel was left open when the socket closed or errored, so a consumer driven only by server pushes — which never issues a request and so never sees a transport error — waited forever on a message that could not arrive. The stream now terminates (`recv()`/`next()` yields `None`), which is that consumer's signal to reconnect.
+
+### Changed
+- `AlreadySubscribed` moved from `websocket_client` to `error`, so both notify-capable clients name one type. `repe::AlreadySubscribed` and `repe::websocket_client::AlreadySubscribed` both still resolve, and it is now exported whenever either `websocket` or `websocket-wasm` is enabled. Its `Display` text drops the `WebSocketClient` mention: "a notify subscription is already active on this client".
+
 ## [7.0.2] - 2026-08-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   Same one-subscriber contract as `WebSocketClient`, including `Err(AlreadySubscribed)` rather than a silent steal. The receiver is a `futures_channel::mpsc::UnboundedReceiver<Message>` — a `Stream`, drained with `StreamExt::next()` — because tokio does not build for `wasm32-unknown-unknown`. See [docs/websocket.md](docs/websocket.md#from-the-browser).
 
 ### Fixed
-- **A notify subscription now ends when the connection does,** on both `WebSocketClient` and `WasmClient`. The channel was left open when the socket closed or errored, so a consumer driven only by server pushes — which never issues a request and so never sees a transport error — waited forever on a message that could not arrive. The stream now terminates (`recv()`/`next()` yields `None`), which is that consumer's signal to reconnect.
+- **A notify subscription now ends when the connection does,** on both `WebSocketClient` and `WasmClient`. The channel was left open when the socket closed or errored, so a consumer driven only by server pushes — which never issues a request and so never sees a transport error — waited forever on a message that could not arrive. The stream now terminates (`recv()`/`next()` yields `None`), which is that consumer's signal to reconnect. A malformed inbound frame does not end it: the socket is still live and the next frame may be a valid notify.
 
 ### Changed
 - `AlreadySubscribed` moved from `websocket_client` to `error`, so both notify-capable clients name one type. `repe::AlreadySubscribed` and `repe::websocket_client::AlreadySubscribed` both still resolve, and it is now exported whenever either `websocket` or `websocket-wasm` is enabled. Its `Display` text drops the `WebSocketClient` mention: "a notify subscription is already active on this client".

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,9 @@ thiserror = "1"
 repe-derive = { path = "repe-derive", version = "0.1.0" }
 parking_lot = { version = "0.12", optional = true }
 uniudp = { version = "1.2.1", optional = true }
-futures-channel = { version = "0.3", optional = true }
+# 0.3.32 for `UnboundedReceiver::try_recv`, which the `notify_slot` tests use
+# (`try_next` is deprecated there, and CI builds tests at `-D warnings`).
+futures-channel = { version = "0.3.32", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4", optional = true }

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Receiving Server-Pushed Notifies
 
-`WebSocketClient::subscribe_notifies()` returns a tokio mpsc receiver that yields every inbound `Message` whose `notify` header flag is set. The response loop checks the notify flag *before* the request/response correlation map, so server-pushed notifies never collide with an in-flight request that happens to share the same id.
+`WebSocketClient::subscribe_notifies()` returns a tokio mpsc receiver that yields every inbound `Message` whose `notify` header flag is set. The response loop checks the notify flag *before* the request/response correlation map, so server-pushed notifies never collide with an in-flight request that happens to share the same id. The browser `WasmClient` has the same method; see [From the browser](#from-the-browser).
 
 ```rust
 use repe::WebSocketClient;
@@ -50,12 +50,42 @@ The receiver yields raw `Message` values; decode the body using `Message::json_b
 - At most one subscriber may be active at a time. If a live subscription already exists, `subscribe_notifies` returns `Err(AlreadySubscribed)` without disturbing the existing receiver. This matters because `WebSocketClient` is `Clone`: the loud-replace contract keeps two holders of the same client from silently stealing each other's subscription. Call `unsubscribe_notifies()` first to take over.
 - A stale slot whose receiver was already dropped does not block a new subscription; in that case `subscribe_notifies` silently installs the new sender.
 - Notifies that arrive while no subscriber is registered are silently dropped. Logging every drop would avalanche under high-rate notifies (e.g. server-pushed binary chunks).
+- The channel closes when the socket closes or errors, so `recv()` yields `None`. A consumer driven only by server pushes never issues a request and so never sees a transport error; end-of-stream is its signal to reconnect. Resubscribing on a dead client succeeds but yields a receiver that never produces anything.
 
 ### Backpressure
 
 The notify channel is unbounded by design. The transport read loop pushes every inbound notify into the channel without backpressure, so a slow consumer plus a high-rate producer will grow the buffer until the process OOMs. Application-level backpressure (e.g. ACK windows in a chunk protocol; see [streaming.md](streaming.md)) is the right fix; the consumer must drain the receiver promptly.
 
 A bounded variant is not offered: dropping notifies on overflow corrupts chunk streams, and blocking the read loop on overflow stalls the request/response correlation path that shares the same socket.
+
+### From the browser
+
+`WasmClient::subscribe_notifies()` is the same API under the `websocket-wasm` feature, with the same subscription rules (including end-of-stream when the socket drops, which surfaces here as `next()` yielding `None`), the same notify-before-correlation ordering, and the same unbounded-channel hazard.
+
+One difference: it returns a `futures_channel::mpsc::UnboundedReceiver<Message>`, which is a `Stream`, not a tokio receiver. Drain it with `StreamExt::next().await` rather than `recv().await`. tokio does not build for `wasm32-unknown-unknown`, so the browser client uses `futures_channel` throughout. Naming that receiver type or calling `next()` on it means depending on the same crates repe does:
+
+```toml
+[dependencies]
+repe = { version = "7", features = ["websocket-wasm"] }
+futures-channel = "0.3"       # only to name UnboundedReceiver in a struct or signature
+futures-util = "0.3"          # StreamExt::next
+wasm-bindgen-futures = "0.4"  # spawn_local
+web-sys = { version = "0.3", features = ["console"] }
+```
+
+```rust,ignore
+use futures_util::StreamExt;
+use repe::WasmClient;
+
+let client = WasmClient::connect("ws://127.0.0.1:8081/repe").await?;
+let mut notifies = client.subscribe_notifies()?;
+wasm_bindgen_futures::spawn_local(async move {
+    while let Some(msg) = notifies.next().await {
+        let path = msg.query_str().unwrap_or("");
+        web_sys::console::log_1(&format!("notify {path}").into());
+    }
+});
+```
 
 ## Server-Initiated Notifies
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -50,7 +50,7 @@ The receiver yields raw `Message` values; decode the body using `Message::json_b
 - At most one subscriber may be active at a time. If a live subscription already exists, `subscribe_notifies` returns `Err(AlreadySubscribed)` without disturbing the existing receiver. This matters because `WebSocketClient` is `Clone`: the loud-replace contract keeps two holders of the same client from silently stealing each other's subscription. Call `unsubscribe_notifies()` first to take over.
 - A stale slot whose receiver was already dropped does not block a new subscription; in that case `subscribe_notifies` silently installs the new sender.
 - Notifies that arrive while no subscriber is registered are silently dropped. Logging every drop would avalanche under high-rate notifies (e.g. server-pushed binary chunks).
-- The channel closes when the socket closes or errors, so `recv()` yields `None`. A consumer driven only by server pushes never issues a request and so never sees a transport error; end-of-stream is its signal to reconnect. Resubscribing on a dead client succeeds but yields a receiver that never produces anything.
+- The channel closes when the socket closes or errors, so `recv()` yields `None`. A consumer driven only by server pushes never issues a request and so never sees a transport error; end-of-stream is its signal to reconnect. A malformed inbound frame does *not* end the stream on its own — only the connection going away does. Resubscribing on a dead client succeeds, but the receiver it hands back is wired to a socket that is gone; reconnect instead.
 
 ### Backpressure
 
@@ -68,7 +68,7 @@ One difference: it returns a `futures_channel::mpsc::UnboundedReceiver<Message>`
 [dependencies]
 repe = { version = "7", features = ["websocket-wasm"] }
 futures-channel = "0.3"       # only to name UnboundedReceiver in a struct or signature
-futures-util = "0.3"          # StreamExt::next
+futures-util = "0.3"          # StreamExt::next; needs default features, unlike repe's own build of it
 wasm-bindgen-futures = "0.4"  # spawn_local
 web-sys = { version = "0.3", features = ["console"] }
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,33 @@ impl Display for ErrorCode {
     }
 }
 
+/// Returned by a client's `subscribe_notifies` when a live subscription
+/// already exists.
+///
+/// "Live" means the prior receiver has not been dropped. To replace a live
+/// subscription, call `unsubscribe_notifies` first. A subscription whose
+/// receiver has already been dropped does not block resubscription:
+/// `subscribe_notifies` silently replaces the stale slot and returns the new
+/// receiver.
+///
+/// Shared by `WebSocketClient` and `WasmClient` so the one-subscriber contract
+/// reads the same on both transports. Lives here rather than in either client
+/// because both modules are feature- and target-gated, and neither can see the
+/// other.
+#[cfg(any(feature = "websocket", feature = "websocket-wasm"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlreadySubscribed;
+
+#[cfg(any(feature = "websocket", feature = "websocket-wasm"))]
+impl Display for AlreadySubscribed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a notify subscription is already active on this client")
+    }
+}
+
+#[cfg(any(feature = "websocket", feature = "websocket-wasm"))]
+impl std::error::Error for AlreadySubscribed {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub mod header;
 pub mod io;
 pub mod json_pointer;
 pub mod message;
+// `wasm_client`'s notify slot, hoisted so the host test suite can exercise it.
+// Compiled off wasm32 only under `test`; a plain host build has no user for it.
+#[cfg(all(feature = "websocket-wasm", any(target_arch = "wasm32", test)))]
+mod notify_slot;
 pub mod peer;
 pub mod registry;
 pub mod server;
@@ -115,10 +119,14 @@ pub use value_stream::{
     pull_to_file_verified_async, pull_to_vec, pull_to_vec_async, pull_typed_slice,
     pull_typed_slice_async, pull_value, pull_value_async,
 };
+// Both notify-capable clients share this, so it is exported off the feature
+// rather than off either transport.
+#[cfg(any(feature = "websocket", feature = "websocket-wasm"))]
+pub use error::AlreadySubscribed;
 #[cfg(all(feature = "websocket-wasm", target_arch = "wasm32"))]
 pub use wasm_client::WasmClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
-pub use websocket_client::{AlreadySubscribed, WebSocketClient};
+pub use websocket_client::WebSocketClient;
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_limits::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_MESSAGE_SIZE, WebSocketLimits};
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]

--- a/src/notify_slot.rs
+++ b/src/notify_slot.rs
@@ -19,8 +19,11 @@ use std::cell::RefCell;
 
 /// Holds the one live notify subscriber, or `None` while nobody is listening.
 ///
-/// A `RefCell` suffices because wasm32 is single-threaded and every borrow here
-/// is released before anything that could re-enter.
+/// A `RefCell` suffices because wasm32 is single-threaded. It is not free,
+/// though: dropping a sender or sending on one wakes the receiver
+/// synchronously, so every function here releases its borrow before doing
+/// either. A consumer that resubscribes when woken would otherwise re-enter a
+/// live borrow and panic.
 pub(crate) type NotifySlot = RefCell<Option<mpsc::UnboundedSender<Message>>>;
 
 /// Install a fresh subscriber, refusing to displace a live one.
@@ -37,6 +40,9 @@ pub(crate) fn subscribe(
         return Err(AlreadySubscribed);
     }
     let (tx, rx) = mpsc::unbounded();
+    // Safe to drop the old sender under the guard, unlike in `unsubscribe`: we
+    // only get here when the slot was empty or its receiver was already gone, so
+    // the wake that `close_channel` fires has no live task to re-enter with.
     *slot = Some(tx);
     Ok(rx)
 }
@@ -44,7 +50,14 @@ pub(crate) fn subscribe(
 /// Drop the active subscription. Subsequent notifies are discarded until the
 /// next [`subscribe`].
 pub(crate) fn unsubscribe(slot: &NotifySlot) {
-    *slot.borrow_mut() = None;
+    // Taken out and dropped *after* the guard, not assigned over. Dropping the
+    // last sender calls `close_channel`, which wakes the parked receiver
+    // synchronously; `*slot.borrow_mut() = None` would run that wake with the
+    // mutable borrow still held, and a consumer that resubscribes on wake would
+    // panic on the re-entrant borrow. Unlike the drops in `subscribe` and
+    // `route`, this one can reach a *live* receiver, so the wake is real.
+    let previous = slot.borrow_mut().take();
+    drop(previous);
 }
 
 /// Route `msg` to the notify subscriber if its `notify` header flag is set.
@@ -92,6 +105,29 @@ fn route(slot: &NotifySlot, notify: Message) {
 mod tests {
     use super::*;
     use crate::constants::BodyFormat;
+    use futures_util::StreamExt;
+    use std::cell::Cell;
+    use std::sync::Arc;
+
+    thread_local! {
+        /// The slot [`ReentrantProbe`] pokes at when woken, and what it found.
+        /// A thread local rather than a captured reference because
+        /// [`std::task::Wake`] requires `Send + Sync`, which a `RefCell` is not;
+        /// the wake fires synchronously on this same thread, so this reaches the
+        /// slot under test.
+        static PROBE_SLOT: NotifySlot = const { RefCell::new(None) };
+        static PROBE_SAW_FREE_SLOT: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    /// Stands in for a consumer that resubscribes the moment its stream ends.
+    struct ReentrantProbe;
+
+    impl std::task::Wake for ReentrantProbe {
+        fn wake(self: Arc<Self>) {
+            let free = PROBE_SLOT.with(|slot| slot.try_borrow_mut().is_ok());
+            PROBE_SAW_FREE_SLOT.with(|seen| seen.set(Some(free)));
+        }
+    }
 
     fn notify(query: &str) -> Message {
         frame(query, true)
@@ -155,12 +191,20 @@ mod tests {
     }
 
     #[test]
-    fn routing_with_no_subscriber_is_a_silent_no_op() {
+    fn a_notify_with_no_subscriber_is_dropped_not_queued() {
+        // Dropped for real: nothing installs a sender behind the scenes, and the
+        // message is not buffered for whoever subscribes next. A subscriber that
+        // attaches late starts from the notifies that follow it.
         let slot = NotifySlot::default();
 
         route(&slot, notify("/nobody-listening"));
 
-        assert!(slot.borrow().is_none());
+        assert!(slot.borrow().is_none(), "no sender should be installed");
+        let mut late = subscribe(&slot).expect("subscribe after the drop");
+        assert!(
+            late.try_recv().is_err(),
+            "the earlier notify must not be replayed"
+        );
     }
 
     #[test]
@@ -173,6 +217,31 @@ mod tests {
         route(&slot, notify("/into-the-void"));
 
         assert!(slot.borrow().is_none());
+    }
+
+    #[test]
+    fn unsubscribe_releases_its_borrow_before_waking_the_receiver() {
+        // Dropping the last sender calls `close_channel`, which wakes the parked
+        // receiver synchronously. If that wake runs while the slot is still
+        // mutably borrowed, a consumer that resubscribes on end-of-stream -- the
+        // reconnect flow the docs prescribe -- panics on the re-entrant borrow.
+        let mut rx = PROBE_SLOT.with(subscribe).expect("subscribe");
+
+        // Park the receiver so there is a registered waker to fire.
+        let waker = std::task::Waker::from(Arc::new(ReentrantProbe));
+        let mut cx = std::task::Context::from_waker(&waker);
+        assert!(
+            rx.poll_next_unpin(&mut cx).is_pending(),
+            "an empty, open channel should park"
+        );
+
+        PROBE_SLOT.with(unsubscribe);
+
+        match PROBE_SAW_FREE_SLOT.with(|seen| seen.get()) {
+            Some(true) => {}
+            Some(false) => panic!("the slot was still borrowed when the receiver woke"),
+            None => panic!("unsubscribe did not wake the parked receiver"),
+        }
     }
 
     #[test]

--- a/src/notify_slot.rs
+++ b/src/notify_slot.rs
@@ -1,0 +1,219 @@
+//! The one-live-subscriber notify slot behind
+//! [`WasmClient::subscribe_notifies`](crate::wasm_client::WasmClient::subscribe_notifies).
+//!
+//! Split out of [`crate::wasm_client`] so it can be tested. That module is gated
+//! on `target_arch = "wasm32"`, and its tests would need a wasm runner and a
+//! connected `WebSocket`; nothing here needs either, so these tests run in the
+//! ordinary host suite where a regression is actually noticed. The gate below
+//! keeps the module out of non-test host builds, where it would be dead code.
+//!
+//! The native `WebSocketClient` keeps its own copy of this logic: it stores the
+//! sender behind a `std::sync::Mutex` and hands out a tokio channel, neither of
+//! which exists on wasm32. The rules the two must agree on are the ones tested
+//! here.
+
+use crate::error::AlreadySubscribed;
+use crate::message::Message;
+use futures_channel::mpsc;
+use std::cell::RefCell;
+
+/// Holds the one live notify subscriber, or `None` while nobody is listening.
+///
+/// A `RefCell` suffices because wasm32 is single-threaded and every borrow here
+/// is released before anything that could re-enter.
+pub(crate) type NotifySlot = RefCell<Option<mpsc::UnboundedSender<Message>>>;
+
+/// Install a fresh subscriber, refusing to displace a live one.
+///
+/// A slot whose receiver was already dropped counts as empty and is replaced
+/// silently.
+pub(crate) fn subscribe(
+    slot: &NotifySlot,
+) -> Result<mpsc::UnboundedReceiver<Message>, AlreadySubscribed> {
+    let mut slot = slot.borrow_mut();
+    if let Some(existing) = slot.as_ref()
+        && !existing.is_closed()
+    {
+        return Err(AlreadySubscribed);
+    }
+    let (tx, rx) = mpsc::unbounded();
+    *slot = Some(tx);
+    Ok(rx)
+}
+
+/// Drop the active subscription. Subsequent notifies are discarded until the
+/// next [`subscribe`].
+pub(crate) fn unsubscribe(slot: &NotifySlot) {
+    *slot.borrow_mut() = None;
+}
+
+/// Route `msg` to the notify subscriber if its `notify` header flag is set.
+///
+/// Returns `None` once the message has been routed (or dropped for want of a
+/// subscriber). A non-notify message is handed straight back as `Some`, for the
+/// caller to correlate against its pending-request map.
+///
+/// The flag is checked here rather than at the call site so that the ordering
+/// rule -- notify before correlation -- is covered by the tests below. A notify
+/// carries no reply correlation, so matching one against `pending` would either
+/// hit nothing or, worse, steal a waiter that happens to share the id.
+pub(crate) fn route_notify(slot: &NotifySlot, msg: Message) -> Option<Message> {
+    if msg.header.notify == 0 {
+        return Some(msg);
+    }
+    route(slot, msg);
+    None
+}
+
+/// Hand one inbound notify to the subscriber, if there is one.
+fn route(slot: &NotifySlot, notify: Message) {
+    // Cloned out so the borrow ends before the send: `unbounded_send` wakes the
+    // consumer, and a task that resubscribes on wake could otherwise re-enter
+    // this `RefCell` while it is still borrowed. Under `spawn_local` the wake is
+    // a microtask and cannot re-enter, but the receiver may be polled by any
+    // waker the application supplies.
+    let Some(sender) = slot.borrow().clone() else {
+        // No subscriber. Dropping silently matches `WebSocketClient`: chunk-style
+        // notifies arrive at high rate, so per-drop logging would be an avalanche.
+        return;
+    };
+
+    if sender.unbounded_send(notify).is_err() {
+        // Receiver gone; empty the slot so the next `subscribe` is not refused by
+        // a corpse. `WebSocketClient` first checks the slot still holds the
+        // channel that failed, because another thread can subscribe in that
+        // window. Nothing can here: a `RefCell` is `!Sync`, and a send to a
+        // dropped receiver wakes no one.
+        *slot.borrow_mut() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::BodyFormat;
+
+    fn notify(query: &str) -> Message {
+        frame(query, true)
+    }
+
+    fn response(query: &str) -> Message {
+        frame(query, false)
+    }
+
+    fn frame(query: &str, notify: bool) -> Message {
+        Message::builder()
+            .query_str(query)
+            .notify(notify)
+            .body_format(BodyFormat::Json)
+            .body_utf8("{}")
+            .build()
+    }
+
+    #[test]
+    fn a_second_subscribe_is_refused_while_the_first_receiver_lives() {
+        let slot = NotifySlot::default();
+        let _first = subscribe(&slot).expect("first subscribe");
+
+        assert_eq!(subscribe(&slot).unwrap_err(), AlreadySubscribed);
+    }
+
+    #[test]
+    fn the_refused_subscribe_leaves_the_incumbent_working() {
+        // The point of refusing rather than replacing: a clone of the client
+        // must not be able to silently steal the stream.
+        let slot = NotifySlot::default();
+        let mut first = subscribe(&slot).expect("first subscribe");
+        let _ = subscribe(&slot);
+
+        route(&slot, notify("/still-mine"));
+
+        let received = first.try_recv().expect("a notify");
+        assert_eq!(received.query_utf8(), "/still-mine");
+    }
+
+    #[test]
+    fn dropping_the_receiver_frees_the_slot_for_a_new_subscriber() {
+        let slot = NotifySlot::default();
+        drop(subscribe(&slot).expect("first subscribe"));
+
+        // Stale, not live: no `unsubscribe` needed.
+        let mut second = subscribe(&slot).expect("resubscribe over a stale slot");
+        route(&slot, notify("/second"));
+
+        assert_eq!(second.try_recv().expect("a notify").query_utf8(), "/second");
+    }
+
+    #[test]
+    fn unsubscribe_hands_the_slot_back() {
+        let slot = NotifySlot::default();
+        let _first = subscribe(&slot).expect("first subscribe");
+
+        unsubscribe(&slot);
+
+        subscribe(&slot).expect("subscribe after unsubscribe");
+    }
+
+    #[test]
+    fn routing_with_no_subscriber_is_a_silent_no_op() {
+        let slot = NotifySlot::default();
+
+        route(&slot, notify("/nobody-listening"));
+
+        assert!(slot.borrow().is_none());
+    }
+
+    #[test]
+    fn routing_to_a_dropped_receiver_clears_the_stale_sender() {
+        // Without this the slot would stay non-empty forever, and every later
+        // `subscribe` would see a live-looking sender and return AlreadySubscribed.
+        let slot = NotifySlot::default();
+        drop(subscribe(&slot).expect("first subscribe"));
+
+        route(&slot, notify("/into-the-void"));
+
+        assert!(slot.borrow().is_none());
+    }
+
+    #[test]
+    fn route_notify_consumes_a_notify_frame() {
+        let slot = NotifySlot::default();
+        let mut rx = subscribe(&slot).expect("subscribe");
+
+        let passed_back = route_notify(&slot, notify("/pushed"));
+
+        assert!(passed_back.is_none(), "a notify must not reach correlation");
+        assert_eq!(rx.try_recv().expect("a notify").query_utf8(), "/pushed");
+    }
+
+    #[test]
+    fn route_notify_hands_a_response_frame_back() {
+        // The other half of the ordering rule: a frame without the flag belongs
+        // to the pending-request map, and must not be siphoned into the stream.
+        let slot = NotifySlot::default();
+        let mut rx = subscribe(&slot).expect("subscribe");
+
+        let passed_back = route_notify(&slot, response("/reply"));
+
+        assert_eq!(
+            passed_back.expect("response handed back").query_utf8(),
+            "/reply"
+        );
+        assert!(rx.try_recv().is_err(), "subscriber must see nothing");
+    }
+
+    #[test]
+    fn a_delivered_notify_leaves_the_subscription_intact() {
+        // Only a *failed* send may empty the slot. Clearing on every send would
+        // turn the subscription into a one-shot.
+        let slot = NotifySlot::default();
+        let mut rx = subscribe(&slot).expect("subscribe");
+
+        route(&slot, notify("/first"));
+        route(&slot, notify("/second"));
+
+        assert_eq!(rx.try_recv().expect("a notify").query_utf8(), "/first");
+        assert_eq!(rx.try_recv().expect("a notify").query_utf8(), "/second");
+        assert!(slot.borrow().is_some());
+    }
+}

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -168,8 +168,10 @@ impl WasmClient {
     ///
     /// The stream ends (`next()` yields `None`) when the socket closes or
     /// errors, which for a page driven only by server pushes is the sole signal
-    /// that the connection is gone. Resubscribing on a dead client succeeds and
-    /// yields a stream that never produces anything; reconnect instead.
+    /// that the connection is gone. A malformed inbound frame does not end the
+    /// stream on its own. Resubscribing on a dead client succeeds, but the
+    /// stream it hands back is wired to a socket that is gone; reconnect
+    /// instead.
     ///
     /// Memory hazard: the channel is unbounded and the socket callback pushes
     /// into it without backpressure, so a stalled consumer under a high-rate
@@ -666,7 +668,7 @@ impl WasmClientInner {
             let weak = weak.clone();
             Closure::wrap(Box::new(move |_event: Event| {
                 if let Some(inner) = weak.upgrade() {
-                    inner.fail_all_pending(websocket_event_error("websocket error"));
+                    inner.fail_connection(websocket_event_error("websocket error"));
                 }
             }) as Box<dyn FnMut(Event)>)
         };
@@ -674,7 +676,7 @@ impl WasmClientInner {
         let onclose = {
             Closure::wrap(Box::new(move |_event: CloseEvent| {
                 if let Some(inner) = weak.upgrade() {
-                    inner.fail_all_pending(websocket_closed_error());
+                    inner.fail_connection(websocket_closed_error());
                 }
             }) as Box<dyn FnMut(CloseEvent)>)
         };
@@ -719,17 +721,31 @@ impl WasmClientInner {
         }
     }
 
+    /// Hand `err` to every in-flight request. The socket is left alone: a single
+    /// undecodable frame does not desynchronize a message-framed transport, so
+    /// later frames may still be good.
     fn fail_all_pending(&self, err: RepeError) {
         let waiters = self.pending.borrow_mut().drain().collect::<Vec<_>>();
         for (request_id, sender) in waiters {
             let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
         }
+    }
 
-        // End the notify stream as well. A request waiter learns the socket died
-        // from the error above; a notify subscriber has no such channel, and a
-        // page driven only by server pushes would otherwise await a message that
-        // can never arrive. Dropping the sender terminates the stream, so
-        // `next()` yields `None`.
+    /// The socket itself is gone: fail every waiter *and* end the notify stream.
+    ///
+    /// Kept distinct from [`Self::fail_all_pending`] because ending the stream is
+    /// a claim that no further notify can arrive. That is true once the socket is
+    /// closed or errored, and false after a decode failure, where the socket
+    /// stays open and the next frame may well be a valid notify. A subscriber
+    /// treats end-of-stream as its signal to reconnect, so ending it early would
+    /// churn a live connection.
+    fn fail_connection(&self, err: RepeError) {
+        self.fail_all_pending(err);
+
+        // A request waiter learns the socket died from the error above; a notify
+        // subscriber has no such channel, and a page driven only by server pushes
+        // would otherwise await a message that can never arrive. Dropping the
+        // sender terminates the stream, so `next()` yields `None`.
         notify_slot::unsubscribe(&self.notify_tx);
     }
 }

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -1,8 +1,9 @@
 use crate::constants::{BodyFormat, ErrorCode, QueryFormat, REPE_VERSION};
-use crate::error::RepeError;
+use crate::error::{AlreadySubscribed, RepeError};
 use crate::message::{Message, MessageBuilder};
+use crate::notify_slot::{self, NotifySlot};
 use beve::from_slice as beve_from_slice;
-use futures_channel::oneshot;
+use futures_channel::{mpsc, oneshot};
 use futures_util::future::{Either, join_all, select};
 use js_sys::{ArrayBuffer, Uint8Array};
 use serde::Serialize;
@@ -33,6 +34,9 @@ struct WasmClientInner {
     ws: WebSocket,
     pending: RefCell<PendingRequests>,
     next_id: Cell<u64>,
+    /// Inbound notifies go here. `None` means no subscriber, in which case they
+    /// are dropped; see [`WasmClient::subscribe_notifies`].
+    notify_tx: NotifySlot,
     onmessage: Closure<dyn FnMut(MessageEvent)>,
     onerror: Closure<dyn FnMut(Event)>,
     onclose: Closure<dyn FnMut(CloseEvent)>,
@@ -139,6 +143,53 @@ impl WasmClient {
             .set_onclose(Some(inner.onclose.as_ref().unchecked_ref()));
 
         Ok(Self { inner })
+    }
+
+    /// Subscribe to inbound notify messages (server-pushed messages with the
+    /// `notify` header flag set).
+    ///
+    /// Returns an unbounded receiver yielding raw [`Message`]s; decoding bodies
+    /// is the application's job. The receiver is a [`Stream`], so drain it with
+    /// `StreamExt::next().await`. This differs from
+    /// `WebSocketClient::subscribe_notifies`, which returns a tokio receiver
+    /// with `recv()`: tokio does not build for wasm32, so the browser client
+    /// uses `futures_channel` throughout.
+    ///
+    /// At most one subscriber may be active at a time. If a live subscription
+    /// already exists, this returns [`AlreadySubscribed`] without disturbing the
+    /// existing receiver; call [`Self::unsubscribe_notifies`] first to take
+    /// over. "Live" means the prior receiver has not been dropped: a stale slot
+    /// whose receiver was dropped installs the new subscription silently. That
+    /// matters because [`WasmClient`] is `Clone`, and without the loud-replace
+    /// rule two holders of the same client could steal each other's stream.
+    ///
+    /// Notifies arriving with no subscriber registered are dropped silently, so
+    /// subscribe before the first one you care about.
+    ///
+    /// The stream ends (`next()` yields `None`) when the socket closes or
+    /// errors, which for a page driven only by server pushes is the sole signal
+    /// that the connection is gone. Resubscribing on a dead client succeeds and
+    /// yields a stream that never produces anything; reconnect instead.
+    ///
+    /// Memory hazard: the channel is unbounded and the socket callback pushes
+    /// into it without backpressure, so a stalled consumer under a high-rate
+    /// producer grows the buffer until the tab dies. Drain promptly and apply
+    /// application-level backpressure. No bounded variant is offered for the
+    /// same reason as on the native client: dropping notifies on overflow
+    /// corrupts chunk streams, and blocking the callback would stall the
+    /// request/response correlation sharing this socket.
+    ///
+    /// [`Stream`]: futures_util::Stream
+    pub fn subscribe_notifies(
+        &self,
+    ) -> Result<mpsc::UnboundedReceiver<Message>, AlreadySubscribed> {
+        notify_slot::subscribe(&self.inner.notify_tx)
+    }
+
+    /// Drop the active notify subscription, if any. Notifies are dropped again
+    /// until [`Self::subscribe_notifies`] is called.
+    pub fn unsubscribe_notifies(&self) {
+        notify_slot::unsubscribe(&self.inner.notify_tx);
     }
 
     pub async fn call_json<P: AsRef<str>, T: Serialize>(
@@ -632,6 +683,7 @@ impl WasmClientInner {
             ws,
             pending: RefCell::new(HashMap::new()),
             next_id: Cell::new(1),
+            notify_tx: RefCell::new(None),
             onmessage,
             onerror,
             onclose,
@@ -645,6 +697,12 @@ impl WasmClientInner {
                 self.fail_all_pending(err);
                 return;
             }
+        };
+
+        // Notifies are siphoned off before the id lookup; see
+        // [`notify_slot::route_notify`].
+        let Some(response) = notify_slot::route_notify(&self.notify_tx, response) else {
+            return;
         };
 
         let sender = self.pending.borrow_mut().remove(&response.header.id);
@@ -666,6 +724,13 @@ impl WasmClientInner {
         for (request_id, sender) in waiters {
             let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
         }
+
+        // End the notify stream as well. A request waiter learns the socket died
+        // from the error above; a notify subscriber has no such channel, and a
+        // page driven only by server pushes would otherwise await a message that
+        // can never arrive. Dropping the sender terminates the stream, so
+        // `next()` yields `None`.
+        notify_slot::unsubscribe(&self.notify_tx);
     }
 }
 

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -197,9 +197,10 @@ impl WebSocketClient {
     ///
     /// The channel closes (`recv()` yields `None`) when the socket
     /// closes or errors, which for a consumer driven only by server
-    /// pushes is the sole signal that the connection is gone.
-    /// Resubscribing on a dead client succeeds and yields a receiver
-    /// that never produces anything; reconnect instead.
+    /// pushes is the sole signal that the connection is gone. A
+    /// malformed inbound frame does not end the stream on its own.
+    /// Resubscribing on a dead client succeeds, but the receiver it
+    /// hands back is wired to a socket that is gone; reconnect instead.
     ///
     /// Memory hazard: the channel is unbounded. The transport read loop
     /// pushes every inbound notify into the channel without backpressure,
@@ -233,11 +234,7 @@ impl WebSocketClient {
     /// notify will be dropped until [`Self::subscribe_notifies`] is
     /// called again.
     pub fn unsubscribe_notifies(&self) {
-        *self
-            .inner
-            .notify_tx
-            .lock()
-            .expect("repe websocket notify_tx mutex poisoned") = None;
+        take_notify_sender(&self.inner);
     }
 
     fn next_request_id(&self) -> u64 {
@@ -832,6 +829,17 @@ async fn fail_all_pending(inner: &std::sync::Weak<WebSocketClientInner>, err: Re
         return;
     };
 
+    // End the notify stream first. A request waiter learns the socket died from
+    // the error below; a notify subscriber has no such channel, and a consumer
+    // driven only by server pushes would otherwise park on `recv()` forever.
+    // Dropping the sender terminates the stream, so `recv()` yields `None`.
+    //
+    // Ahead of `close_writer` deliberately: that awaits a close handshake on a
+    // socket already known to be dead, which on a half-open connection (or
+    // behind another task mid-flush) can stall for TCP-retransmit durations.
+    // The subscriber should not wait on it to learn the connection is gone.
+    take_notify_sender(&inner_ref);
+
     let _ = close_writer(&inner_ref).await;
 
     let waiters = {
@@ -842,16 +850,23 @@ async fn fail_all_pending(inner: &std::sync::Weak<WebSocketClientInner>, err: Re
     for (request_id, sender) in waiters {
         let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
     }
+}
 
-    // End the notify stream as well. A request waiter learns the socket died
-    // from the error above; a notify subscriber has no such channel, and a
-    // consumer driven only by server pushes would otherwise park on `recv()`
-    // forever. Dropping the sender terminates the stream, so `recv()` yields
-    // `None`.
-    *inner_ref
+/// Empty the notify slot, dropping the sender *after* the mutex guard is
+/// released.
+///
+/// Dropping the last sender wakes the parked receiver. tokio wakers never run
+/// inline, so an assignment under the guard would not deadlock today, but
+/// waking anything while holding a non-reentrant `std::sync::Mutex` is a trap
+/// to leave lying around. `notify_slot::unsubscribe` keeps the same discipline
+/// on the wasm side, where the equivalent bug is a live `RefCell` panic.
+fn take_notify_sender(inner: &Arc<WebSocketClientInner>) {
+    let previous = inner
         .notify_tx
         .lock()
-        .expect("repe websocket notify_tx mutex poisoned") = None;
+        .expect("repe websocket notify_tx mutex poisoned")
+        .take();
+    drop(previous);
 }
 
 async fn close_writer(inner: &Arc<WebSocketClientInner>) -> Result<(), RepeError> {
@@ -1165,16 +1180,34 @@ mod tests {
         drop(first);
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test]
     async fn the_notify_stream_ends_when_the_socket_closes() {
         // A push-only consumer never issues a request, so end-of-stream is the
         // only way it can learn the connection died. Without the slot being
         // cleared on teardown, `recv()` here parks forever.
+        //
+        // The server pushes only after seeing a request, so the notify cannot
+        // race ahead of `subscribe_notifies` and be dropped. That keeps the test
+        // deterministic regardless of runtime flavor, matching
+        // `subscribe_notifies_routes_inbound_notify_to_subscriber`.
         let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server_task = tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
             let mut ws = accept_async(stream).await.unwrap();
+
+            let request = match ws.next().await.unwrap().unwrap() {
+                WsMessage::Binary(payload) => Message::from_slice_exact(&payload).unwrap(),
+                other => panic!("unexpected frame: {other:?}"),
+            };
+            let ack = Message::builder()
+                .id(request.header.id)
+                .query_str("/ack")
+                .query_format(QueryFormat::JsonPointer)
+                .body_json(&serde_json::json!({ "ok": true }))
+                .unwrap()
+                .build();
+            ws.send(WsMessage::Binary(ack.to_vec())).await.unwrap();
 
             let pushed = Message::builder()
                 .id(0)
@@ -1192,6 +1225,10 @@ mod tests {
             .await
             .unwrap();
         let mut notifies = client.subscribe_notifies().expect("subscribe");
+        client
+            .call_json("/ready", &serde_json::json!({}))
+            .await
+            .unwrap();
 
         // The pushed notify arrives first, then the close ends the stream.
         let pushed = timeout(Duration::from_secs(2), notifies.recv())

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -29,24 +29,10 @@ pub struct WebSocketClient {
     inner: Arc<WebSocketClientInner>,
 }
 
-/// Returned by [`WebSocketClient::subscribe_notifies`] when a live
-/// subscription already exists.
-///
-/// "Live" means the prior receiver has not been dropped. To replace a
-/// live subscription, call [`WebSocketClient::unsubscribe_notifies`]
-/// first. A subscription whose receiver has already been dropped does
-/// not block resubscription: `subscribe_notifies` silently replaces
-/// the stale slot and returns the new receiver.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AlreadySubscribed;
-
-impl std::fmt::Display for AlreadySubscribed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("a notify subscription is already active on this WebSocketClient")
-    }
-}
-
-impl std::error::Error for AlreadySubscribed {}
+/// Re-exported so `repe::websocket_client::AlreadySubscribed` keeps resolving.
+/// The type moved to [`crate::error`] when `WasmClient` gained the same
+/// one-subscriber contract.
+pub use crate::error::AlreadySubscribed;
 
 struct WebSocketClientInner {
     writer: Mutex<WsWriter>,
@@ -63,6 +49,10 @@ struct WebSocketClientInner {
     /// [`WebSocketClient::subscribe_notifies`] returns an
     /// [`AlreadySubscribed`] error if this slot still holds a sender
     /// whose receiver hasn't been dropped.
+    ///
+    /// `WasmClient` implements the same rules over a `RefCell` and a
+    /// `futures_channel` sender; that copy lives in `crate::notify_slot`,
+    /// where the shared rules are unit-tested. Keep the two in step.
     notify_tx: StdMutex<Option<mpsc::UnboundedSender<Message>>>,
 }
 
@@ -204,6 +194,12 @@ impl WebSocketClient {
     /// binary chunks) make any per-drop logging an avalanche, so we
     /// elide it; if the application needs to know whether messages were
     /// missed, it must subscribe before the first such notify.
+    ///
+    /// The channel closes (`recv()` yields `None`) when the socket
+    /// closes or errors, which for a consumer driven only by server
+    /// pushes is the sole signal that the connection is gone.
+    /// Resubscribing on a dead client succeeds and yields a receiver
+    /// that never produces anything; reconnect instead.
     ///
     /// Memory hazard: the channel is unbounded. The transport read loop
     /// pushes every inbound notify into the channel without backpressure,
@@ -846,6 +842,16 @@ async fn fail_all_pending(inner: &std::sync::Weak<WebSocketClientInner>, err: Re
     for (request_id, sender) in waiters {
         let _ = sender.send(Err(clone_fatal_error_for_waiter(&err, request_id)));
     }
+
+    // End the notify stream as well. A request waiter learns the socket died
+    // from the error above; a notify subscriber has no such channel, and a
+    // consumer driven only by server pushes would otherwise park on `recv()`
+    // forever. Dropping the sender terminates the stream, so `recv()` yields
+    // `None`.
+    *inner_ref
+        .notify_tx
+        .lock()
+        .expect("repe websocket notify_tx mutex poisoned") = None;
 }
 
 async fn close_writer(inner: &Arc<WebSocketClientInner>) -> Result<(), RepeError> {
@@ -1157,6 +1163,52 @@ mod tests {
         // stale-slot path (which only kicks in after the receiver is
         // dropped).
         drop(first);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn the_notify_stream_ends_when_the_socket_closes() {
+        // A push-only consumer never issues a request, so end-of-stream is the
+        // only way it can learn the connection died. Without the slot being
+        // cleared on teardown, `recv()` here parks forever.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = accept_async(stream).await.unwrap();
+
+            let pushed = Message::builder()
+                .id(0)
+                .notify(true)
+                .query_str("/push")
+                .query_format(QueryFormat::JsonPointer)
+                .body_json(&serde_json::json!({}))
+                .unwrap()
+                .build();
+            ws.send(WsMessage::Binary(pushed.to_vec())).await.unwrap();
+            ws.close(None).await.unwrap();
+        });
+
+        let client = WebSocketClient::connect(&format!("ws://{addr}/close"))
+            .await
+            .unwrap();
+        let mut notifies = client.subscribe_notifies().expect("subscribe");
+
+        // The pushed notify arrives first, then the close ends the stream.
+        let pushed = timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("notify did not arrive in time")
+            .expect("subscriber channel closed early");
+        assert_eq!(pushed.query_str().unwrap(), "/push");
+
+        // `client` is deliberately still alive: the stream must end because the
+        // socket died, not because the last client handle was dropped.
+        let ended = timeout(Duration::from_secs(2), notifies.recv())
+            .await
+            .expect("stream did not end after close");
+        assert!(ended.is_none(), "expected end-of-stream, got {ended:?}");
+
+        drop(client);
+        server_task.await.unwrap();
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## What

`WasmClient` matched every inbound frame by request id and dropped anything unmatched, so a server-pushed notify could not reach the application at all — push-driven protocols were native-only. Notifies are now checked *before* the correlation map, exactly as `WebSocketClient` does, and handed to a subscriber.

```rust
let mut notifies = client.subscribe_notifies()?;
wasm_bindgen_futures::spawn_local(async move {
    while let Some(msg) = notifies.next().await { /* ... */ }
});
```

Same one-subscriber contract as the native client, including `Err(AlreadySubscribed)` rather than a silent steal (`WasmClient` is `Clone`). The receiver is a `futures_channel` `UnboundedReceiver<Message>` — a `Stream`, drained with `next()` — because tokio does not build for `wasm32-unknown-unknown`.

## Also fixed: subscriptions outlived their connection

Both clients left the notify channel open when the socket closed or errored. A request waiter learns the socket died from its error; a notify subscriber has no such channel, so a consumer driven only by server pushes waited forever on a message that could not arrive. Both clients now drop the sender on teardown, terminating the stream — which is that consumer's signal to reconnect.

This was a pre-existing bug on `WebSocketClient`, not something the wasm work introduced; it is fixed on both sides to keep the contract identical.

A malformed inbound frame deliberately does *not* end the stream: the socket is still live and the next frame may be a valid notify.

## Fixed in review (second commit)

- **Re-entrant borrow in `notify_slot::unsubscribe`.** `*slot.borrow_mut() = None` drops the sender *inside* the `RefMut` guard, and dropping the last `UnboundedSender` calls `close_channel` → `recv_task.wake()` synchronously. A consumer that resubscribes on end-of-stream (the reconnect flow these docs prescribe) re-entered a live borrow and panicked. Unreachable through `spawn_local`, whose waker defers to a microtask — but `route` already refuses to rely on that, and the `NotifySlot` invariant claimed no borrow was ever held across a wake. Now takes the sender out and drops it after the guard, with a test that parks a receiver on an inline waker. The native equivalent (self-deadlock rather than panic, unreachable because tokio wakers never run inline) gets the same discipline via `take_notify_sender`.
- **Decode errors no longer kill the subscription.** Ending the stream from wasm's `fail_all_pending` was too broad — that path leaves the socket open, so one malformed frame killed the subscription on a healthy connection and the application would churn a live socket. Split `fail_connection` out for genuine socket death; the decode path fails only request waiters. Native never had this problem (its decode path breaks the read loop and closes the writer).
- **Teardown latency.** Native cleared the slot *after* `close_writer().await`, which on a half-open socket can stall for TCP-retransmit durations. Moved ahead of it.

## Testing

The slot logic lives in a small `notify_slot` module rather than inside `wasm_client`, which is gated on `target_arch = "wasm32"` and would need a wasm runner and a live `WebSocket` to exercise. Hoisted, the shared rules run in the ordinary host suite:

- 11 unit tests in `notify_slot` covering refusal vs. stale replacement, silent drops (and non-replay to a late subscriber), stale-sender cleanup, borrow-release before wake, and — via the `route_notify` seam — the notify-before-correlation ordering in both directions. Each was verified to fail under a targeted mutation of the rule it covers.
- 1 new `websocket_client` integration test for end-of-stream on socket close, verified to fail (2s timeout, no end-of-stream) without the fix, and made runtime-flavor-independent by gating the server push on a request/response round-trip.

Note these compile only with `websocket-wasm` enabled, so they run under CI's `cargo test --all-features`, not under a bare `cargo test`.

**Known gap:** there is no `wasm-bindgen-test` infrastructure in this repo, so the wasm-side *wiring* — that `handle_message` calls `route_notify` before the pending lookup, and that `fail_connection` ends the stream — is compile-checked only. The hoist makes the rules testable; it does not close that last gap. Adding a headless-browser CI job is worth doing separately.

Verified locally:
- `cargo test --all-features` — 184 lib tests + integration suites, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo clippy --features websocket-wasm --target wasm32-unknown-unknown -- -D warnings` — clean
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Builds with no features, `--features websocket`, and `--features websocket-wasm` on the host
- `cargo doc --document-private-items` on wasm32 — no new intra-doc warnings

## Note

`AlreadySubscribed` moves from `websocket_client` to `error` so both clients name one type. `repe::AlreadySubscribed` and `repe::websocket_client::AlreadySubscribed` both still resolve. Its `Display` text no longer names `WebSocketClient`.

`futures-channel` is pinned to 0.3.32 for `UnboundedReceiver::try_recv` (`try_next` is deprecated there, and CI builds tests at `-D warnings`).