### PR TITLE
Size broadcast notify bodies for the wire prefix they will carry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **`PeerRegistry::broadcast_notify_*` allocates once per peer instead of twice.** A broadcast has to copy its body once per peer regardless — each sink takes an owned `NotifyBody` — but that copy landed in a buffer sized exactly to the body. `Message::into_wire_bytes` prepends the header and query in place only when the body buffer has capacity for them, so every peer then missed the fast path and allocated a second buffer to copy the body across again. Each per-peer body is now built with room for the prefix, which halves the allocation count of a fan-out and drops the raw variant's redundant leading `to_vec`.
+
+  Bytes moved is unchanged: both paths make two passes over the body, the second now a memmove inside one allocation rather than a copy between two. The saving is allocator pressure at fan-out, which is what a broadcast at data rate is actually spending. No API or wire change; over-reserving is harmless for an embedder sink that frames a different query.
+
 ## [7.1.0] - 2026-08-10
 
 ### Added

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -115,6 +115,32 @@ impl NotifyBody {
     }
 }
 
+/// Bytes a notify's wire prefix occupies ahead of its body: the fixed REPE
+/// header plus the query, which for the `QueryFormat::JsonPointer` notifies
+/// the `broadcast_notify_*` helpers emit is `path` verbatim.
+fn notify_prefix_len(path: &str) -> usize {
+    crate::constants::HEADER_SIZE + path.len()
+}
+
+/// Copy `src` into a fresh buffer that also has room for a `prefix_len`-byte
+/// wire prefix.
+///
+/// A broadcast has to copy the body once per peer regardless, because each
+/// peer's sink takes an owned [`NotifyBody`]. Sizing that copy for the prefix
+/// too is what makes it the *only* allocation: [`Message::into_wire_bytes`]
+/// prepends the header and query in place when the body buffer already has
+/// the capacity, and otherwise allocates a second buffer and copies the body
+/// across again. Over-reserving is harmless: a sink that frames a longer query
+/// than `path` (or none at all) just falls back to the same behavior it had
+/// before.
+///
+/// [`Message::into_wire_bytes`]: crate::Message::into_wire_bytes
+fn clone_with_prefix_room(src: &[u8], prefix_len: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(prefix_len + src.len());
+    buf.extend_from_slice(src);
+    buf
+}
+
 /// Implemented by the embedder for each connected peer's outbound side.
 ///
 /// Repe-rs does not provide a default implementation. Embedders construct
