### PR TITLE
Target-gate zstd and uniudp so wasm32 builds at any feature set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
   # is how it spent 6.0.0 through 7.0.1 failing to compile against a
   # `RepeError` variant added in 6.0.0.
   #
-  # `--all-features` is wrong here on purpose. `websocket` pulls
-  # tokio-tungstenite and `value-stream` pulls zstd, neither of which targets
-  # wasm32; `websocket-wasm` is the feature that claims to.
+  # Every non-portable module is `not(wasm32)` in lib.rs and every non-portable
+  # dependency is target-gated to match, so any feature set is buildable here.
+  # The `--lib` on the all-features step is what excludes the `cli` binary,
+  # which is a native CLI (tokio runtime, sockets) and is not meant to target
+  # wasm32 at any feature set.
   wasm:
     runs-on: ubuntu-latest
     env:
@@ -63,6 +65,15 @@ jobs:
 
       - name: Clippy (core, no features)
         run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
+
+      # Guards the target-gating of `zstd` and `uniudp`. Enabling `value-stream`
+      # or `fleet-udp` on wasm32 used to fail in a *build script* — zstd-sys
+      # compiling `huf_decompress_amd64.S`, mio rejecting the target — which no
+      # job here reached, so a workspace could not hoist either feature into a
+      # feature set shared with a browser client. `--lib` skips the `cli` bin;
+      # everything else stays covered as new features are added.
+      - name: Clippy (all features, lib only)
+        run: cargo clippy --all-features --lib --target wasm32-unknown-unknown -- -D warnings
 
   # The job above proves `wasm_client` compiles. This one proves it works.
   #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`value-stream` and `fleet-udp` no longer break a `wasm32-unknown-unknown` build.** Both features' modules have always been `not(target_arch = "wasm32")` in `lib.rs`, but their non-portable dependencies sat in the untargeted `[dependencies]` table, so Cargo built them for wasm32 regardless — for a consumer that `cfg` had already compiled out. `zstd` failed inside `zstd-sys`'s build script (clang: "No available targets are compatible with triple wasm32-unknown-unknown", compiling `huf_decompress_amd64.S`) and `uniudp` failed inside mio ("This wasm target is unsupported by mio"). Both are now declared under `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` alongside `tokio`, so enabling either feature on wasm32 is inert rather than fatal.
+
+  The cost landed on workspaces rather than on single crates. Cargo features are purely additive: a crate inheriting a workspace dependency can add features but never subtract one. A workspace that hoists one shared repe pin — the usual way to make repe compile once and share a single `beve` build across several products — therefore could not carry `value-stream` at all if any member targeted wasm32, even when that member wanted nothing but core `Message` framing. The workaround was a second, hand-maintained repe entry with `default-features = false` for the browser crate, and a comment explaining why the two must not be merged.
+
+  Native builds are unaffected in every respect: the same dependencies resolve, with the same features, the same API, and the same wire output, and `Cargo.lock` does not move. The gate is `target_arch`, matching the existing module gates exactly, so `wasm32-wasip1` and `wasm32-wasip2` likewise stop building a dependency whose only consumer was already `cfg`'d out there.
+
+- **`CallContext::with_cancel` and `stamp_response_query` no longer warn as dead code on wasm32.** Their `#[cfg_attr(..., allow(dead_code))]` predicates keyed on `not(feature = "websocket")`, but their only caller — `websocket_server` — is gated on that feature *and* `not(target_arch = "wasm32")`. With `websocket` enabled on wasm32 the allow went inactive while the caller stayed absent, so the build warned about functions it had itself removed the users of. Both predicates now mirror the module's own gate. Surfaced by the new CI step below, and unreachable before it, since nothing built that combination.
+
+### Changed
+- **CI clippies `--all-features --lib` for `wasm32-unknown-unknown` at `-D warnings`.** The job's previous comment said `--all-features` was "wrong here on purpose" because `value-stream` pulls zstd. That was true when written, and it is also why the target-gating defect went unnoticed: the failure was in a build script no job ever reached, so the manifest and the `cfg`s in `lib.rs` were free to disagree. `--lib` excludes the `cli` binary, which is a native CLI (tokio runtime, sockets) and is not meant to target wasm32 at any feature set; every other feature is now covered here automatically as more are added.
+
+- `value-stream` appears in the feature tables in `README.md` and `docs/index.md`, which had omitted it entirely, together with a note that it and `fleet-udp` compile away on wasm32 instead of failing.
+
 ## [8.0.0] - 2026-08-17
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ cli = ["websocket", "dep:clap", "dep:clap_complete"]
 # Streaming transfer of a serialized, optionally zstd-compressed in-memory value
 # over ordinary REPE request/response (the SVS wire contract). Pulls in `zstd`
 # for the compressed path; the engine itself is plain `std` threads + channels.
