### PR TITLE
Check the outbound frame limit before building the frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Changed
+- **The outbound frame guard no longer allocates a `String` per frame.** `frame_outbound` — the one place every response and pushed notify funnels through — copied the message's query out to a `String` before consuming the message, so it would still have the method name if the frame turned out to be over the peer's assumed limit. That name is read only to fill the `OutboundTooLarge` error hook, which almost never fires, so every frame the server sent paid for a heap allocation it immediately dropped.
+
+  The limit is now checked before the frame is built, from the closed-form length (`HEADER_SIZE + query + body`, exactly what `into_wire_bytes` emits) rather than by measuring the built frame. That leaves the message intact through the check, so the method is read from it only on the rejection path. A refused frame is also no longer built at all — previously an over-limit message was serialized in full and then thrown away, which is the case where that buffer is at its largest.
+
+  No API, wire, or behavior change: the guard trips at the same threshold, and reports the same method, size, and limit. A new unit test pins the threshold end to end so the closed form and the framer cannot drift apart.
+
 - **The lockfile resolves `beve` to 7.3.0** (from 7.1.0). The requirement in `Cargo.toml` stays `beve = "7"`, which already admitted it, so this is lockfile-only and downstreams resolve their own — but unlike the last bump, this one is not inert. 7.2.0 and 7.3.0 carry fixes and a behavior change that reach code repe calls.
 
   Every bulk primitive repe names directly is untouched. `to_writer_complex_slice`, `complex_slice_size`, `read_complex_slice`, `read_typed_slice`, and the aligned typed-slice family all live in beve's `fast` module, whose only diff across these two releases is a doc comment. `MessageBuilder::body_complex_slice`, `write_message_complex_slice`, and the SVS bulk modes emit and accept the same bytes they did on 7.1.0. (7.2.0's headline "complex arrays in one bulk copy" speedup is about beve's `serde(with)` helpers; `to_writer_complex_slice` was already a single `write_all`.)

