### PR TITLE
Update beve to 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **The lockfile resolves `beve` to 7.3.0** (from 7.1.0). The requirement in `Cargo.toml` stays `beve = "7"`, which already admitted it, so this is lockfile-only and downstreams resolve their own — but unlike the last bump, this one is not inert. 7.2.0 and 7.3.0 carry fixes and a behavior change that reach code repe calls.
+
+  Every bulk primitive repe names directly is untouched. `to_writer_complex_slice`, `complex_slice_size`, `read_complex_slice`, `read_typed_slice`, and the aligned typed-slice family all live in beve's `fast` module, whose only diff across these two releases is a doc comment. `MessageBuilder::body_complex_slice`, `write_message_complex_slice`, and the SVS bulk modes emit and accept the same bytes they did on 7.1.0. (7.2.0's headline "complex arrays in one bulk copy" speedup is about beve's `serde(with)` helpers; `to_writer_complex_slice` was already a single `write_all`.)
+
+  What does reach repe is the generic serde path — `to_writer_streaming` / `from_reader_streaming` behind SVS value mode, and `from_slice` / `to_vec` behind every JSON-or-BEVE body — where the payload type is the caller's:
+
+  - **An untrusted element count can no longer abort the process** (beve 7.3.0). The `beve::typed::*` and `beve::complex_array::*` visitors sized their result `Vec` from a sequence `size_hint` taken straight off the wire, so a 27-byte body claiming 2^55 elements reached `Vec::with_capacity`, which aborts rather than returning an error. A repe server decodes bodies it did not write, so a handler whose payload struct carries either annotation was one malformed frame away from an abort no `Result` could catch. The reserve is now capped at 8 MiB and grows with what actually arrives.
+
+  - **`Complex<f16>` and `Complex<bf16>` survive SVS value mode** (beve 7.2.0). `to_writer_streaming` rejected every `Complex<bf16>` as `Mismatch("invalid complex payload size")`, and `from_reader_streaming` refused both half widths as `Unsupported("unsupported complex float width")` — so a value-mode stream of a type holding either field failed at the producer or the consumer, on payloads the buffered codec handled. Both now decode the four float widths the slice deserializer always has.
+
+  - **A complex array whose component class differs from the field's now decodes** through serde instead of returning `Error::Mismatch` (beve 7.3.0) — a complex `i16` payload into a `Vec<Complex<f32>>` field converts in one pass. This is a loosening, so anything that leaned on the old strictness as a schema check needs its own check. `Message::complex_slice` is deliberately *not* part of this: it calls `read_complex_slice`, where naming `T` is the whole interface and a class mismatch is still an error. The two disagreeing is intended, not an oversight.
+
+  The `mat` feature moved to hdf5-pure 0.39 over the same span, which repe does not enable.
+
+  The `wasm-tests` lockfiles move in step, and pick up the stale `repe` path-dep version they still recorded as 7.0.2.
+
 ## [7.1.0] - 2026-08-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "beve"
-version = "7.1.0"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5b2bf165b993a52802d2dcbfb77d8834a083928a306002d14f1261b9d588e1"
+checksum = "891c827e7345c15e79140e300d751276ad1ebd64b24c40b01c98f097d1652606"
 dependencies = [
  "bytemuck",
  "half",

--- a/wasm-tests/client/Cargo.lock
+++ b/wasm-tests/client/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "beve"
-version = "7.1.0"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5b2bf165b993a52802d2dcbfb77d8834a083928a306002d14f1261b9d588e1"
+checksum = "891c827e7345c15e79140e300d751276ad1ebd64b24c40b01c98f097d1652606"
 dependencies = [
  "bytemuck",
  "half",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "repe"
-version = "7.0.2"
+version = "7.1.0"
 dependencies = [
  "beve",
  "futures-channel",

--- a/wasm-tests/server/Cargo.lock
+++ b/wasm-tests/server/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "beve"
-version = "7.1.0"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5b2bf165b993a52802d2dcbfb77d8834a083928a306002d14f1261b9d588e1"
+checksum = "891c827e7345c15e79140e300d751276ad1ebd64b24c40b01c98f097d1652606"
 dependencies = [
  "bytemuck",
  "half",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "repe"
-version = "7.0.2"
+version = "7.1.0"
 dependencies = [
  "beve",
  "repe-derive",


### PR DESCRIPTION
Lockfile-only: the requirement in `Cargo.toml` stays `beve = "7"`, which already admitted 7.3.0, so downstreams resolve their own. Unlike the 7.0.1 bump, this one is not inert.

## What does not change

Every bulk primitive repe names directly — `to_writer_complex_slice`, `complex_slice_size`, `read_complex_slice`, `read_typed_slice`, and the aligned typed-slice family — lives in beve's `fast` module, whose only diff across 7.2.0 and 7.3.0 is a doc comment. `MessageBuilder::body_complex_slice`, `write_message_complex_slice`, and the SVS bulk modes emit and accept the same bytes they did on 7.1.0.

Worth naming because it is easy to misread: beve 7.2.0's headline "complex arrays in one bulk copy" speedup is about its `serde(with)` helpers. `to_writer_complex_slice` was already a single `write_all`, so repe's bulk complex path was never on the slow side of that change.

The `mat` feature moved to hdf5-pure 0.39 over the same span. repe does not enable it.

## What does change

The generic serde path — `to_writer_streaming` / `from_reader_streaming` behind SVS value mode, and `from_slice` / `to_vec` behind every JSON-or-BEVE body — where the payload type is the caller's:

- **An untrusted element count can no longer abort the process** (beve 7.3.0). The `beve::typed::*` and `beve::complex_array::*` visitors sized their result `Vec` from a sequence `size_hint` taken straight off the wire, so a 27-byte body claiming 2^55 elements reached `Vec::with_capacity`, which aborts rather than returning an error. A repe server decodes bodies it did not write, so a handler whose payload struct carries either annotation was one malformed frame away from an abort no `Result` could catch. The reserve is now capped at 8 MiB and grows with what actually arrives.

- **`Complex<f16>` and `Complex<bf16>` survive SVS value mode** (beve 7.2.0). `to_writer_streaming` rejected every `Complex<bf16>` as `Mismatch("invalid complex payload size")`, and `from_reader_streaming` refused both half widths as `Unsupported("unsupported complex float width")` — so a value-mode stream of a type holding either field failed at the producer or the consumer, on payloads the buffered codec handled.

- **A complex array whose component class differs from the field's now decodes** through serde instead of returning `Error::Mismatch` (beve 7.3.0). A loosening, so anything leaning on the old strictness as a schema check needs its own check. `Message::complex_slice` is deliberately not part of this: it calls `read_complex_slice`, where naming `T` is the whole interface and a class mismatch is still an error. The two disagreeing is intended.

## Also

The `wasm-tests` lockfiles move in step, and pick up the stale `repe` path-dep version they still recorded as 7.0.2.

## Verification

`cargo test --all-features` (26 test binaries), `cargo test --no-default-features`, and `cargo clippy --all-features --all-targets` are clean. `wasm-tests/server` and `wasm-tests/client` check against the new lock.
