### PR TITLE
Serve connections another HTTP stack upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,20 @@
 
   Path validation is the caller's job here (the framework already routed the request), which is the counterpart to the `path` argument `WebSocketServer::accept` takes.
 
-- **`derive_accept_key`** (re-exported at the crate root): the `Sec-WebSocket-Accept` derivation an embedder answering the upgrade itself needs. It is the one part of the handshake that is easy to get subtly wrong, and a wrong answer is rejected by the client, not by this crate.
+- **`SharedWebSocketServer::adopt_upgraded_partially_read(io, buffered)`**, for a framework that returns the bytes it read past the upgrade request separately from the stream. A client may legally pipeline its first frame with the upgrade, so dropping those bytes loses a frame; `hyper` replays them itself, but a framework handing back `(io, buffered)` has nowhere else to put them.
 
-- **`repe::tokio_tungstenite`**, the `tokio-tungstenite` this crate is built against. Needed only to *name* `WebSocketStream` in an embedder's own signatures — the value comes from `adopt_upgraded`, which infers it. Previously an embedder had to guess which version requirement would unify with repe's.
+- **`HandshakeContext::from_http_request(&req)`.** `HandshakeContext` had no public constructor, so `on_peer_connect_with_handshake` — the hook for keying peers off an identity carried in the upgrade request — could not fire on a connection repe did not accept. That excluded the best-positioned caller in the crate: a framework handler holding the entire request. Generic over the body type and borrowing, so it composes with any `http::Request` and leaves the caller free to answer the upgrade afterwards.
+
+- **`derive_accept_key`** (at the crate root): the `Sec-WebSocket-Accept` derivation an embedder answering the upgrade itself needs. It is the one part of the handshake that is easy to get subtly wrong, and a wrong answer is rejected by the client, not by this crate. A thin wrapper rather than a re-export of the transport's function, so the signature is repe's to keep stable.
+
+- **`repe::tokio_tungstenite`**, the `tokio-tungstenite` this crate is built against. Needed only to *name* `WebSocketStream` (or the `http` types behind `from_http_request`) in an embedder's own signatures — the value comes from `adopt_upgraded`, which infers it. Previously an embedder had to guess which version requirement would unify with repe's.
 
 ### Changed
 - `SharedWebSocketServer::serve_connection`, `serve_connection_with_handshake`, `serve_connection_with_cancel`, and `serve_connection_with_cancel_and_handshake` are now generic over the underlying byte stream (`S: AsyncRead + AsyncWrite + Unpin + Send + 'static`) rather than fixed to `WebSocketStream<TcpStream>` — matching `proxy_connection`, which was already generic. The connection loop never used a `TcpStream` method, so the restriction was incidental rather than principled.
 
   Existing calls compile unchanged: `TcpStream` satisfies the bound and is inferred from the argument. Only a caller who named one of these as a function item or turbofished it is affected.
+
+- `WebSocketLimits`' documentation no longer claims repe "exposes no transport types in its public API". It never quite did (`accept` returns a `WebSocketStream`), and `repe::tokio_tungstenite` makes it plainly false. The honest version: the repe-owned type exists to keep the surface to knobs that carry protocol meaning and to keep out buffer fields the transport panics on, and a tokio-tungstenite major bump is a repe major bump either way.
 
 ## [7.1.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`SharedWebSocketServer::adopt_upgraded(io)`.** Serves a connection whose upgrade repe did not perform, wrapping the already-upgraded byte stream into a server-role `WebSocketStream` that carries this server's configured `WebSocketLimits`.
+
+  The shipped one-port recipe (`is_websocket_upgrade` + `WebSocketServer::accept`) requires repe to own the `TcpStream` before any HTTP is parsed. That excluded the shape an embedder actually has when its routes live in an HTTP framework: an `axum` `Router` already holding `/healthz` and some `/api/*` routes, wanting the REPE endpoint to be one more route on it. There, the framework owns the socket and answers the `101`, so repe never sees a `TcpStream` — and no entry point accepted an already-upgraded stream, at any price. The only ways out were a second port or abandoning the framework's serving path for a hand-written accept loop. See [docs/websocket.md](docs/websocket.md#adopting-a-connection-your-http-framework-upgraded) for the worked `axum` recipe.
+
+  Path validation is the caller's job here (the framework already routed the request), which is the counterpart to the `path` argument `WebSocketServer::accept` takes.
+
+- **`derive_accept_key`** (re-exported at the crate root): the `Sec-WebSocket-Accept` derivation an embedder answering the upgrade itself needs. It is the one part of the handshake that is easy to get subtly wrong, and a wrong answer is rejected by the client, not by this crate.
+
+- **`repe::tokio_tungstenite`**, the `tokio-tungstenite` this crate is built against. Needed only to *name* `WebSocketStream` in an embedder's own signatures — the value comes from `adopt_upgraded`, which infers it. Previously an embedder had to guess which version requirement would unify with repe's.
+
+### Changed
+- `SharedWebSocketServer::serve_connection`, `serve_connection_with_handshake`, `serve_connection_with_cancel`, and `serve_connection_with_cancel_and_handshake` are now generic over the underlying byte stream (`S: AsyncRead + AsyncWrite + Unpin + Send + 'static`) rather than fixed to `WebSocketStream<TcpStream>` — matching `proxy_connection`, which was already generic. The connection loop never used a `TcpStream` method, so the restriction was incidental rather than principled.
+
+  Existing calls compile unchanged: `TcpStream` satisfies the bound and is inferred from the argument. Only a caller who named one of these as a function item or turbofished it is affected.
+
 ## [7.1.0] - 2026-08-10
 
 ### Added

--- a/dev/http-cohosting-and-keyed-peer-registry.md
+++ b/dev/http-cohosting-and-keyed-peer-registry.md
@@ -4,6 +4,8 @@
 
 Shipped in 3.2.0. Both friction points were addressed: co-hosting via `is_websocket_upgrade` + `examples/websocket_cohosting.rs` + `HandshakeContext` / `on_peer_connect_with_handshake`; embedder-keyed lookup via `PeerRegistry::alias` / `get_by` / `key_for` / `aliases_for`. Retained as the design record behind those additions.
 
+**Follow-on (unreleased):** R1 covers only embedders willing to own the raw accept loop, because peek-then-fork requires repe to hold the `TcpStream` before any HTTP is parsed. A second consumer surfaced with the opposite shape — routes already on an `axum` `Router`, so the *framework* owns the socket and answers the `101`. That case was not merely inconvenient, it was impossible: no entry point took an already-upgraded stream. `SharedWebSocketServer::adopt_upgraded` plus generic-over-`S` `serve_connection*` closes it. Notably this resolves the framework case **without** R2: repe does not grow an HTTP surface, it accepts a stream from whatever already serves HTTP. R2 remains parked, and is now needed only by an embedder that wants co-hosted HTTP with *no* framework at all.
+
 ## Summary
 
 Two friction points surfaced while building a server-push application on top of the shipped `WebSocketServer` + `PeerRegistry` surface. Neither is a blocker; both have working manual workarounds today. This document records them as requests so the core crate can decide whether to smooth them over.

--- a/dev/tls-support.md
+++ b/dev/tls-support.md
@@ -10,7 +10,7 @@ The immediate trigger: `wss://` is advertised in the CLI help and in `docs/cli.m
 
 repe has no TLS support on any native transport. Adding it is not one feature flag, because three things in the current shape assume a plain `TcpStream`:
 
-1. The WebSocket server API is concrete over `TcpStream` in every public signature.
+1. The WebSocket server API is concrete over `TcpStream` in every public signature. **Partly resolved (unreleased):** the *serving* half is done — `handle_connection_with_config`, `reader_task`, `writer_task`, and all four public `serve_connection*` methods are now generic over `S: AsyncRead + AsyncWrite + Unpin + Send + 'static`, generalized in place rather than as the `serve_connection_on<S>` sibling this document proposed (no duplicate surface, no naming debt — prefer that shape for the rest). What remains concrete is the *accept* half: `WebSocketServer::accept{,_with_limits,_with_handshake,_with_handshake_and_limits}`, `SharedWebSocketServer::accept{,_with_handshake}`, and the internal `accept_repe_websocket`. An embedder holding a `TlsStream` can already serve it by performing the upgrade itself and calling `SharedWebSocketServer::adopt_upgraded`; making `accept` generic is what removes that requirement. See `http-cohosting-and-keyed-peer-registry.md`.
 2. Two of the four clients split a connection using mechanisms that exist only for TCP sockets (`try_clone`, `into_split`). Neither works for a TLS session.
 3. The shipped co-hosting helper `is_websocket_upgrade` is built on `TcpStream::peek`, and a decrypted TLS stream has no `peek`.
 
@@ -73,16 +73,20 @@ The codec layer is already transport-agnostic and needs no work: `io.rs` is gene
 
 ### 1. The server API is concrete over `TcpStream`
 
+> **Half of this landed (unreleased).** The serving path is generic now; the text
+> below is kept because the remaining accept half is the same problem with the
+> same fix, and the reasoning still applies to it verbatim.
+
 Every public entry point on the WebSocket server names the stream type:
 
 ```rust
-pub async fn accept(stream: TcpStream, ...) -> Result<WebSocketStream<TcpStream>, RepeError>          // :844
-pub async fn serve_connection(&self, ws: WebSocketStream<TcpStream>) -> Result<(), RepeError>          // :982
+pub async fn accept(stream: TcpStream, ...) -> Result<WebSocketStream<TcpStream>, RepeError>          // still concrete
+pub async fn serve_connection(&self, ws: WebSocketStream<TcpStream>) -> Result<(), RepeError>          // now generic over S
 ```
 
-An embedder holding a `tokio_rustls::server::TlsStream<TcpStream>` has nothing to call.
+An embedder holding a `tokio_rustls::server::TlsStream<TcpStream>` has nothing to call — though it can now perform the upgrade itself and hand the result to `adopt_upgraded`, which is a workaround rather than the fix.
 