--- a/src/websocket_server.rs
+++ b/src/websocket_server.rs
@@ -1515,12 +1515,22 @@ fn frame_outbound(
     limits: &crate::WebSocketLimits,
     on_error: &[ErrorHook],
 ) -> Option<Vec<u8>> {
-    let method = m.query_str().unwrap_or("").to_string();
-    let notify = m.header.notify != 0;
-    let id = m.header.id;
-    let bytes = m.into_wire_bytes();
-    let Err(err) = limits.check_outbound(bytes.len()) else {
-        return Some(bytes);
+    // Size the frame in closed form and check the limit before building it,
+    // rather than framing first and measuring the result. `into_wire_bytes`
+    // emits exactly `HEADER_SIZE + query + body` bytes, so the guard sees the
+    // same number either way — `frame_outbound_checks_the_length_it_frames`
+    // pins that equality so the two cannot drift.
+    //
+    // Ordering it this way is what keeps the message intact through the check,
+    // which is what the common path is actually paying for: the method name is
+    // read only to report a rejection, so it no longer has to be copied out of
+    // the message before it is consumed. Every frame the server sends was
+    // allocating (and immediately dropping) a `String` for a hook that almost
+    // never fires. A rejected frame is now never built either, which is the
+    // one case where that buffer is at its largest.
+    let frame_len = crate::constants::HEADER_SIZE + m.query.len() + m.body.len();
+    let Err(err) = limits.check_outbound(frame_len) else {
+        return Some(m.into_wire_bytes());
     };
     let (size, limit) = match err {
         RepeError::MessageTooLarge { size, limit } => (size, limit),
@@ -1529,14 +1539,15 @@ fn frame_outbound(
     report_error(
         on_error,
         ConnectionError::OutboundTooLarge {
-            method: method.clone(),
+            method: m.query_str().unwrap_or("").to_string(),
             size,
             limit,
         },
     );
-    if notify {
+    if m.header.notify != 0 {
         return None;
     }
+    let id = m.header.id;
     let mut replacement = crate::message::create_error_message(
         ErrorCode::InternalError,
         format!(
@@ -3244,6 +3255,74 @@ mod tests {
         assert_eq!(
             ConnectionError::Handshake(RepeError::InvalidSpec(0)).error_code(),
             None
+        );
+    }
+
+    // ---- Outbound framing guard ------------------------------------
+
+    /// `frame_outbound` sizes a frame in closed form and checks the limit
+    /// before building it, so the number the guard sees is right only while
+    /// `HEADER_SIZE + query + body` is what `into_wire_bytes` emits. This pins
+    /// the threshold end to end — a frame exactly at the limit goes out, one
+    /// byte over is refused — plus the two things the reordering could quietly
+    /// break: the reported `size` is still the framed length, and the method
+    /// name still survives to the hook now that it is read from a message the
+    /// guard has already inspected rather than copied out beforehand.
+    #[test]
+    fn frame_outbound_checks_the_length_it_frames() {
+        const PATH: &str = "/sized";
+        const BODY: usize = 64;
+        let build = |notify: bool| {
+            Message::builder()
+                .id(1)
+                .notify(notify)
+                .query_str(PATH)
+                .query_format(QueryFormat::JsonPointer)
+                .body_bytes(vec![b'x'; BODY])
+                .body_format_code(u16::from(BodyFormat::RawBinary))
+                .build()
+        };
+        let framed_len = build(true).into_wire_bytes().len();
+        assert_eq!(
+            framed_len,
+            crate::constants::HEADER_SIZE + PATH.len() + BODY
+        );
+
+        let at_limit =
+            crate::WebSocketLimits::default().with_assumed_peer_frame_limit(Some(framed_len));
+        assert_eq!(
+            frame_outbound(build(true), &at_limit, &[])
+                .expect("a frame exactly at the limit goes out")
+                .len(),
+            framed_len,
+        );
+
+        // One byte under. A notify has no response to carry an error, so it is
+        // dropped outright — the unambiguous signal that the guard fired.
+        let under =
+            crate::WebSocketLimits::default().with_assumed_peer_frame_limit(Some(framed_len - 1));
+        assert!(frame_outbound(build(true), &under, &[]).is_none());
+
+        // The same refusal on a request yields the replacement error frame and
+        // reports what the refused message was carrying.
+        let seen = Arc::new(Mutex::new(Vec::<(String, usize, usize)>::new()));
+        let seen_h = Arc::clone(&seen);
+        let hook: ErrorHook = Arc::new(move |err: &ConnectionError| {
+            if let ConnectionError::OutboundTooLarge {
+                method,
+                size,
+                limit,
+            } = err
+            {
+                seen_h.lock().unwrap().push((method.clone(), *size, *limit));
+            }
+        });
+        let replacement = frame_outbound(build(false), &under, std::slice::from_ref(&hook))
+            .expect("a request's response is replaced rather than dropped");
+        assert_ne!(replacement.len(), framed_len);
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(PATH.to_string(), framed_len, framed_len - 1)],
         );
     }
 


### PR DESCRIPTION
`frame_outbound` is the single funnel every response and pushed notify passes through on its way to the wire (`src/websocket_server.rs:1513`, called from the writer task and the off-reader response path). Its first line was:

```rust
let method = m.query_str().unwrap_or("").to_string();
```

That copy exists only because `into_wire_bytes` consumes the message two lines later, and the method name is needed if the frame turns out to exceed the peer's assumed frame limit. It fills exactly one field, on `ConnectionError::OutboundTooLarge`, reported through the error hooks — a path that almost never fires. So every frame the server sent allocated a `String`, dropped it unread, and paid for it again on the next frame.

## What changed

The limit is checked *before* the frame is built, against the length in closed form rather than by measuring the built frame:

```rust
let frame_len = crate::constants::HEADER_SIZE + m.query.len() + m.body.len();
let Err(err) = limits.check_outbound(frame_len) else {
    return Some(m.into_wire_bytes());
};
```

`into_wire_bytes` emits exactly `HEADER_SIZE + query.len() + body.len()` bytes (`src/message.rs:92`), so the guard sees the same number it saw before. The reorder is what makes the rest fall out: the message is still whole at the point of rejection, so the method is read from it only on the path that reports it, `notify` and `id` no longer need hoisting into locals, and the `method.clone()` at the single use site — dead, since `method` was never read again — goes with it.

## Two allocations removed, at opposite ends

- **Every frame**, on the common path: the `String` that was only ever needed on rejection.
- **Every refused frame**: the frame itself. An over-limit message was previously serialized in full and then thrown away. That is precisely the case where the buffer is at its largest — the message was rejected for being too big.

## Compatibility

None observable. Same threshold, same `method`/`size`/`limit` on the hook, same replacement error response carrying the original request id, same `None` for a refused notify. `frame_outbound` is private; no API or wire change.

## Tests

`frame_outbound_checks_the_length_it_frames`, in `src/websocket_server.rs`, pins the threshold end to end rather than restating the arithmetic: a frame whose length is exactly the limit goes out at its full size, one byte over is refused, and the hook receives the path, the framed size, and the limit. The refusal case is asserted through a notify (dropped, so `None` is unambiguous) and through a request (replaced, so the error frame comes back).

The reported `size` assertion is the one that matters most here — it pins that the number reported is still the *framed* length even though it is now computed before framing.

Mutation-checked: dropping the query term from the closed form fails it with `assertion failed: frame_outbound(build(true), &under, &[]).is_none()`.

The five existing integration tests in `tests/websocket_limits.rs` cover the guard's behavior through a real connection and are unchanged.

Full suite green at `--all-features` (403 passing), clippy and fmt clean.

## Context

Found while reviewing #48, which removes an allocation per peer per broadcast. This is the same order of cost on the same path — a broadcast to N peers pushes N frames through `frame_outbound` — and independent of it. The two touch different files and can land in either order.