@@ -600,7 +626,8 @@ impl PeerRegistry {
     /// Broadcast a JSON-bodied notify to every connected peer.
     ///
     /// The body is encoded once on the caller's task; the encoded
-    /// bytes are cloned into each peer's outbound channel. Returns a
+    /// bytes are cloned into each peer's outbound channel, sized so the
+    /// sink can frame that clone in place. Returns a
     /// per-peer result map so callers can surface backpressure
     /// ([`PeerSendError::Full`]) or prune dead peers
     /// ([`PeerSendError::Disconnected`]). The registry's lock is held
@@ -617,7 +644,9 @@ impl PeerRegistry {
         T: Serialize + ?Sized,
     {
         let encoded = serde_json::to_vec(body)?;
-        Ok(self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Json(encoded.clone())))
+        Ok(self.broadcast_each(path.as_ref(), |_peer, prefix_room| {
+            NotifyBody::Json(clone_with_prefix_room(&encoded, prefix_room))
+        }))
     }
 
     /// BEVE-bodied broadcast. See [`broadcast_notify_json`] for
@@ -634,7 +663,9 @@ impl PeerRegistry {
         T: Serialize,
     {
         let encoded = beve::to_vec(body)?;
-        Ok(self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Beve(encoded.clone())))
+        Ok(self.broadcast_each(path.as_ref(), |_peer, prefix_room| {
+            NotifyBody::Beve(clone_with_prefix_room(&encoded, prefix_room))
+        }))
     }
 
     /// UTF-8-bodied broadcast. Plain text is advertised with
@@ -648,8 +679,12 @@ impl PeerRegistry {
         P: AsRef<str>,
         S: AsRef<str>,
     {
-        let text = text.as_ref().to_owned();
-        self.broadcast_each(path.as_ref(), |_peer| NotifyBody::Utf8(text.clone()))
+        let text = text.as_ref();
+        self.broadcast_each(path.as_ref(), |_peer, prefix_room| {
+            let mut buf = String::with_capacity(prefix_room + text.len());
+            buf.push_str(text);
+            NotifyBody::Utf8(buf)
+        })
     }
 
     /// Raw-body broadcast. The caller supplies the body bytes and the
@@ -663,24 +698,29 @@ impl PeerRegistry {
     where
         P: AsRef<str>,
     {
-        let bytes = body.to_vec();
-        self.broadcast_each(path.as_ref(), move |_peer| {
-            NotifyBody::Raw(bytes.clone(), body_format)
+        self.broadcast_each(path.as_ref(), |_peer, prefix_room| {
+            NotifyBody::Raw(clone_with_prefix_room(body, prefix_room), body_format)
         })
     }
 
+    /// Shared body of the `broadcast_notify_*` helpers.
+    ///
+    /// `body_for` is handed the number of bytes to leave free ahead of the
+    /// body it builds, so the per-peer copy it has to make anyway lands in an
+    /// allocation the sink can frame in place. See [`clone_with_prefix_room`].
     fn broadcast_each<F>(
         &self,
         path: &str,
         mut body_for: F,
     ) -> HashMap<PeerId, Result<(), PeerSendError>>
     where
-        F: FnMut(&PeerHandle) -> NotifyBody,
+        F: FnMut(&PeerHandle, usize) -> NotifyBody,
     {
+        let prefix_room = notify_prefix_len(path);
         let snapshot = self.peers();
         let mut out = HashMap::with_capacity(snapshot.len());
         for peer in snapshot {
-            let body = body_for(&peer);
+            let body = body_for(&peer, prefix_room);
             let result = peer.send_notify(path, body);
             out.insert(peer.peer_id(), result);
         }
@@ -955,5 +995,62 @@ mod tests {
             .collect();
         assert!(keyed.contains_key("alice"));
         assert!(keyed.contains_key("bob"));
+    }
+
+    #[test]
+    fn broadcast_bodies_carry_room_for_the_wire_prefix() {
+        // Every broadcast body is built with room for the header and query,
+        // so the sink's `Message::into_wire_bytes` prepends them in place
+        // instead of allocating a second buffer and copying the body across
+        // again. What this asserts is that function's fast-path condition.
+        let sink = Arc::new(CapturingSink {
+            connected: true,
+            ..Default::default()
+        });
+        let registry = PeerRegistry::new();
+        registry.insert(PeerHandle::new(PeerId(1), sink.clone()));
+
+        let path = "/broadcast/prefix_room";
+        registry
+            .broadcast_notify_json(path, &serde_json::json!({ "n": 1 }))
+            .unwrap();
+        registry
+            .broadcast_notify_beve(path, &vec![1u8, 2, 3])
+            .unwrap();
+        registry.broadcast_notify_utf8(path, "hello");
+        registry.broadcast_notify_raw(path, BodyFormat::RawBinary, &[9u8; 64]);
+
+        let captured = sink.sent.lock().unwrap();
+        assert_eq!(captured.len(), 4);
+        let prefix = notify_prefix_len(path);
+        for (method, body, fmt) in captured.iter() {
+            assert_eq!(method, path);
+            assert!(!body.is_empty());
+            assert!(
+                body.capacity() >= prefix + body.len(),
+                "{fmt:?} body of {} bytes has capacity {}, short of the {prefix}-byte prefix",
+                body.len(),
+                body.capacity(),
+            );
+        }
+    }
+
+    #[test]
+    fn broadcast_prefix_room_matches_the_framed_prefix() {
+        // Pins `notify_prefix_len` to what the sink actually prepends, so a
+        // change to either side cannot silently push every broadcast back
+        // onto `into_wire_bytes`' reallocating path.
+        let path = "/broadcast/prefix_room";
+        let body = vec![7u8; 32];
+        let msg = crate::Message::builder()
+            .id(0)
+            .notify(true)
+            .query_str(path)
+            .query_format(crate::constants::QueryFormat::JsonPointer)
+            .body_bytes(body.clone())
+            .body_format(BodyFormat::RawBinary)
+            .build();
+        let framed = msg.into_wire_bytes();
+        assert_eq!(framed.len() - body.len(), notify_prefix_len(path));
     }
 }


### PR DESCRIPTION
A `PeerRegistry` broadcast has to copy its body once per peer regardless: `PeerSink::send_notify` takes an owned `NotifyBody`, so there is nothing to share. That copy landed in a buffer sized exactly to the body, which then missed the one place the cost could have stopped there.

`Message::into_wire_bytes` prepends the header and query in place when the body buffer already has capacity for them (`src/message.rs:96`), and otherwise allocates a second buffer and copies the body across again. Every peer took the second branch. So a fan-out to N peers made 2N allocations of body-length or larger where N would do, and `broadcast_notify_raw` added one more up front: it called `to_vec` on its `&[u8]` only to clone that vec per peer.

## What changed

`broadcast_each` now computes the prefix its notifies will be framed with, `HEADER_SIZE + path.len()`, since these are `JsonPointer` queries carrying `path` verbatim, and hands it to the body closure, which builds each per-peer copy with that headroom. All four helpers route through it. The raw variant's leading `to_vec` is gone; the utf8 variant's leading `to_owned` with it.

## What it buys, precisely

Bytes moved is unchanged. Both paths make two passes over the body; the second is now a memmove inside a single allocation rather than a copy between two. What this removes is an allocation and a free per peer, which is the cost that scales with fan-out width and is what a broadcast at data rate is actually spending. Worth stating plainly because "halves the per-peer cost" would overclaim it.

## Compatibility

Nothing observable changes. `broadcast_each` is private and the closure signature is internal; `NotifyBody`, `PeerSink`, and the wire output are untouched. Over-reserving is safe for an embedder sink that frames something other than a `JsonPointer` query: a longer query simply falls back to the reallocating path it already took.

## Tests

Two, both in `src/peer.rs`:

- `broadcast_bodies_carry_room_for_the_wire_prefix` asserts every broadcast body reaches its sink with capacity for the prefix, which is `into_wire_bytes`' fast-path condition stated directly. Mutation-checked: dropping the headroom from the helper fails it with `Json body of 7 bytes has capacity 7, short of the 70-byte prefix`.
- `broadcast_prefix_room_matches_the_framed_prefix` pins `notify_prefix_len` against a real framed message, so a change to either side cannot quietly put every broadcast back on the slow path with the first test still passing.

Full suite green at `--all-features`, clippy and fmt clean.

## Context

Found while reviewing a report that `broadcast_notify_raw` has no zero-copy body. The report is right that it copies per peer, and understates it at one copy rather than two.

Its proposed fix, a `Bytes`/`Arc<[u8]>` body, does not reach encode-once on its own: the header and query still have to be assembled per peer, so the body is still copied into each frame. Sharing the whole *framed* buffer is what would do it, and that means the outbound channel carries pre-framed bytes rather than `Message`. That refactor stays unbuilt. This is the part of the win available without it.

Two notes for anyone who picks that up later. Notify frames genuinely are byte-identical across peers (id 0, notify 1, same query, same body), unlike responses which carry per-request ids, so encode-once is sound here in a way it was not on the response path. And limits are server-level (`config.limits`, cloned per connection), so a pre-framed path could run `check_outbound` once, as long as it does not bypass `frame_outbound` and lose the guard along with the `OutboundTooLarge` hook.