-There is already precedent in the file for the fix. `proxy_connection` (`:1098`) is generic over exactly the right bound:
+There is already precedent in the file for the fix. `proxy_connection` is generic over exactly the right bound:
 
 ```rust
 pub async fn proxy_connection<S>(ws_stream: WebSocketStream<S>, upstream: AsyncClient) -> Result<(), RepeError>
@@ -90,7 +94,7 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 ```
 
-So the bound is written and proven; it just is not applied to the main path. `handle_connection_with_config` (`:1194`) and the `writer_task` / `reader_task` pair (`:1554`, `:1318`) would need the same parameter threaded through.
+So the bound is written and proven. It is now applied to `handle_connection_with_config`, `reader_task`, and `writer_task` as well; `accept_repe_websocket` is the one internal still concrete, and `accept_hdr_async_with_config` beneath it is already generic, so threading the parameter through is mechanical.
 
 ### 2. Two clients split the connection with TCP-only mechanisms
 

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -446,6 +446,62 @@ loop {
 
 The built-in `serve` / `serve_listener` loop is itself implemented on top of `into_shared` + `accept` + `serve_connection`, so a co-hosted connection behaves identically to one accepted by the built-in loop.
 
+### Adopting a connection your HTTP framework upgraded
+
+The peek-then-fork recipe above requires repe to own the `TcpStream` before any HTTP is parsed. That is the wrong shape for an embedder whose routes already live in an HTTP framework — an `axum` `Router` with a `/healthz` probe and a handful of `/api/*` routes, wanting the REPE endpoint to be one more route on it. There, the framework owns the socket and answers the `101` itself; repe never sees a `TcpStream`.
+
+For that shape, hand repe the byte stream the framework upgraded. `SharedWebSocketServer::adopt_upgraded(io)` wraps it into a server-role `WebSocketStream` carrying this server's configured `WebSocketLimits`, and `serve_connection` takes it from there — the serving path is generic over the underlying stream, so it does not have to be a socket this crate accepted.
+
+```rust
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use hyper::upgrade::OnUpgrade;
+use hyper_util::rt::TokioIo;
+use repe::{derive_accept_key, SharedWebSocketServer, WebSocketServer};
+
+async fn repe_upgrade(State(shared): State<SharedWebSocketServer>, mut req: Request) -> Response {
+    let Some(key) = req.headers().get("sec-websocket-key").cloned() else {
+        return (StatusCode::BAD_REQUEST, "missing Sec-WebSocket-Key").into_response();
+    };
+    let Some(on_upgrade) = req.extensions_mut().remove::<OnUpgrade>() else {
+        return (StatusCode::BAD_REQUEST, "not an upgrade request").into_response();
+    };
+
+    tokio::spawn(async move {
+        let Ok(upgraded) = on_upgrade.await else { return };
+        let ws = shared.adopt_upgraded(TokioIo::new(upgraded)).await;
+        let _ = shared.serve_connection(ws).await;
+    });
+
+    Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-accept", derive_accept_key(key.as_bytes()))
+        .body(Body::empty())
+        .expect("valid 101 response")
+}
+
+let shared = WebSocketServer::new(router).into_shared();
+let app = axum::Router::new()
+    .route("/healthz", get(|| async { "ok" }))
+    .route("/repe", get(repe_upgrade))
+    .with_state(shared);
+axum::serve(listener, app).await?;
+```
+
+Everything a connection gets under `serve` it also gets here: connect/disconnect hooks, an attached `PeerRegistry`, `CallContext::peer`, off-reader dispatch, and pushed notifies. `serve_connection_with_cancel` works the same way, so a framework-hosted server drains exactly as [below](#draining-a-co-hosted-server).
+
+Two things are the caller's responsibility, because they happen before repe is involved:
+
+- **The handshake.** Validate the upgrade request and answer `101` with the `derive_accept_key` of the client's `Sec-WebSocket-Key` — `derive_accept_key` is re-exported for that. `adopt_upgraded` reads nothing before the first REPE frame, so a stream whose handshake never completed surfaces as a protocol error on that one connection.
+- **Path routing.** `adopt_upgraded` does no path validation, since the framework already routed the request to this handler. This is the counterpart to the `path` argument that `WebSocketServer::accept` takes.
+
+Only the *outbound* size guard is repe's to set on an adopted stream: inbound thresholds are fixed when the stream is constructed. That is why this constructor exists rather than leaving embedders to call `tokio_tungstenite`'s `from_raw_socket` themselves, which would silently substitute the transport defaults for the limits the server was built with. The `tokio_tungstenite` repe is built against is re-exported as `repe::tokio_tungstenite` for embedders who need to *name* `WebSocketStream` in their own signatures.
+
 ### Draining a co-hosted server
 
 Because a co-hosting embedder owns its accept loop, it cannot hand its listener to `serve_listener_with_graceful_drain`. To get the cancellation half on its own terms, create one `ShutdownToken`, serve each connection with `serve_connection_with_cancel(ws, &token)` instead of `serve_connection(ws)`, and `token.cancel()` on shutdown — every connection's in-flight off-reader handlers then observe [`ctx.is_cancelled()`](#cancellation-on-disconnect-and-shutdown) at once. Track the futures in your own `JoinSet` (as you already do for one-port hosting) and drain it with whatever deadline you choose.

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -328,7 +328,7 @@ WebSocket size limits are enforced by the **reader**. Each endpoint carries its 
 
 ### Configuring what an endpoint accepts
 
-`WebSocketLimits` sets the thresholds for a connection. It is a repe-owned type rather than a re-export of the underlying transport's config, so a transport version bump does not become a repe breaking change.
+`WebSocketLimits` sets the thresholds for a connection. It is a repe-owned type rather than a re-export of the underlying transport's config, so the surface stays the knobs that carry protocol meaning and leaves out buffer-tuning fields the transport panics on if set inconsistently. (The transport type itself does appear in repe's public API — `accept`, `proxy_connection`, and `adopt_upgraded` all name `WebSocketStream` — so a tokio-tungstenite major bump is a repe major bump either way; it is re-exported as `repe::tokio_tungstenite` so you can always name the matching version.)
 
 ```rust
 use repe::{WebSocketClient, WebSocketLimits, WebSocketServer};
@@ -452,55 +452,88 @@ The peek-then-fork recipe above requires repe to own the `TcpStream` before any 
 
 For that shape, hand repe the byte stream the framework upgraded. `SharedWebSocketServer::adopt_upgraded(io)` wraps it into a server-role `WebSocketStream` carrying this server's configured `WebSocketLimits`, and `serve_connection` takes it from there — the serving path is generic over the underlying stream, so it does not have to be a socket this crate accepted.
 
+Note this does *not* go through `axum::extract::ws::WebSocketUpgrade`. That extractor hands back axum's own `WebSocket`, a wrapper around its own tungstenite version with only `send`/`recv` on it — not a byte stream anything else can adopt. Taking `hyper::upgrade::OnUpgrade` out of the request directly is what yields the raw upgraded IO, and it keeps axum's tungstenite out of the dependency graph entirely.
+
 ```rust
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::StatusCode;
+use axum::http::header::{SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use hyper::upgrade::OnUpgrade;
 use hyper_util::rt::TokioIo;
-use repe::{derive_accept_key, SharedWebSocketServer, WebSocketServer};
+use repe::{HandshakeContext, ShutdownToken, SharedWebSocketServer, WebSocketServer, derive_accept_key};
 
-async fn repe_upgrade(State(shared): State<SharedWebSocketServer>, mut req: Request) -> Response {
-    let Some(key) = req.headers().get("sec-websocket-key").cloned() else {
+#[derive(Clone)]
+struct AppState {
+    repe: SharedWebSocketServer,
+    shutdown: ShutdownToken,
+}
+
+async fn repe_upgrade(State(state): State<AppState>, mut req: Request) -> Response {
+    // RFC 6455 requires all three. The framework routed the path here, but it
+    // did not check that this is really a WebSocket upgrade.
+    if req.headers().get(SEC_WEBSOCKET_VERSION).map(|v| v.as_bytes()) != Some(b"13") {
+        return (StatusCode::BAD_REQUEST, "unsupported Sec-WebSocket-Version").into_response();
+    }
+    let Some(key) = req.headers().get(SEC_WEBSOCKET_KEY).cloned() else {
         return (StatusCode::BAD_REQUEST, "missing Sec-WebSocket-Key").into_response();
     };
     let Some(on_upgrade) = req.extensions_mut().remove::<OnUpgrade>() else {
         return (StatusCode::BAD_REQUEST, "not an upgrade request").into_response();
     };
 
+    // Capture before answering: the peer is keyed off the upgrade request, and
+    // after this handler returns the request is gone.
+    let handshake = HandshakeContext::from_http_request(&req);
+
     tokio::spawn(async move {
-        let Ok(upgraded) = on_upgrade.await else { return };
-        let ws = shared.adopt_upgraded(TokioIo::new(upgraded)).await;
-        let _ = shared.serve_connection(ws).await;
+        let upgraded = match on_upgrade.await {
+            Ok(upgraded) => upgraded,
+            Err(err) => return tracing::warn!(%err, "upgrade failed"),
+        };
+        let ws = state.repe.adopt_upgraded(TokioIo::new(upgraded)).await;
+        // Errors surface here rather than through `on_error` — this is an
+        // embedder-driven path, so the connection result is yours to handle.
+        if let Err(err) = state
+            .repe
+            .serve_connection_with_cancel_and_handshake(ws, handshake, &state.shutdown)
+            .await
+        {
+            tracing::warn!(%err, "repe connection ended");
+        }
     });
 
     Response::builder()
         .status(StatusCode::SWITCHING_PROTOCOLS)
-        .header("upgrade", "websocket")
-        .header("connection", "Upgrade")
-        .header("sec-websocket-accept", derive_accept_key(key.as_bytes()))
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "Upgrade")
+        .header(SEC_WEBSOCKET_ACCEPT, derive_accept_key(key.as_bytes()))
         .body(Body::empty())
         .expect("valid 101 response")
 }
 
-let shared = WebSocketServer::new(router).into_shared();
+let state = AppState {
+    repe: WebSocketServer::new(router).into_shared(),
+    shutdown: ShutdownToken::new(),
+};
 let app = axum::Router::new()
     .route("/healthz", get(|| async { "ok" }))
     .route("/repe", get(repe_upgrade))
-    .with_state(shared);
+    .with_state(state);
 axum::serve(listener, app).await?;
 ```
 
-Everything a connection gets under `serve` it also gets here: connect/disconnect hooks, an attached `PeerRegistry`, `CallContext::peer`, off-reader dispatch, and pushed notifies. `serve_connection_with_cancel` works the same way, so a framework-hosted server drains exactly as [below](#draining-a-co-hosted-server).
+Everything a connection gets under `serve` it also gets here: connect/disconnect hooks, an attached `PeerRegistry`, `CallContext::peer`, off-reader dispatch, pushed notifies, and — via the captured `HandshakeContext` — `on_peer_connect_with_handshake`, so peers can be `alias`ed by an identity carried in the upgrade request just as they are under `serve`.
 
-Two things are the caller's responsibility, because they happen before repe is involved:
+Three things are the caller's responsibility, because they happen before repe is involved:
 
-- **The handshake.** Validate the upgrade request and answer `101` with the `derive_accept_key` of the client's `Sec-WebSocket-Key` — `derive_accept_key` is re-exported for that. `adopt_upgraded` reads nothing before the first REPE frame, so a stream whose handshake never completed surfaces as a protocol error on that one connection.
+- **The handshake.** Validate the request and answer `101` with the `derive_accept_key` of the client's `Sec-WebSocket-Key`. `adopt_upgraded` reads nothing before the first REPE frame, so a botched handshake that produces garbage surfaces as a protocol error on that connection alone. The quieter shape is a client still waiting for a `101` that never came: neither side speaks, and repe applies no read timeout or idle deadline, so the framework's own upgrade timeout is what bounds it.
 - **Path routing.** `adopt_upgraded` does no path validation, since the framework already routed the request to this handler. This is the counterpart to the `path` argument that `WebSocketServer::accept` takes.
+- **Draining.** The connection runs on a task the embedder spawned, and `axum::serve`'s graceful shutdown does not wait for upgraded connections. Serving through `serve_connection_with_cancel*` and a shared `ShutdownToken`, as above, is what gives you the cancellation half; see [below](#draining-a-co-hosted-server) for the rest.
 
-Only the *outbound* size guard is repe's to set on an adopted stream: inbound thresholds are fixed when the stream is constructed. That is why this constructor exists rather than leaving embedders to call `tokio_tungstenite`'s `from_raw_socket` themselves, which would silently substitute the transport defaults for the limits the server was built with. The `tokio_tungstenite` repe is built against is re-exported as `repe::tokio_tungstenite` for embedders who need to *name* `WebSocketStream` in their own signatures.
+`adopt_upgraded` is where the connection's inbound thresholds are fixed — they cannot be changed afterwards — which is why it exists rather than leaving you to call `tokio_tungstenite`'s `from_raw_socket`, whose defaults would silently replace the limits the server was built with. If your framework hands back the bytes it read past the request separately, as `(io, buffered)`, use `adopt_upgraded_partially_read(io, buffered)` instead: a client may legally pipeline its first frame with the upgrade request, and dropping those bytes loses a frame. (`hyper` replays them itself, so the plain call is right there.)
 
 ### Draining a co-hosted server
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,10 +134,14 @@ pub use websocket_server::{
     ConnectionError, HandshakeContext, SharedWebSocketServer, ShutdownToken, WebSocketServer,
     derive_accept_key, is_websocket_upgrade, proxy_connection,
 };
-/// The `tokio-tungstenite` this crate is built against, re-exported so an
-/// embedder handing repe a connection its own HTTP stack upgraded can name
-/// `WebSocketStream` at the matching version instead of guessing which
-/// requirement to add. Only needed to *name* the type — the value itself
-/// comes from [`SharedWebSocketServer::adopt_upgraded`], which infers it.
+// The `tokio-tungstenite` this crate is built against, so an embedder handing
+// repe a connection its own HTTP stack upgraded can name `WebSocketStream` (or
+// the `http` types behind `HandshakeContext::from_http_request`) at the matching
+// version instead of guessing which requirement to add.
+//
+// Deliberately a plain comment: rustdoc renders a bare `pub use <crate>;` as a
+// Re-exports table row with no description slot, so a doc comment here would not
+// reach a reader. The user-facing explanation lives on
+// `SharedWebSocketServer::adopt_upgraded` and in `docs/websocket.md`.
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use tokio_tungstenite;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,5 +132,12 @@ pub use websocket_limits::{DEFAULT_MAX_FRAME_SIZE, DEFAULT_MAX_MESSAGE_SIZE, Web
 #[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
 pub use websocket_server::{
     ConnectionError, HandshakeContext, SharedWebSocketServer, ShutdownToken, WebSocketServer,
-    is_websocket_upgrade, proxy_connection,
+    derive_accept_key, is_websocket_upgrade, proxy_connection,
 };
+/// The `tokio-tungstenite` this crate is built against, re-exported so an
+/// embedder handing repe a connection its own HTTP stack upgraded can name
+/// `WebSocketStream` at the matching version instead of guessing which
+/// requirement to add. Only needed to *name* the type — the value itself
+/// comes from [`SharedWebSocketServer::adopt_upgraded`], which infers it.
+#[cfg(all(feature = "websocket", not(target_arch = "wasm32")))]
+pub use tokio_tungstenite;

--- a/src/websocket_limits.rs
+++ b/src/websocket_limits.rs
@@ -31,12 +31,16 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 64 << 20;
 /// Size limits for one WebSocket connection.
 ///
 /// This is a repe-owned type rather than a re-export of the underlying
-/// transport's configuration struct. repe exposes no transport types in its
-/// public API, and keeping it that way means a transport version bump stays an
-/// internal detail instead of a repe breaking change. It also keeps the surface
-/// to the knobs that carry protocol meaning: buffer-tuning fields are
-/// deliberately absent, which additionally avoids the transport's habit of
-/// panicking on internally inconsistent buffer settings.
+/// transport's configuration struct, so the surface stays the knobs that carry
+/// protocol meaning: buffer-tuning fields are deliberately absent, which
+/// additionally avoids the transport's habit of panicking on internally
+/// inconsistent buffer settings.
+///
+/// The transport type itself does appear in repe's public API — `accept`,
+/// `proxy_connection`, and `adopt_upgraded` all name `WebSocketStream` — so a
+/// tokio-tungstenite major bump is a repe major bump regardless. The crate is
+/// re-exported as `repe::tokio_tungstenite` so an embedder can always name the
+/// matching version rather than guess it.
 ///
 /// # Example
 ///

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -37,12 +37,18 @@ use tokio_util::sync::CancellationToken;
 /// Derive the `Sec-WebSocket-Accept` response header value from a client's
 /// `Sec-WebSocket-Key`, per RFC 6455.
 ///
-/// Re-exported for an embedder answering the upgrade with its own HTTP
-/// stack before handing the connection to
-/// [`SharedWebSocketServer::adopt_upgraded`]. This is the one piece of the
-/// handshake that is easy to get subtly wrong, and getting it wrong is
-/// rejected by the *client*, not by this crate.
-pub use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+/// For an embedder answering the upgrade with its own HTTP stack before
+/// handing the connection to [`SharedWebSocketServer::adopt_upgraded`].
+/// This is the one piece of the handshake that is easy to get subtly
+/// wrong, and getting it wrong is rejected by the *client*, not by this
+/// crate.
+///
+/// A thin wrapper rather than a re-export of the transport's function, so
+/// this signature is repe's to keep stable across a transport version
+/// bump.
+pub fn derive_accept_key(sec_websocket_key: &[u8]) -> String {
+    tokio_tungstenite::tungstenite::handshake::derive_accept_key(sec_websocket_key)
+}
 
 type ConnectHook = Arc<dyn Fn(PeerHandle) + Send + Sync>;
 type ConnectCtxHook = Arc<dyn Fn(&PeerHandle, &HandshakeContext) + Send + Sync>;
@@ -221,8 +227,30 @@ pub struct HandshakeContext {
 }
 
 impl HandshakeContext {
-    /// Capture the parts of an upgrade [`Request`] an embedder may key on.
-    fn from_request(request: &Request) -> Self {
+    /// Capture the parts of an upgrade request an embedder may key on.
+    ///
+    /// Public for the embedder whose HTTP framework performed the upgrade
+    /// itself and who is serving the result through
+    /// [`SharedWebSocketServer::adopt_upgraded`]: repe never saw that
+    /// request, so it cannot capture the context on its own. Such a
+    /// handler is holding the whole request, which makes it the
+    /// best-positioned caller in the crate for the identity-keying this
+    /// type exists for. Pair it with
+    /// [`SharedWebSocketServer::serve_connection_with_handshake`].
+    ///
+    /// Generic over the body type so it accepts any `http::Request`,
+    /// whatever the framework parameterizes it with, and borrows rather
+    /// than consumes so the caller can still answer the upgrade with it.
+    /// The `http` version is the one this crate's transport is built
+    /// against, reachable as
+    /// `repe::tokio_tungstenite::tungstenite::http` if you need to name
+    /// it.
+    ///
+    /// Connections repe upgrades itself get this for free — the built-in
+    /// `serve*` loops and
+    /// [`WebSocketServer::accept_with_handshake`](WebSocketServer::accept_with_handshake)
+    /// capture it — so this is only for the adopted path.
+    pub fn from_http_request<T>(request: &tungstenite::http::Request<T>) -> Self {
         let uri = request.uri();
         let headers = request
             .headers()
@@ -996,22 +1024,66 @@ impl SharedWebSocketServer {
     /// `Upgrade`/`Connection`/`Sec-WebSocket-Version` and answering `101`
     /// with the [`derive_accept_key`] of the client's `Sec-WebSocket-Key`.
     /// Frameworks that expose the upgrade as an extractor do that part;
-    /// `derive_accept_key` is re-exported for those that hand back the raw
-    /// request. Nothing is read from `io` before the first REPE frame, so
-    /// passing a stream whose handshake never completed produces a
-    /// protocol error on that connection rather than corrupting others.
+    /// [`derive_accept_key`] is provided for those that hand back the raw
+    /// request. Path validation is the caller's too — the framework
+    /// already routed the request here, which is the counterpart to the
+    /// `path` argument [`WebSocketServer::accept`] takes.
     ///
-    /// Unlike a stream this crate upgraded, only the *outbound* guard is
-    /// this server's to set here — inbound thresholds are fixed at
-    /// construction, which is precisely why this constructor exists rather
-    /// than leaving embedders to call `from_raw_socket` with defaults and
-    /// silently lose their configured limits.
+    /// Nothing is read from `io` before the first REPE frame, so a stream
+    /// whose handshake produced garbage surfaces as a protocol error on
+    /// that connection alone. The other failure shape is quieter: if the
+    /// client is still waiting for a `101` that never came, neither side
+    /// speaks, and repe applies no read timeout or idle deadline — the
+    /// framework's own upgrade timeout is what bounds that.
+    ///
+    /// To *name* the returned type in your own signatures, the transport
+    /// crate is re-exported as `repe::tokio_tungstenite`; call sites that
+    /// pass the value straight to
+    /// [`serve_connection`](Self::serve_connection) never need to.
+    ///
+    /// This call is where the connection's inbound thresholds are fixed —
+    /// they cannot be changed afterwards — which is precisely why it
+    /// exists rather than leaving embedders to call the transport's
+    /// `from_raw_socket` themselves and silently substitute its defaults
+    /// for the limits the server was built with. The outbound guard
+    /// travels with the server config and applies on every path.
     pub async fn adopt_upgraded<S>(&self, io: S) -> WebSocketStream<S>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
         WebSocketStream::from_raw_socket(
             io,
+            tungstenite::protocol::Role::Server,
+            Some(self.config.limits.into()),
+        )
+        .await
+    }
+
+    /// [`adopt_upgraded`](Self::adopt_upgraded) for a framework that hands
+    /// back the bytes it read past the upgrade request separately from the
+    /// stream, as `(io, buffered)`.
+    ///
+    /// A client may legally pipeline its first frame with the upgrade
+    /// request, so those bytes can be real REPE traffic. `hyper` hides this
+    /// — its `Upgraded` replays what it buffered — but a framework that
+    /// returns the two halves separately needs somewhere to put them, and
+    /// dropping them loses a frame. Pass them here and they are decoded
+    /// ahead of anything read from `io`.
+    ///
+    /// Prefer [`adopt_upgraded`](Self::adopt_upgraded) when the stream
+    /// already replays its own leftovers; passing `buffered` bytes that
+    /// `io` will also yield would double-decode them.
+    pub async fn adopt_upgraded_partially_read<S>(
+        &self,
+        io: S,
+        buffered: Vec<u8>,
+    ) -> WebSocketStream<S>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        WebSocketStream::from_partially_read(
+            io,
+            buffered,
             tungstenite::protocol::Role::Server,
             Some(self.config.limits.into()),
         )
@@ -1028,7 +1100,7 @@ impl SharedWebSocketServer {
     /// some *other* HTTP stack upgraded — an `axum`/`hyper` route that
     /// answered the 101 itself — is served by wrapping its upgraded IO
     /// with [`adopt_upgraded`](Self::adopt_upgraded) and passing the
-    /// result here. See the crate docs on co-hosting.
+    /// result here.
     ///
     /// Connect/disconnect hooks (and any [`PeerRegistry`] attached via
     /// [`WebSocketServer::with_peer_registry`]) fire for connections
@@ -1916,7 +1988,7 @@ impl Callback for WebSocketPathValidator {
             // below without capturing).
             if let Some(slot) = &self.captured {
                 *slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                    Some(HandshakeContext::from_request(request));
+                    Some(HandshakeContext::from_http_request(request));
             }
             Ok(response)
         } else {
@@ -3727,7 +3799,7 @@ mod tests {
             .body(())
             .unwrap();
 
-        let ctx = HandshakeContext::from_request(&request);
+        let ctx = HandshakeContext::from_http_request(&request);
 
         // The ASCII header survives and stays case-insensitively addressable.
         assert_eq!(ctx.header("authorization"), Some("Bearer good-token"));
@@ -3752,7 +3824,7 @@ mod tests {
             .body(())
             .unwrap();
 
-        let ctx = HandshakeContext::from_request(&request);
+        let ctx = HandshakeContext::from_http_request(&request);
         let rendered = format!("{ctx:?}");
 
         // Neither secret value appears anywhere in the rendering.

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -20,6 +20,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
@@ -32,6 +33,16 @@ use tokio_tungstenite::tungstenite::handshake::server::{
 use tokio_tungstenite::tungstenite::{self, Message as WsMessage, http::StatusCode};
 use tokio_tungstenite::{WebSocketStream, accept_hdr_async_with_config};
 use tokio_util::sync::CancellationToken;
+
+/// Derive the `Sec-WebSocket-Accept` response header value from a client's
+/// `Sec-WebSocket-Key`, per RFC 6455.
+///
+/// Re-exported for an embedder answering the upgrade with its own HTTP
+/// stack before handing the connection to
+/// [`SharedWebSocketServer::adopt_upgraded`]. This is the one piece of the
+/// handshake that is easy to get subtly wrong, and getting it wrong is
+/// rejected by the *client*, not by this crate.
+pub use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
 
 type ConnectHook = Arc<dyn Fn(PeerHandle) + Send + Sync>;
 type ConnectCtxHook = Arc<dyn Fn(&PeerHandle, &HandshakeContext) + Send + Sync>;
@@ -965,10 +976,59 @@ impl SharedWebSocketServer {
         self.config.limits
     }
 
+    /// Wrap the raw IO of a connection **another HTTP stack already
+    /// upgraded** into a server-role [`WebSocketStream`] carrying this
+    /// server's configured [`WebSocketLimits`](crate::WebSocketLimits),
+    /// ready for [`serve_connection`](Self::serve_connection).
+    ///
+    /// This is the seam for an embedder whose HTTP routes live in a
+    /// framework (`axum`, `hyper`, `tower`) rather than in a hand-written
+    /// accept loop. Such an embedder already owns a `Router` with its own
+    /// paths on it and wants the REPE endpoint to be one more route,
+    /// answering the 101 through the framework's own upgrade machinery.
+    /// The peek-then-fork recipe (`is_websocket_upgrade` +
+    /// [`accept`](Self::accept)) cannot serve that shape, because it
+    /// requires repe to own the `TcpStream` before any HTTP is parsed.
+    /// Here the framework keeps the socket, performs the handshake, and
+    /// hands back the upgraded byte stream — which is what `io` is.
+    ///
+    /// The caller is responsible for the handshake itself: validating
+    /// `Upgrade`/`Connection`/`Sec-WebSocket-Version` and answering `101`
+    /// with the [`derive_accept_key`] of the client's `Sec-WebSocket-Key`.
+    /// Frameworks that expose the upgrade as an extractor do that part;
+    /// `derive_accept_key` is re-exported for those that hand back the raw
+    /// request. Nothing is read from `io` before the first REPE frame, so
+    /// passing a stream whose handshake never completed produces a
+    /// protocol error on that connection rather than corrupting others.
+    ///
+    /// Unlike a stream this crate upgraded, only the *outbound* guard is
+    /// this server's to set here — inbound thresholds are fixed at
+    /// construction, which is precisely why this constructor exists rather
+    /// than leaving embedders to call `from_raw_socket` with defaults and
+    /// silently lose their configured limits.
+    pub async fn adopt_upgraded<S>(&self, io: S) -> WebSocketStream<S>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        WebSocketStream::from_raw_socket(
+            io,
+            tungstenite::protocol::Role::Server,
+            Some(self.config.limits.into()),
+        )
+        .await
+    }
+
     /// Run one connection's reader/writer loop using this server's
     /// router, hooks, and capacities. Pair with
     /// [`WebSocketServer::accept`] to serve a stream the embedder
     /// accepted and upgraded itself.
+    ///
+    /// Generic over the underlying byte stream, so the connection need
+    /// not have come from a [`TcpStream`] this crate accepted. A stream
+    /// some *other* HTTP stack upgraded — an `axum`/`hyper` route that
+    /// answered the 101 itself — is served by wrapping its upgraded IO
+    /// with [`adopt_upgraded`](Self::adopt_upgraded) and passing the
+    /// result here. See the crate docs on co-hosting.
     ///
     /// Connect/disconnect hooks (and any [`PeerRegistry`] attached via
     /// [`WebSocketServer::with_peer_registry`]) fire for connections
@@ -979,7 +1039,10 @@ impl SharedWebSocketServer {
     /// [`CallContext::cancelled`](crate::CallContext::cancelled)) fire on
     /// disconnect. To also fire it on an embedder-driven shutdown, use
     /// [`serve_connection_with_cancel`](Self::serve_connection_with_cancel).
-    pub async fn serve_connection(&self, ws: WebSocketStream<TcpStream>) -> Result<(), RepeError> {
+    pub async fn serve_connection<S>(&self, ws: WebSocketStream<S>) -> Result<(), RepeError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         // No parent: the connection token is cancelled only when this
         // connection's reader exits (disconnect). No captured handshake,
         // so on_peer_connect_with_handshake hooks do not fire.
@@ -993,11 +1056,14 @@ impl SharedWebSocketServer {
     /// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
     /// hooks fire for this connection. For a one-port co-hosting embedder
     /// that keys peers off the upgrade request.
-    pub async fn serve_connection_with_handshake(
+    pub async fn serve_connection_with_handshake<S>(
         &self,
-        ws: WebSocketStream<TcpStream>,
+        ws: WebSocketStream<S>,
         handshake: HandshakeContext,
-    ) -> Result<(), RepeError> {
+    ) -> Result<(), RepeError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         handle_connection_with_config(
             ws,
             Arc::clone(&self.config),
@@ -1019,11 +1085,14 @@ impl SharedWebSocketServer {
     /// shared one, so cancelling the shared token cancels every
     /// connection, and a single connection's disconnect cancels only its
     /// own child.
-    pub async fn serve_connection_with_cancel(
+    pub async fn serve_connection_with_cancel<S>(
         &self,
-        ws: WebSocketStream<TcpStream>,
+        ws: WebSocketStream<S>,
         shutdown: &ShutdownToken,
-    ) -> Result<(), RepeError> {
+    ) -> Result<(), RepeError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         handle_connection_with_config(ws, Arc::clone(&self.config), shutdown.child_token(), None)
             .await
     }
@@ -1035,12 +1104,15 @@ impl SharedWebSocketServer {
     /// handlers down, and
     /// [`on_peer_connect_with_handshake`](WebSocketServer::on_peer_connect_with_handshake)
     /// hooks fire from the captured `handshake`.
-    pub async fn serve_connection_with_cancel_and_handshake(
+    pub async fn serve_connection_with_cancel_and_handshake<S>(
         &self,
-        ws: WebSocketStream<TcpStream>,
+        ws: WebSocketStream<S>,
         handshake: HandshakeContext,
         shutdown: &ShutdownToken,
-    ) -> Result<(), RepeError> {
+    ) -> Result<(), RepeError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         handle_connection_with_config(
             ws,
             Arc::clone(&self.config),
@@ -1191,12 +1263,15 @@ async fn accept_repe_websocket(
     Ok((ws, handshake))
 }
 
-async fn handle_connection_with_config(
-    ws_stream: WebSocketStream<TcpStream>,
+async fn handle_connection_with_config<S>(
+    ws_stream: WebSocketStream<S>,
     config: Arc<ConnectionConfig>,
     conn_token: CancellationToken,
     handshake: Option<HandshakeContext>,
-) -> Result<(), RepeError> {
+) -> Result<(), RepeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
     let (outbound_tx, outbound_rx) = mpsc::channel::<Message>(config.outbound_capacity);
 
     let peer_id_value = config.peer_id_counter.fetch_add(1, Ordering::Relaxed);
@@ -1314,12 +1389,15 @@ struct ConnDispatch {
     on_error: Arc<Vec<ErrorHook>>,
 }
 
-async fn reader_task(
-    mut ws_reader: SplitStream<WebSocketStream<TcpStream>>,
+async fn reader_task<S>(
+    mut ws_reader: SplitStream<WebSocketStream<S>>,
     router: &Router,
     conn: ConnDispatch,
     offreader_sem: Option<Arc<Semaphore>>,
-) -> Result<(), RepeError> {
+) -> Result<(), RepeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     // One signal shared by every inline dispatch on this connection; the
     // off-reader path builds its own owned clone per spawned handler.
     let inline_signal = TokenSignal(conn.conn_token.clone());
@@ -1550,13 +1628,16 @@ fn frame_outbound(
     Some(replacement.into_wire_bytes())
 }
 
-async fn writer_task(
-    mut ws_writer: SplitSink<WebSocketStream<TcpStream>, WsMessage>,
+async fn writer_task<S>(
+    mut ws_writer: SplitSink<WebSocketStream<S>, WsMessage>,
     mut outbound_rx: mpsc::Receiver<Message>,
     mut shutdown_rx: oneshot::Receiver<()>,
     limits: crate::WebSocketLimits,
     on_error: Arc<Vec<ErrorHook>>,
-) -> Result<(), RepeError> {
+) -> Result<(), RepeError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let mut result: Result<(), RepeError> = Ok(());
     loop {
         tokio::select! {

--- a/tests/websocket_adopt_upgraded.rs
+++ b/tests/websocket_adopt_upgraded.rs
@@ -44,7 +44,9 @@ async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<(TcpStream, h
 
     let mut request_line = String::new();
     if reader.read_line(&mut request_line).await? == 0 {
-        return Err(std::io::Error::other("client closed before the request line"));
+        return Err(std::io::Error::other(
+            "client closed before the request line",
+        ));
     }
     let target = request_line
         .split_whitespace()
@@ -341,8 +343,11 @@ async fn an_adopted_connection_enforces_the_outbound_guard() {
         Ok(json!({ "data": "x".repeat(len) }))
     });
     let small = WebSocketLimits::default().with_assumed_peer_frame_limit(Some(4096));
-    let (addr, _) =
-        spawn_adopting_server(WebSocketServer::new(router).with_limits(small), Serve::Plain).await;
+    let (addr, _) = spawn_adopting_server(
+        WebSocketServer::new(router).with_limits(small),
+        Serve::Plain,
+    )
+    .await;
 
     let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
         .await
@@ -432,7 +437,9 @@ async fn buffered_bytes_are_decoded_before_the_stream() {
 
     let (server_io, client_io) = tokio::io::duplex(64 * 1024);
     let shared = WebSocketServer::new(echo_router()).into_shared();
-    let ws = shared.adopt_upgraded_partially_read(server_io, pipelined).await;
+    let ws = shared
+        .adopt_upgraded_partially_read(server_io, pipelined)
+        .await;
     tokio::spawn(async move { shared.serve_connection(ws).await });
 
     // The client never sent that request over the socket, yet the response

--- a/tests/websocket_adopt_upgraded.rs
+++ b/tests/websocket_adopt_upgraded.rs
@@ -1,0 +1,243 @@
+#![cfg(feature = "websocket")]
+//! Serving a connection whose upgrade this crate did not perform.
+//!
+//! The shipped one-port recipe (`is_websocket_upgrade` + `WebSocketServer::accept`)
+//! requires repe to own the `TcpStream` before any HTTP is parsed, so it cannot
+//! serve an embedder whose routes live in an HTTP framework: that framework owns
+//! the socket and answers the 101 itself. These tests cover the other direction —
+//! the framework hands back an already-upgraded byte stream and repe adopts it.
+//!
+//! No HTTP framework is a dependency here, so the "framework" is hand-rolled:
+//! the 101 is written by the test, exactly as `axum`/`hyper` would write it.
+//! That keeps the test an executable spec of the recipe rather than a test of
+//! somebody else's upgrade machinery.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use repe::server::Router;
+use repe::{
+    Message, PeerRegistry, QueryFormat, WebSocketClient, WebSocketLimits, WebSocketServer,
+    derive_accept_key,
+};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+fn echo_router() -> Router {
+    Router::new().with_json("/echo", |payload: Value| Ok(json!({ "saw": payload })))
+}
+
+/// Read the upgrade request off `stream` and answer `101`, the way an HTTP
+/// framework's WebSocket route does, returning the stream positioned at the
+/// first WebSocket frame. Deliberately minimal: it trusts the client to be a
+/// well-formed REPE client, because what is under test is the adoption seam,
+/// not request parsing.
+async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<TcpStream> {
+    let mut reader = BufReader::new(stream);
+    let mut key = String::new();
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).await? == 0 {
+            return Err(std::io::Error::other("client closed mid-handshake"));
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break; // end of headers
+        }
+        if let Some(value) = line
+            .split_once(':')
+            .filter(|(name, _)| name.eq_ignore_ascii_case("sec-websocket-key"))
+            .map(|(_, value)| value.trim())
+        {
+            key = value.to_owned();
+        }
+    }
+
+    // `BufReader` may have buffered past the header block. It has not here (a
+    // REPE client sends no frame until the 101 arrives), so unwrapping back to
+    // the raw stream cannot drop buffered frame bytes.
+    assert!(
+        reader.buffer().is_empty(),
+        "client sent frames before the 101; the recipe would lose them"
+    );
+    let mut stream = reader.into_inner();
+
+    let accept = derive_accept_key(key.as_bytes());
+    stream
+        .write_all(
+            format!(
+                "HTTP/1.1 101 Switching Protocols\r\n\
+                 Upgrade: websocket\r\n\
+                 Connection: Upgrade\r\n\
+                 Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            )
+            .as_bytes(),
+        )
+        .await?;
+    Ok(stream)
+}
+
+/// Bind an ephemeral port whose connections are upgraded by the test and then
+/// adopted by `server`, and return the address to point a client at.
+async fn spawn_adopting_server(server: WebSocketServer) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let shared = server.into_shared();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let shared = shared.clone();
+            tokio::spawn(async move {
+                let Ok(stream) = hand_rolled_upgrade(stream).await else {
+                    return;
+                };
+                let ws = shared.adopt_upgraded(stream).await;
+                let _ = shared.serve_connection(ws).await;
+            });
+        }
+    });
+    addr
+}
+
+/// The headline case: a connection repe never handshook serves requests exactly
+/// like one it accepted itself.
+#[tokio::test]
+async fn an_adopted_connection_serves_requests() {
+    let addr = spawn_adopting_server(WebSocketServer::new(echo_router())).await;
+    let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+        .await
+        .expect("connect");
+
+    let got: Value = client
+        .call_typed_json::<_, _, Value>("/echo", &json!({ "n": 7 }))
+        .await
+        .expect("call");
+    assert_eq!(got["saw"]["n"], 7);
+
+    // Not a one-shot: the reader/writer pair keeps running on the adopted
+    // stream the same as on an accepted one.
+    let again: Value = client
+        .call_typed_json::<_, _, Value>("/echo", &json!({ "n": 8 }))
+        .await
+        .expect("second call");
+    assert_eq!(again["saw"]["n"], 8);
+}
+
+/// Push works on an adopted connection: connect hooks fire and an attached
+/// `PeerRegistry` sees the peer, so a server-push consumer is not restricted to
+/// connections repe accepted. This is the property that makes the seam useful
+/// rather than merely present.
+#[tokio::test]
+async fn hooks_and_the_peer_registry_fire_on_an_adopted_connection() {
+    let peers = PeerRegistry::new();
+    let connects = Arc::new(AtomicUsize::new(0));
+    let connects_hook = Arc::clone(&connects);
+
+    let addr = spawn_adopting_server(
+        WebSocketServer::new(echo_router())
+            .with_peer_registry(peers.clone())
+            .on_peer_connect(move |_peer| {
+                connects_hook.fetch_add(1, Ordering::SeqCst);
+            }),
+    )
+    .await;
+
+    let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+        .await
+        .expect("connect");
+    // Round-trip first: the connect hook runs before traffic is processed, so a
+    // completed call proves it has already fired without polling for it.
+    let _: Value = client
+        .call_typed_json::<_, _, Value>("/echo", &json!({}))
+        .await
+        .expect("call");
+
+    assert_eq!(connects.load(Ordering::SeqCst), 1);
+    assert_eq!(peers.len(), 1, "the adopted peer should be registered");
+
+    let delivered = peers
+        .broadcast_notify_json("/ping", &json!({ "hello": true }))
+        .expect("encode notify");
+    assert_eq!(delivered.len(), 1);
+    assert!(
+        delivered.values().all(Result::is_ok),
+        "a notify should reach a peer on an adopted connection: {delivered:?}"
+    );
+}
+
+/// `adopt_upgraded` exists so the server's configured limits reach a connection
+/// it did not handshake. Calling `from_raw_socket` directly would silently use
+/// the transport defaults, so this asserts the outbound guard — the half that is
+/// repe's own on an already-upgraded stream — is the one that was configured.
+#[tokio::test]
+async fn an_adopted_connection_carries_the_servers_configured_limits() {
+    let router = Router::new().with_json("/blob", |payload: Value| {
+        let len = payload.get("len").and_then(Value::as_u64).unwrap_or(0) as usize;
+        Ok(json!({ "data": "x".repeat(len) }))
+    });
+    let small = WebSocketLimits::default().with_assumed_peer_frame_limit(Some(4096));
+    let addr = spawn_adopting_server(WebSocketServer::new(router).with_limits(small)).await;
+
+    let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+        .await
+        .expect("connect");
+    let err = client
+        .call_typed_json::<_, _, Value>("/blob", &json!({ "len": 64 * 1024 }))
+        .await
+        .expect_err("the configured outbound guard must refuse this response");
+    assert!(
+        err.to_string().contains("assumed peer frame limit"),
+        "the refusal should name the guard, got: {err}"
+    );
+}
+
+/// The API change itself: the serving path is generic over the byte stream, so
+/// a connection that is not a `TcpStream` at all can be served. An in-memory
+/// duplex stands in for the `hyper::upgrade::Upgraded` an embedder actually has
+/// — neither is a socket this crate accepted, which is the whole point.
+#[tokio::test]
+async fn a_connection_that_is_not_a_tcp_stream_can_be_served() {
+    // Through repe's own re-export, which is how an embedder names these
+    // types at the version repe is built against.
+    use repe::tokio_tungstenite::WebSocketStream;
+    use repe::tokio_tungstenite::tungstenite::Message as WsMessage;
+    use repe::tokio_tungstenite::tungstenite::protocol::Role;
+
+    use futures_util::{SinkExt, StreamExt};
+
+    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+    let shared = WebSocketServer::new(echo_router()).into_shared();
+    let ws = shared.adopt_upgraded(server_io).await;
+    tokio::spawn(async move { shared.serve_connection(ws).await });
+
+    // The server side skipped the handshake, so the client must too; this is
+    // the same `from_raw_socket` pairing, in the client role.
+    let mut client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+
+    let request = Message::builder()
+        .id(1)
+        .query_format(QueryFormat::JsonPointer)
+        .query_str("/echo")
+        .body_json(&json!({ "n": 9 }))
+        .expect("body")
+        .build();
+    client
+        .send(WsMessage::Binary(request.into_wire_bytes()))
+        .await
+        .expect("send");
+
+    let frame = client
+        .next()
+        .await
+        .expect("a response frame")
+        .expect("frame is not an error");
+    let WsMessage::Binary(bytes) = frame else {
+        panic!("expected a binary REPE frame, got {frame:?}");
+    };
+    let response = Message::from_slice_exact(&bytes).expect("decode response");
+    let body: Value = response.json_body().expect("json body");
+    assert_eq!(body["saw"]["n"], 9);
+}

--- a/tests/websocket_adopt_upgraded.rs
+++ b/tests/websocket_adopt_upgraded.rs
@@ -8,17 +8,21 @@
 //! the framework hands back an already-upgraded byte stream and repe adopts it.
 //!
 //! No HTTP framework is a dependency here, so the "framework" is hand-rolled:
-//! the 101 is written by the test, exactly as `axum`/`hyper` would write it.
-//! That keeps the test an executable spec of the recipe rather than a test of
-//! somebody else's upgrade machinery.
+//! the 101 is written by the test, exactly as `axum`/`hyper` would write it, and
+//! the request is reassembled into an `http::Request` so the handshake-keyed path
+//! is exercised through the same public API an embedder would use. That keeps
+//! these tests an executable spec of the recipe rather than a test of somebody
+//! else's upgrade machinery.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use repe::server::Router;
+use repe::tokio_tungstenite::tungstenite::http;
 use repe::{
-    Message, PeerRegistry, QueryFormat, WebSocketClient, WebSocketLimits, WebSocketServer,
-    derive_accept_key,
+    HandshakeContext, Message, PeerRegistry, QueryFormat, SharedWebSocketServer, ShutdownToken,
+    WebSocketClient, WebSocketLimits, WebSocketServer, derive_accept_key,
 };
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -29,12 +33,26 @@ fn echo_router() -> Router {
 }
 
 /// Read the upgrade request off `stream` and answer `101`, the way an HTTP
-/// framework's WebSocket route does, returning the stream positioned at the
-/// first WebSocket frame. Deliberately minimal: it trusts the client to be a
-/// well-formed REPE client, because what is under test is the adoption seam,
-/// not request parsing.
-async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<TcpStream> {
+/// framework's WebSocket route does. Returns the stream positioned at the first
+/// WebSocket frame, plus the request itself — which is what an embedder holds
+/// and can hand to `HandshakeContext::from_http_request`.
+///
+/// Deliberately minimal: it trusts the client to be a well-formed REPE client,
+/// because what is under test is the adoption seam, not request parsing.
+async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<(TcpStream, http::Request<()>)> {
     let mut reader = BufReader::new(stream);
+
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).await? == 0 {
+        return Err(std::io::Error::other("client closed before the request line"));
+    }
+    let target = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| std::io::Error::other("malformed request line"))?
+        .to_owned();
+
+    let mut builder = http::Request::builder().method("GET").uri(&target);
     let mut key = String::new();
     loop {
         let mut line = String::new();
@@ -45,21 +63,27 @@ async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<TcpStream> {
         if line.is_empty() {
             break; // end of headers
         }
-        if let Some(value) = line
-            .split_once(':')
-            .filter(|(name, _)| name.eq_ignore_ascii_case("sec-websocket-key"))
-            .map(|(_, value)| value.trim())
-        {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("sec-websocket-key") {
             key = value.to_owned();
         }
+        builder = builder.header(name, value);
     }
+    let request = builder
+        .body(())
+        .map_err(|err| std::io::Error::other(format!("rebuilding the request: {err}")))?;
 
     // `BufReader` may have buffered past the header block. It has not here (a
     // REPE client sends no frame until the 101 arrives), so unwrapping back to
-    // the raw stream cannot drop buffered frame bytes.
+    // the raw stream cannot drop buffered frame bytes. A framework that *can*
+    // buffer past the request hands those bytes back separately, which is what
+    // `adopt_upgraded_partially_read` is for.
     assert!(
         reader.buffer().is_empty(),
-        "client sent frames before the 101; the recipe would lose them"
+        "client pipelined frames with its upgrade; this helper would lose them"
     );
     let mut stream = reader.into_inner();
 
@@ -75,38 +99,63 @@ async fn hand_rolled_upgrade(stream: TcpStream) -> std::io::Result<TcpStream> {
             .as_bytes(),
         )
         .await?;
-    Ok(stream)
+    Ok((stream, request))
+}
+
+/// How the test's accept loop hands an upgraded connection to repe.
+#[derive(Clone, Copy)]
+enum Serve {
+    /// `serve_connection` — no captured handshake, no shared cancellation.
+    Plain,
+    /// `serve_connection_with_cancel_and_handshake` — the full-fidelity path an
+    /// embedder that keys peers off the upgrade and drains on shutdown uses.
+    WithHandshakeAndCancel,
 }
 
 /// Bind an ephemeral port whose connections are upgraded by the test and then
-/// adopted by `server`, and return the address to point a client at.
-async fn spawn_adopting_server(server: WebSocketServer) -> std::net::SocketAddr {
+/// adopted by `server`. Returns the address to point a client at, and the
+/// `ShutdownToken` those connections were served under.
+async fn spawn_adopting_server(
+    server: WebSocketServer,
+    mode: Serve,
+) -> (std::net::SocketAddr, ShutdownToken) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("addr");
     let shared = server.into_shared();
+    let shutdown = ShutdownToken::new();
+    let loop_shutdown = shutdown.clone();
     tokio::spawn(async move {
         loop {
             let Ok((stream, _)) = listener.accept().await else {
                 break;
             };
-            let shared = shared.clone();
+            let (shared, shutdown): (SharedWebSocketServer, ShutdownToken) =
+                (shared.clone(), loop_shutdown.clone());
             tokio::spawn(async move {
-                let Ok(stream) = hand_rolled_upgrade(stream).await else {
+                let Ok((stream, request)) = hand_rolled_upgrade(stream).await else {
                     return;
                 };
                 let ws = shared.adopt_upgraded(stream).await;
-                let _ = shared.serve_connection(ws).await;
+                let _ = match mode {
+                    Serve::Plain => shared.serve_connection(ws).await,
+                    Serve::WithHandshakeAndCancel => {
+                        let handshake = HandshakeContext::from_http_request(&request);
+                        shared
+                            .serve_connection_with_cancel_and_handshake(ws, handshake, &shutdown)
+                            .await
+                    }
+                };
             });
         }
     });
-    addr
+    (addr, shutdown)
 }
 
 /// The headline case: a connection repe never handshook serves requests exactly
 /// like one it accepted itself.
 #[tokio::test]
 async fn an_adopted_connection_serves_requests() {
-    let addr = spawn_adopting_server(WebSocketServer::new(echo_router())).await;
+    let (addr, _) = spawn_adopting_server(WebSocketServer::new(echo_router()), Serve::Plain).await;
     let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
         .await
         .expect("connect");
@@ -136,12 +185,13 @@ async fn hooks_and_the_peer_registry_fire_on_an_adopted_connection() {
     let connects = Arc::new(AtomicUsize::new(0));
     let connects_hook = Arc::clone(&connects);
 
-    let addr = spawn_adopting_server(
+    let (addr, _) = spawn_adopting_server(
         WebSocketServer::new(echo_router())
             .with_peer_registry(peers.clone())
             .on_peer_connect(move |_peer| {
                 connects_hook.fetch_add(1, Ordering::SeqCst);
             }),
+        Serve::Plain,
     )
     .await;
 
@@ -168,18 +218,131 @@ async fn hooks_and_the_peer_registry_fire_on_an_adopted_connection() {
     );
 }
 
-/// `adopt_upgraded` exists so the server's configured limits reach a connection
-/// it did not handshake. Calling `from_raw_socket` directly would silently use
-/// the transport defaults, so this asserts the outbound guard — the half that is
-/// repe's own on an already-upgraded stream — is the one that was configured.
+/// Teardown is the half that only runs on the way out, and it runs from a `Drop`
+/// guard, so it is worth asserting separately from the connect side: dropping
+/// the client must fire `on_peer_disconnect` and evict the peer.
 #[tokio::test]
-async fn an_adopted_connection_carries_the_servers_configured_limits() {
+async fn disconnect_teardown_runs_on_an_adopted_connection() {
+    let peers = PeerRegistry::new();
+    let disconnects = Arc::new(AtomicUsize::new(0));
+    let disconnects_hook = Arc::clone(&disconnects);
+
+    let (addr, _) = spawn_adopting_server(
+        WebSocketServer::new(echo_router())
+            .with_peer_registry(peers.clone())
+            .on_peer_disconnect(move |_id| {
+                disconnects_hook.fetch_add(1, Ordering::SeqCst);
+            }),
+        Serve::Plain,
+    )
+    .await;
+
+    {
+        let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+            .await
+            .expect("connect");
+        let _: Value = client
+            .call_typed_json::<_, _, Value>("/echo", &json!({}))
+            .await
+            .expect("call");
+        assert_eq!(peers.len(), 1);
+    }
+
+    wait_for(|| disconnects.load(Ordering::SeqCst) == 1 && peers.is_empty()).await;
+}
+
+/// The handshake-keyed path, which is the reason `HandshakeContext` is publicly
+/// constructible: an embedder holding the upgrade request captures it and repe
+/// fires `on_peer_connect_with_handshake`, so the peer can be `alias`ed by an
+/// identity that rode in the query string.
+#[tokio::test]
+async fn handshake_hooks_fire_when_the_embedder_captures_the_request() {
+    let peers = PeerRegistry::new();
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<(String, Option<String>)>::new()));
+    let seen_hook = Arc::clone(&seen);
+    let alias_peers = peers.clone();
+
+    let (addr, _) = spawn_adopting_server(
+        WebSocketServer::new(echo_router())
+            .with_peer_registry(peers.clone())
+            .on_peer_connect_with_handshake(move |peer, hs| {
+                seen_hook
+                    .lock()
+                    .expect("lock")
+                    .push((hs.path().to_owned(), hs.query().map(str::to_owned)));
+                if let Some(token) = hs.query().and_then(|q| q.strip_prefix("token=")) {
+                    alias_peers.alias(peer.peer_id(), token);
+                }
+            }),
+        Serve::WithHandshakeAndCancel,
+    )
+    .await;
+
+    let client = WebSocketClient::connect(&format!("ws://{addr}/repe?token=abc123"))
+        .await
+        .expect("connect");
+    let _: Value = client
+        .call_typed_json::<_, _, Value>("/echo", &json!({}))
+        .await
+        .expect("call");
+
+    let captured = seen.lock().expect("lock").clone();
+    assert_eq!(
+        captured,
+        vec![("/repe".to_owned(), Some("token=abc123".to_owned()))],
+        "the hook should see the path and query of the upgrade the embedder answered"
+    );
+    assert!(
+        peers.get_by("abc123").is_some(),
+        "the peer should be addressable by the key that rode in the handshake"
+    );
+}
+
+/// `adopt_upgraded` exists so the server's configured *inbound* thresholds reach
+/// a connection repe did not handshake — they are fixed when the stream is
+/// constructed and cannot be set afterwards, so calling `from_raw_socket`
+/// directly would silently substitute the transport defaults.
+///
+/// Asserted on the constructed stream rather than through behavior, because
+/// nothing observable from a client distinguishes the two: the outbound guard
+/// (the next test) is threaded separately from `config.limits` and would pass
+/// either way. Dropping the config argument in `adopt_upgraded` leaves the rest
+/// of the suite green; this is the test that fails.
+#[tokio::test]
+async fn adopt_upgraded_fixes_the_servers_configured_inbound_thresholds() {
+    let limits = WebSocketLimits::default()
+        .with_max_incoming_frame_size(Some(4096))
+        .with_max_incoming_message_size(Some(8192));
+    let shared = WebSocketServer::new(echo_router())
+        .with_limits(limits)
+        .into_shared();
+
+    let (server_io, _client_io) = tokio::io::duplex(1024);
+    let ws = shared.adopt_upgraded(server_io).await;
+    assert_eq!(ws.get_config().max_frame_size, Some(4096));
+    assert_eq!(ws.get_config().max_message_size, Some(8192));
+
+    // Same for the partially-read sibling, which takes the identical path.
+    let (server_io, _client_io) = tokio::io::duplex(1024);
+    let ws = shared
+        .adopt_upgraded_partially_read(server_io, Vec::new())
+        .await;
+    assert_eq!(ws.get_config().max_frame_size, Some(4096));
+    assert_eq!(ws.get_config().max_message_size, Some(8192));
+}
+
+/// The outbound guard reaches an adopted connection too. This one *is*
+/// observable from a client, because an oversized response is refused and
+/// substituted rather than sent.
+#[tokio::test]
+async fn an_adopted_connection_enforces_the_outbound_guard() {
     let router = Router::new().with_json("/blob", |payload: Value| {
         let len = payload.get("len").and_then(Value::as_u64).unwrap_or(0) as usize;
         Ok(json!({ "data": "x".repeat(len) }))
     });
     let small = WebSocketLimits::default().with_assumed_peer_frame_limit(Some(4096));
-    let addr = spawn_adopting_server(WebSocketServer::new(router).with_limits(small)).await;
+    let (addr, _) =
+        spawn_adopting_server(WebSocketServer::new(router).with_limits(small), Serve::Plain).await;
 
     let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
         .await
@@ -194,50 +357,154 @@ async fn an_adopted_connection_carries_the_servers_configured_limits() {
     );
 }
 
+/// Cancelling the shared token winds an adopted connection down, which is what
+/// makes the documented drain story true for a framework-hosted server: its
+/// connections run on tasks the framework's own graceful shutdown never awaits.
+#[tokio::test]
+async fn cancelling_the_shared_token_winds_down_an_adopted_connection() {
+    let peers = PeerRegistry::new();
+    let (addr, shutdown) = spawn_adopting_server(
+        WebSocketServer::new(echo_router()).with_peer_registry(peers.clone()),
+        Serve::WithHandshakeAndCancel,
+    )
+    .await;
+
+    let client = WebSocketClient::connect(&format!("ws://{addr}/repe"))
+        .await
+        .expect("connect");
+    let _: Value = client
+        .call_typed_json::<_, _, Value>("/echo", &json!({}))
+        .await
+        .expect("call");
+    assert_eq!(peers.len(), 1);
+
+    shutdown.cancel();
+
+    // The reader stops on the cancelled token and teardown runs, evicting the
+    // peer without the client having disconnected.
+    wait_for(|| peers.is_empty()).await;
+}
+
 /// The API change itself: the serving path is generic over the byte stream, so
 /// a connection that is not a `TcpStream` at all can be served. An in-memory
 /// duplex stands in for the `hyper::upgrade::Upgraded` an embedder actually has
 /// — neither is a socket this crate accepted, which is the whole point.
 #[tokio::test]
 async fn a_connection_that_is_not_a_tcp_stream_can_be_served() {
-    // Through repe's own re-export, which is how an embedder names these
-    // types at the version repe is built against.
-    use repe::tokio_tungstenite::WebSocketStream;
-    use repe::tokio_tungstenite::tungstenite::Message as WsMessage;
-    use repe::tokio_tungstenite::tungstenite::protocol::Role;
-
-    use futures_util::{SinkExt, StreamExt};
-
     let (server_io, client_io) = tokio::io::duplex(64 * 1024);
     let shared = WebSocketServer::new(echo_router()).into_shared();
     let ws = shared.adopt_upgraded(server_io).await;
     tokio::spawn(async move { shared.serve_connection(ws).await });
 
-    // The server side skipped the handshake, so the client must too; this is
-    // the same `from_raw_socket` pairing, in the client role.
-    let mut client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+    let mut client = raw_client(client_io).await;
+    assert_eq!(round_trip(&mut client, 9).await["saw"]["n"], 9);
+}
 
-    let request = Message::builder()
-        .id(1)
-        .query_format(QueryFormat::JsonPointer)
-        .query_str("/echo")
-        .body_json(&json!({ "n": 9 }))
-        .expect("body")
-        .build();
-    client
-        .send(WsMessage::Binary(request.into_wire_bytes()))
-        .await
-        .expect("send");
+/// Bytes a framework read past the upgrade request are decoded ahead of the
+/// stream, so a client that pipelines its first frame with the handshake does
+/// not lose it. The plain `adopt_upgraded` has nowhere to put them.
+#[tokio::test]
+async fn buffered_bytes_are_decoded_before_the_stream() {
+    use futures_util::StreamExt;
+    use repe::tokio_tungstenite::WebSocketStream;
+    use repe::tokio_tungstenite::tungstenite::Message as WsMessage;
+    use repe::tokio_tungstenite::tungstenite::protocol::Role;
 
+    // Frame a request the way a client would, then hand those bytes to the
+    // server as "already read past the request" rather than writing them.
+    let (encoder_io, mut sink) = tokio::io::duplex(64 * 1024);
+    let mut encoder = WebSocketStream::from_raw_socket(encoder_io, Role::Client, None).await;
+    {
+        use futures_util::SinkExt;
+        encoder
+            .send(WsMessage::Binary(request_bytes(11)))
+            .await
+            .expect("frame the request");
+    }
+    let pipelined = {
+        use tokio::io::AsyncReadExt;
+        let mut buf = vec![0u8; 4096];
+        let n = sink.read(&mut buf).await.expect("read framed bytes");
+        buf.truncate(n);
+        buf
+    };
+    assert!(!pipelined.is_empty());
+
+    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+    let shared = WebSocketServer::new(echo_router()).into_shared();
+    let ws = shared.adopt_upgraded_partially_read(server_io, pipelined).await;
+    tokio::spawn(async move { shared.serve_connection(ws).await });
+
+    // The client never sent that request over the socket, yet the response
+    // arrives — the buffered bytes were decoded.
+    let mut client = raw_client(client_io).await;
     let frame = client
         .next()
         .await
         .expect("a response frame")
         .expect("frame is not an error");
+    assert_eq!(decode(frame)["saw"]["n"], 11);
+}
+
+// ---- helpers for the handshake-free (raw stream) tests ----
+
+type RawClient = repe::tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>;
+
+/// A client on a stream whose handshake was skipped, pairing with the server
+/// side's `adopt_upgraded`.
+async fn raw_client(io: tokio::io::DuplexStream) -> RawClient {
+    use repe::tokio_tungstenite::WebSocketStream;
+    use repe::tokio_tungstenite::tungstenite::protocol::Role;
+    WebSocketStream::from_raw_socket(io, Role::Client, None).await
+}
+
+/// The wire bytes of an `/echo` request carrying `{"n": n}`.
+fn request_bytes(n: u64) -> Vec<u8> {
+    Message::builder()
+        .id(1)
+        .query_format(QueryFormat::JsonPointer)
+        .query_str("/echo")
+        .body_json(&json!({ "n": n }))
+        .expect("body")
+        .build()
+        .into_wire_bytes()
+}
+
+fn decode(frame: repe::tokio_tungstenite::tungstenite::Message) -> Value {
+    use repe::tokio_tungstenite::tungstenite::Message as WsMessage;
     let WsMessage::Binary(bytes) = frame else {
         panic!("expected a binary REPE frame, got {frame:?}");
     };
-    let response = Message::from_slice_exact(&bytes).expect("decode response");
-    let body: Value = response.json_body().expect("json body");
-    assert_eq!(body["saw"]["n"], 9);
+    Message::from_slice_exact(&bytes)
+        .expect("decode response")
+        .json_body()
+        .expect("json body")
+}
+
+async fn round_trip(client: &mut RawClient, n: u64) -> Value {
+    use futures_util::{SinkExt, StreamExt};
+    use repe::tokio_tungstenite::tungstenite::Message as WsMessage;
+    client
+        .send(WsMessage::Binary(request_bytes(n)))
+        .await
+        .expect("send");
+    let frame = client
+        .next()
+        .await
+        .expect("a response frame")
+        .expect("frame is not an error");
+    decode(frame)
+}
+
+/// Poll `cond` until it holds. Teardown runs on the connection's own task, so
+/// there is no completion to await from here; the alternative is a fixed sleep,
+/// which is both slower and flakier.
+async fn wait_for(cond: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if cond() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("condition did not hold within 2s");
 }


### PR DESCRIPTION
## The gap

The shipped one-port recipe (`is_websocket_upgrade` + `WebSocketServer::accept` + `serve_connection`, 3.2.0) requires repe to own the `TcpStream` before any HTTP is parsed. That excludes the shape an embedder actually has when its routes already live in an HTTP framework: an `axum` `Router` holding `/healthz` and a few `/api/*` routes, wanting the REPE endpoint to be one more route on it. There the framework owns the socket and answers the `101`, so repe never sees a `TcpStream`.

No entry point accepted an already-upgraded stream, at any price — `serve_connection` and its three siblings were concrete over `WebSocketStream<TcpStream>`. So such an embedder had two options: run a REPE endpoint on a second port, or abandon the framework's serving path for a hand-written accept loop and feed non-WS streams back into its `Router` through hyper glue.

The restriction was incidental rather than principled: the connection loop never calls a `TcpStream` method (no `peer_addr`, `local_addr`, or `get_ref`), and `proxy_connection` was already generic over `S`.

## The change

- **`SharedWebSocketServer::adopt_upgraded(io)`** — wraps an already-upgraded byte stream into a server-role `WebSocketStream`. This call is where the connection's inbound thresholds are fixed; it exists rather than pointing embedders at `from_raw_socket`, whose defaults would silently replace the limits the server was built with.
- **`adopt_upgraded_partially_read(io, buffered)`** — for a framework that returns the bytes it read past the upgrade request separately. A client may legally pipeline its first frame with the handshake; `hyper` replays those itself, but a framework handing back `(io, buffered)` has nowhere else to put them.
- **`serve_connection` + its three siblings are generic** over `S: AsyncRead + AsyncWrite + Unpin + Send + 'static`.
- **`HandshakeContext::from_http_request(&req)`** — the type had no public constructor, so `on_peer_connect_with_handshake` could not fire on a connection repe did not accept. Generic over the body type and borrowing, so a framework handler can capture the request and still answer the upgrade with it.
- **`derive_accept_key`** — the `Sec-WebSocket-Accept` derivation an embedder answering the upgrade itself needs. The one part of the handshake that is easy to get subtly wrong, and whose wrong answer is rejected by the client, not by this crate. A thin wrapper, not a re-export, so the signature is repe's to keep stable.
- **`repe::tokio_tungstenite`** — needed only to *name* `WebSocketStream` (or the `http` types behind `from_http_request`) in an embedder's own signatures.

Everything a connection gets under `serve` it also gets when adopted: connect/disconnect hooks, `PeerRegistry`, `CallContext::peer`, off-reader dispatch, pushed notifies, handshake-keyed aliasing, and `ShutdownToken` draining.

## Notably not R2

`dev/http-cohosting-and-keyed-peer-registry.md` parked "repe grows a co-hosted HTTP route table" (R2) pending a second consumer. This resolves the framework case **without** it: repe does not grow an HTTP surface, it accepts a stream from whatever already serves HTTP. R2 stays parked, now needed only by an embedder that wants co-hosted HTTP with no framework at all. `dev/tls-support.md` is also updated — the serving half of its blocker #1 has landed, generalized in place rather than as the `serve_connection_on<S>` sibling it proposed.

## Verification

`tests/websocket_adopt_upgraded.rs`, 9 tests: requests over an adopted connection; connect hooks and `PeerRegistry`; disconnect teardown; handshake-keyed aliasing through `from_http_request`; the configured inbound thresholds; the outbound guard; shared-token drain; a connection that is **not** a `TcpStream` (in-memory duplex, standing in for `hyper::upgrade::Upgraded`); and pipelined bytes decoded ahead of the stream. The upgrade is hand-rolled from `derive_accept_key` and the request reassembled into an `http::Request`, so the file is an executable spec of the recipe with no framework dependency.

The axum recipe in the docs was compiled and run end-to-end against real axum 0.8 / hyper 1 / hyper-util 0.1 — sibling HTTP route, REPE round-trip on one port, handshake-keyed alias, and drain — in a throwaway crate, following the existing practice (`/bench/`) of keeping heavy-dependency check crates out of dev-dependencies.

Full suite green at `--all-features`; `cargo clippy --all-features --all-targets` clean; `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

## Review round

A review of the first commit found three real defects, all fixed in `7f70e2a`:

- **The limits test tested nothing.** It asserted on `assumed_peer_frame_limit`, which the writer task threads separately from `config.limits` and which never touches the `WebSocketStream`'s config. Replacing `Some(self.config.limits.into())` with `None` left the whole suite green. It now asserts `get_config()` directly and fails on that mutation, with the 16 MiB transport default in place of the configured 4096.
- **The two `*_with_handshake` methods were generic but uncallable** for any `S != TcpStream`, and the docs claimed the opposite. Fixed by making `HandshakeContext` constructible.
- **The limits doc paragraph said the inverse of what the code does** — it described `adopt_upgraded` as not setting inbound thresholds, when that call is exactly where they are fixed. The wording had been lifted from `proxy_connection_with_limits`, where it is correct.

Also from that round: `derive_accept_key` became a wrapper because rustdoc was concatenating tungstenite's doc onto ours and rendering broken `crate::`-relative markdown on a public page; the axum snippet gained drain, version validation, error handling, and a note on why it avoids `axum::extract::ws::WebSocketUpgrade`; and `WebSocketLimits`' claim that repe "exposes no transport types in its public API" was corrected.

## Compatibility

Additive; a minor bump. The CHANGELOG entry sits under `## [Unreleased]` and the version is left to the usual separate release commit. Existing `serve_connection(ws)` calls compile unchanged — `TcpStream` satisfies the bound and is inferred from the argument. Only a caller who named one of these as a function item or turbofished it is affected.

**Not included:** bumping tokio-tungstenite off 0.24. It isn't needed here — the axum path goes through `hyper::upgrade::OnUpgrade` and never touches axum's own tungstenite, which the compile check confirms. Making `accept*` generic (the other half of `dev/tls-support.md` blocker #1) is likewise left as a follow-up.