+#
+# Resolves to nothing on wasm32: the module is `not(wasm32)` in lib.rs and the
+# `zstd` dep is target-gated to match, so enabling this feature there compiles
+# away instead of failing. That is what lets a workspace hoist it into a shared
+# feature union alongside a wasm32 member, which cannot subtract it.
 value-stream = ["dep:zstd"]
 
 [[bin]]
@@ -97,16 +102,12 @@ serde_json = "1"
 thiserror = "1"
 repe-derive = { path = "repe-derive", version = "0.1.0" }
 parking_lot = { version = "0.12", optional = true }
-uniudp = { version = "1.2.1", optional = true }
 # 0.3.32 for `UnboundedReceiver::try_recv`, which the `notify_slot` tests use
 # (`try_next` is deprecated there, and CI builds tests at `-D warnings`).
 futures-channel = { version = "0.3.32", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"], optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4", optional = true }
-# Streaming zstd codec for the `value-stream` feature (SVS `compression = 1`).
-# Optional so the core crate stays free of the libzstd C dependency.
-zstd = { version = "0.13", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time", "io-util", "sync"] }
@@ -116,6 +117,23 @@ tokio-tungstenite = { version = "0.24", optional = true }
 # onto `CallContext` and the server-level graceful drain. Pulled in
 # only with the `websocket` feature.
 tokio-util = { version = "0.7", optional = true, default-features = false, features = ["rt"] }
+# Same target-gating rationale as `zstd` below: `uniudp_fleet` is already
+# `not(wasm32)` in lib.rs, and uniudp pulls mio and a UDP socket stack that
+# refuse wasm32-unknown-unknown outright ("This wasm target is unsupported by
+# mio").
+uniudp = { version = "1.2.1", optional = true }
+# Streaming zstd codec for the `value-stream` feature (SVS `compression = 1`).
+# Optional so the core crate stays free of the libzstd C dependency.
+#
+# Target-gated because `zstd-sys` is the libzstd C library and its build script
+# cannot target wasm32-unknown-unknown (clang: "No available targets are
+# compatible with triple wasm32-unknown-unknown", compiling
+# `huf_decompress_amd64.S`). `value_stream` is already `not(wasm32)` in lib.rs,
+# so nothing on wasm32 could call it regardless; leaving the dep untargeted
+# only meant Cargo built a C library for a target whose consumer did not exist.
+# That made `value-stream` unusable in a *workspace* feature union, since Cargo
+# features are additive and an inheriting wasm32 crate cannot subtract one.
+zstd = { version = "0.13", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ A `with_typed_slice_ref` route is a drop-in superset of `with_typed_slice`: it s
 | `websocket` | Native `WebSocketClient`, `WebSocketServer`, and `proxy_connection`. |
 | `websocket-wasm` | Browser `WasmClient` on `wasm32-unknown-unknown`. |
 | `fleet-udp` | UDP fanout via `UniUdpFleet`. |
+| `value-stream` | Streaming value transfer (SVS), with an optional zstd codec. |
 | `parking-lot` | `Lockable` impls for `parking_lot::Mutex` / `RwLock`. |
 | `cli` | Builds the `repe` command-line client (pulls in `clap` and `websocket`). |
+
+`fleet-udp` and `value-stream` are native-only: on `wasm32-unknown-unknown` both their modules and their non-portable dependencies compile away, so enabling either there is inert rather than a build failure. That matters for a workspace hoisting one shared feature set across a native server and a browser client, since Cargo features are additive and the wasm member cannot subtract one.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,8 +68,11 @@ Replace `body_json` with `body_beve` to encode the body with BEVE; everything el
 | `websocket` | Native `WebSocketClient`, `WebSocketServer`, and `proxy_connection`. |
 | `websocket-wasm` | Browser `WasmClient` on `wasm32-unknown-unknown`. |
 | `fleet-udp` | UDP fanout via `UniUdpFleet`. |
+| `value-stream` | Streaming value transfer (SVS), with an optional zstd codec. |
 | `parking-lot` | `Lockable` impls for `parking_lot::Mutex` / `RwLock`. |
 | `cli` | Builds the `repe` command-line client (pulls in `clap` and `websocket`). |
+
+`fleet-udp` and `value-stream` are native-only: on `wasm32-unknown-unknown` both their modules and their non-portable dependencies compile away, so enabling either there is inert rather than a build failure. That matters for a workspace hoisting one shared feature set across a native server and a browser client, since Cargo features are additive and the wasm member cannot subtract one.
 
 ## License
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1183,7 +1183,12 @@ pub(crate) fn create_response_unstamped(
 // Used only by the WebSocket server: the off-reader path moves its owned request
 // query in, the inline path copies the borrowed view query. The TCP/async servers
 // echo through `response_echo_query` (a pure borrow) instead.
-#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+// The predicate mirrors `websocket_server`'s own gate in lib.rs, not just its
+// feature: on wasm32 that module is absent even with `websocket` on.
+#[cfg_attr(
+    not(all(feature = "websocket", not(target_arch = "wasm32"))),
+    allow(dead_code)
+)]
 pub(crate) fn stamp_response_query(response: &mut Message, request_query: Cow<[u8]>) {
     if request_query.is_empty() || !response.query.is_empty() {
         return;

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -279,10 +279,14 @@ impl<'a> CallContext<'a> {
     /// Used by the built-in `WebSocketServer` to thread the connection's
     /// cancellation handle (fired on disconnect / shutdown) onto each
     /// dispatch.
-    // Only the feature-gated WebSocket server constructs a cancel-bearing
-    // context (the unit tests above also exercise it); a build without the
-    // `websocket` feature has no caller, so don't warn there.
-    #[cfg_attr(not(feature = "websocket"), allow(dead_code))]
+    // Only the WebSocket server constructs a cancel-bearing context (the unit
+    // tests above also exercise it), so a build without that module has no
+    // caller. The predicate mirrors its gate in lib.rs, not just its feature:
+    // on wasm32 the module is absent even with `websocket` on.
+    #[cfg_attr(
+        not(all(feature = "websocket", not(target_arch = "wasm32"))),
+        allow(dead_code)
+    )]
     pub(crate) fn with_cancel(
         method: &'a str,
         peer: &'a PeerHandle,


### PR DESCRIPTION
## The defect

`value_stream` and `uniudp_fleet` are both `#[cfg(not(target_arch = "wasm32"))]` in `lib.rs`, but their non-portable dependencies were declared in the untargeted `[dependencies]` table. Cargo therefore built them for `wasm32-unknown-unknown` regardless — for a consumer that `cfg` had already compiled out:

- `zstd` → `zstd-sys` build script: `clang: No available targets are compatible with triple wasm32-unknown-unknown`, compiling `huf_decompress_amd64.S`
- `uniudp` → mio: `This wasm target is unsupported by mio`

Both now sit under `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` alongside `tokio`, so enabling either feature on wasm32 is inert rather than fatal.

## Why it mattered

The cost landed on workspaces rather than single crates. Cargo features are purely additive: a crate inheriting a workspace dependency can add a feature but never subtract one. A workspace that hoists a single shared `repe` pin — the usual way to build repe once and share one `beve` build across several products — could not carry `value-stream` at all if any member targeted wasm32, even a member that wanted nothing but core `Message` framing. The workaround was a second, hand-maintained `repe` entry with `default-features = false` for the browser crate.

## Also here

- **`allow(dead_code)` predicates corrected.** `CallContext::with_cancel` and `stamp_response_query` keyed their `#[cfg_attr(..., allow(dead_code))]` on `not(feature = "websocket")`, but their only caller (`websocket_server`) is gated on that feature *and* `not(target_arch = "wasm32")`. With `websocket` on for wasm32 the allow went inactive while the caller stayed absent, so the build warned about functions whose users it had itself removed. Both predicates now mirror the module's own gate.

- **CI clippies `--all-features --lib` for wasm32 at `-D warnings`.** The job's comment previously said `--all-features` was "wrong here on purpose" — true when written, and also why this went unnoticed: the failure was in a build script no job ever reached, so the manifest and the `cfg`s in `lib.rs` were free to disagree. `--lib` excludes the `cli` binary, which is a native CLI and is not meant to target wasm32 at any feature set; every other feature is covered automatically as more are added.

- `value-stream` was missing from the feature tables in `README.md` and `docs/index.md`; both now list it, with a note on the native-only behavior.

## Compatibility

Native builds are unaffected: the same dependencies resolve, with the same features, the same API, and the same wire output. `Cargo.lock` does not move. The gate is `target_arch`, matching the existing module gates exactly, so `wasm32-wasip1` / `wasm32-wasip2` likewise stop building a dependency whose only consumer was already `cfg`'d out there.

## Verification

- `cargo clippy --all-features --lib --target wasm32-unknown-unknown -- -D warnings` — clean (fails on `main`)
- `cargo clippy --all-features --all-targets` — clean
- `cargo test --all-features` — full suite passes, `Cargo.lock` unchanged